### PR TITLE
fixing default branch name for brand new github repos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ submit pull requests as described below.
 ## Pull Requests
 We actively welcome your pull requests.
 
-1. Fork the repo and create your branch from `master`.
+1. Fork the repo and create your branch from `main`.
 2. If you've added code that should be tested, add tests.
 3. If you've changed APIs, update the documentation.
 4. Ensure the test suite passes.

--- a/eden/scm/edenscm/ext/github/gh_submit.py
+++ b/eden/scm/edenscm/ext/github/gh_submit.py
@@ -149,12 +149,13 @@ query ($owner: String!, $name: String!, $number: Int!) {
 
 
 def _parse_repository_from_dict(repo_obj, hostname: str, upstream=None) -> Repository:
+    default_branch = "main" if "defaultBranchRef" not in repo_obj else repo_obj["defaultBranchRef"]["name"]
     return Repository(
         id=repo_obj["id"],
         hostname=hostname,
         owner=repo_obj["owner"]["login"],
         name=repo_obj["name"],
-        default_branch=repo_obj["defaultBranchRef"]["name"],
+        default_branch=default_branch,
         is_fork=repo_obj["isFork"],
         upstream=upstream,
     )

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.65.0"


### PR DESCRIPTION
attempts to fix https://github.com/facebook/sapling/issues/260 and https://github.com/facebook/sapling/issues/258

but I can't test this locally due to https://github.com/facebook/sapling/issues/261

