### PR TITLE
Fix typo

### DIFF
--- a/website/docs/overview/basic-commands.md
+++ b/website/docs/overview/basic-commands.md
@@ -148,7 +148,7 @@ diff --git a/build.sh b/build.sh
      PATH="$TOOLCHAIN_DIR:$PATH"
  fi
 
-+if [[ -n $TEST_ENVRIONMENT ]]; then
++if [[ -n $TEST_ENVIRONMENT ]]; then
 +    exit 1
 +fi
 +
@@ -293,7 +293,7 @@ diff --git a/build.sh b/build.sh
      PATH="$TOOLCHAIN_DIR:$PATH"
  fi
 
-+if [[ -n $TEST_ENVRIONMENT ]]; then
++if [[ -n $TEST_ENVIRONMENT ]]; then
 +    exit 1
 +fi
 +


### PR DESCRIPTION
This PR fixes a very small typo: `TEST_ENVRIONMENT` -> `TEST_ENVIRONMENT`