### PR TITLE
Fix rendering of clone example

### DIFF
--- a/website/docs/overview/basic-commands.md
+++ b/website/docs/overview/basic-commands.md
@@ -56,8 +56,8 @@ From https://github.com/facebook/sapling
  * [new ref]               b8422460814900d8f978a8a34a99ae83c6735a70 -> remote/main
 5689 files updated, 0 files merged, 0 files removed, 0 files unresolved
 
-`# Clones into a 'some_directory' directory.`
-`$ sl clone https://github.com/facebook/sapling some_directory`
+# Clones into a 'some_directory' directory.
+$ sl clone https://github.com/facebook/sapling some_directory
 ```
 
 :::note


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/keith/sapling/pull/156).
* #157
* __->__ #156

Fix rendering of clone example

Summary: Since this was already in a codeblock these backticks also rendered on https://sapling-scm.com/docs/overview/basic-commands

