### PR TITLE
include the name of the release in the data dump

### DIFF
--- a/website/scripts/gen_release_data.py
+++ b/website/scripts/gen_release_data.py
@@ -28,7 +28,7 @@ def main():
         default=default_outfile,
     )
     args = parser.parse_args()
-    assets_json = subprocess.check_output(
+    release_json = subprocess.check_output(
         [
             "gh",
             "release",
@@ -36,10 +36,10 @@ def main():
             "--repo",
             args.repo,
             "--json",
-            "assets",
+            "assets,name",
         ]
     )
-    assets = json.loads(assets_json)
+    assets = json.loads(release_json)
     ts_contents = f"""\
 /\x2a\x2a
  * Copyright (c) Meta Platforms, Inc. and affiliates.

--- a/website/src/rawReleaseData.ts
+++ b/website/src/rawReleaseData.ts
@@ -8,76 +8,77 @@
  */
 
 /*
- * @generated SignedSource<<f8125fd778a19631441aaf11689cf51d>>
+ * @generated SignedSource<<6634000cd9241a02e4654c77f7644319>>
  * Run `./scripts/gen_release_data.py` to regenerate.
  */
 
 export const latestReleaseAssets = {
   "assets": [
     {
-      "apiUrl": "https://api.github.com/repos/facebook/sapling/releases/assets/84673830",
+      "apiUrl": "https://api.github.com/repos/facebook/sapling/releases/assets/84922128",
       "contentType": "application/x-gtar",
-      "createdAt": "2022-11-15T09:55:13Z",
-      "downloadCount": 4,
-      "id": "RA_kwDOA3c_bc4FDAUm",
+      "createdAt": "2022-11-17T05:29:53Z",
+      "downloadCount": 123,
+      "id": "RA_kwDOA3c_bc4FD88Q",
       "label": "",
-      "name": "sapling_0.0-20221115.004809.5076656c.arm64_monterey.bottle.tar.gz",
-      "size": 23979255,
+      "name": "sapling_0.0-20221116.203146.2c1a971a.arm64_monterey.bottle.tar.gz",
+      "size": 23997915,
       "state": "uploaded",
-      "updatedAt": "2022-11-15T09:55:14Z",
-      "url": "https://github.com/facebook/sapling/releases/download/20221115-004809-5076656c/sapling_0.0-20221115.004809.5076656c.arm64_monterey.bottle.tar.gz"
+      "updatedAt": "2022-11-17T05:29:54Z",
+      "url": "https://github.com/facebook/sapling/releases/download/20221116-203146-2c1a971a/sapling_0.0-20221116.203146.2c1a971a.arm64_monterey.bottle.tar.gz"
     },
     {
-      "apiUrl": "https://api.github.com/repos/facebook/sapling/releases/assets/84672852",
+      "apiUrl": "https://api.github.com/repos/facebook/sapling/releases/assets/84922517",
       "contentType": "application/x-gtar",
-      "createdAt": "2022-11-15T09:45:09Z",
-      "downloadCount": 1,
-      "id": "RA_kwDOA3c_bc4FDAFU",
+      "createdAt": "2022-11-17T05:32:47Z",
+      "downloadCount": 99,
+      "id": "RA_kwDOA3c_bc4FD9CV",
       "label": "",
-      "name": "sapling_0.0-20221115.004809.5076656c.monterey.bottle.tar.gz",
-      "size": 24527889,
+      "name": "sapling_0.0-20221116.203146.2c1a971a.monterey.bottle.tar.gz",
+      "size": 24544365,
       "state": "uploaded",
-      "updatedAt": "2022-11-15T09:45:09Z",
-      "url": "https://github.com/facebook/sapling/releases/download/20221115-004809-5076656c/sapling_0.0-20221115.004809.5076656c.monterey.bottle.tar.gz"
+      "updatedAt": "2022-11-17T05:32:48Z",
+      "url": "https://github.com/facebook/sapling/releases/download/20221116-203146-2c1a971a/sapling_0.0-20221116.203146.2c1a971a.monterey.bottle.tar.gz"
     },
     {
-      "apiUrl": "https://api.github.com/repos/facebook/sapling/releases/assets/84671953",
+      "apiUrl": "https://api.github.com/repos/facebook/sapling/releases/assets/84920900",
       "contentType": "application/x-debian-package",
-      "createdAt": "2022-11-15T09:36:56Z",
-      "downloadCount": 0,
-      "id": "RA_kwDOA3c_bc4FC_3R",
+      "createdAt": "2022-11-17T05:17:36Z",
+      "downloadCount": 40,
+      "id": "RA_kwDOA3c_bc4FD8pE",
       "label": "",
-      "name": "sapling_0.0-20221115.004809.5076656c_amd64.Ubuntu20.04.deb",
-      "size": 20035592,
+      "name": "sapling_0.0-20221116.203146.2c1a971a_amd64.Ubuntu20.04.deb",
+      "size": 20036896,
       "state": "uploaded",
-      "updatedAt": "2022-11-15T09:36:58Z",
-      "url": "https://github.com/facebook/sapling/releases/download/20221115-004809-5076656c/sapling_0.0-20221115.004809.5076656c_amd64.Ubuntu20.04.deb"
+      "updatedAt": "2022-11-17T05:17:37Z",
+      "url": "https://github.com/facebook/sapling/releases/download/20221116-203146-2c1a971a/sapling_0.0-20221116.203146.2c1a971a_amd64.Ubuntu20.04.deb"
     },
     {
-      "apiUrl": "https://api.github.com/repos/facebook/sapling/releases/assets/84670386",
+      "apiUrl": "https://api.github.com/repos/facebook/sapling/releases/assets/84920917",
       "contentType": "application/x-debian-package",
-      "createdAt": "2022-11-15T09:26:21Z",
-      "downloadCount": 3,
-      "id": "RA_kwDOA3c_bc4FC_ey",
+      "createdAt": "2022-11-17T05:18:11Z",
+      "downloadCount": 81,
+      "id": "RA_kwDOA3c_bc4FD8pV",
       "label": "",
-      "name": "sapling_0.0-20221115.004809.5076656c_amd64.Ubuntu22.04.deb",
-      "size": 21407152,
+      "name": "sapling_0.0-20221116.203146.2c1a971a_amd64.Ubuntu22.04.deb",
+      "size": 21462932,
       "state": "uploaded",
-      "updatedAt": "2022-11-15T09:26:23Z",
-      "url": "https://github.com/facebook/sapling/releases/download/20221115-004809-5076656c/sapling_0.0-20221115.004809.5076656c_amd64.Ubuntu22.04.deb"
+      "updatedAt": "2022-11-17T05:18:12Z",
+      "url": "https://github.com/facebook/sapling/releases/download/20221116-203146-2c1a971a/sapling_0.0-20221116.203146.2c1a971a_amd64.Ubuntu22.04.deb"
     },
     {
-      "apiUrl": "https://api.github.com/repos/facebook/sapling/releases/assets/84671632",
+      "apiUrl": "https://api.github.com/repos/facebook/sapling/releases/assets/84921418",
       "contentType": "application/zip",
-      "createdAt": "2022-11-15T09:32:11Z",
-      "downloadCount": 1,
-      "id": "RA_kwDOA3c_bc4FC_yQ",
+      "createdAt": "2022-11-17T05:23:24Z",
+      "downloadCount": 139,
+      "id": "RA_kwDOA3c_bc4FD8xK",
       "label": "",
-      "name": "sapling_windows_20221115.004809.5076656c_amd64.zip",
-      "size": 44229300,
+      "name": "sapling_windows_20221116.203146.2c1a971a_amd64.zip",
+      "size": 44374106,
       "state": "uploaded",
-      "updatedAt": "2022-11-15T09:32:12Z",
-      "url": "https://github.com/facebook/sapling/releases/download/20221115-004809-5076656c/sapling_windows_20221115.004809.5076656c_amd64.zip"
+      "updatedAt": "2022-11-17T05:23:25Z",
+      "url": "https://github.com/facebook/sapling/releases/download/20221116-203146-2c1a971a/sapling_windows_20221116.203146.2c1a971a_amd64.zip"
     }
-  ]
+  ],
+  "name": "20221116-203146-2c1a971a"
 };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #245
* #244
* #243
* __->__ #242
* #241

Ran `./scripts/gen_release_data.py` and verified
`rawReleaseData.ts` had the expected values.

Differential Revision: [D41452965](https://our.internmc.facebook.com/intern/diff/D41452965)