### PR TITLE
[docs] add sl-shell-example syntax-highlighting language

### DIFF
--- a/website/docs/internals/drawdag.md
+++ b/website/docs/internals/drawdag.md
@@ -10,7 +10,7 @@ When creating tests, we often need to create a repo with a particular layout.
 For example, to create a linear graph with three commits, we could use the
 following sequence of commands:
 
-```
+```sl-shell-example
 $ sl commit -m A
 $ sl commit -m B
 $ sl commit -m C
@@ -18,7 +18,7 @@ $ sl commit -m C
 
 If the graph is nonlinear, extra commands such as merge and goto are needed:
 
-```
+```sl-shell-example
 $ sl commit -m A
 $ sl commit -m B
 $ sl goto -q '.^'
@@ -129,7 +129,7 @@ Try editing the DrawDag code above. We draw the output live in the browser.
 You can use the `drawdag` shell function in `.t` tests to create commits and
 change the repo.
 
-```
+```sl-shell-example
 $ drawdag << 'EOS'
 >  C
 >  |

--- a/website/docs/introduction/getting-started.md
+++ b/website/docs/introduction/getting-started.md
@@ -54,7 +54,7 @@ From inside a repo, running `sl` with no arguments shows you your commit graph. 
 
 Sapling provides familiar `add` and `commit`/`ci` commands to create a commit:
 
-```
+```sl-shell-example
 $ touch hello.txt
 $ sl add .
 $ echo 'Hello, World!' > hello.txt
@@ -76,7 +76,7 @@ Another important difference from Git is that _there is no index where changes m
 
 For illustration purposes, we'll go ahead and create a few more commits:
 
-```
+```sl-shell-example
 $ echo foo > foo.txt ; sl add foo.txt ; sl ci -m 'adding foo'
 $ echo bar > bar.txt ; sl add bar.txt ; sl ci -m 'adding bar'
 $ echo baz > baz.txt ; sl add baz.txt ; sl ci -m 'adding baz'
@@ -105,7 +105,7 @@ See [Basic Commands](../overview/basic-commands.md) to learn more about manipula
 
 You may also want to try Sapling's built-in GUI that runs in the browser . Run <SLCommand name="web" /> to launch it from the command line:
 
-```
+```sl-shell-example
 $ sl web
 Listening on http://localhost:3011/?token=929fa2b3d75aa4330e0b7b0a10822ee0&cwd=%2FUsers%2Falyssa%2Fsrc%2Fsapling
 Server logs will be written to /var/folders/5c/f3nk25tn7gd7nds59hy_nj7r0000gn/T/isl-server-logKktwaj/isl-server.log
@@ -117,7 +117,7 @@ Sapling will open the URL automatically in your browser. See the docs on [Intera
 
 Sapling supports multiple workflows for interacting with GitHub pull requests. The simplest solution is the <SLCommand name="pr" /> command:
 
-```
+```sl-shell-example
 $ sl pr
 ...
 $ sl
@@ -150,7 +150,7 @@ The "overlapping pull requests" approach may not be an appropriate solution for 
 
 If you have used Sapling to create pull requests for your commits, then you can use `sl ssl` to include the pull request status in your Smartlog. Note that `sl ssl` is not a subcommand, but a built-in alias for `sl smartlog -T {ssl}`:
 
-```
+```sl-shell-example
 $ sl ssl
   @  4d9180fd8  6 minutes ago  alyssa  #178 Unreviewed
   │  adding baz

--- a/website/docs/introduction/git-cheat-sheet.md
+++ b/website/docs/introduction/git-cheat-sheet.md
@@ -8,7 +8,7 @@ Below is a quick cheat sheet for translating a number of Git commands into equiv
 
 You can also use the `sl githelp` command, or `sl git` for short, to automatically translate some git commands into their equivalent Sapling command.
 
-```
+```sl-shell-example
 $ sl githelp -- git clone https://github.com/facebook/sapling
 sl clone https://github.com/facebook/sapling
 

--- a/website/docs/introduction/introduction.md
+++ b/website/docs/introduction/introduction.md
@@ -20,7 +20,7 @@ Additionally, as we developed Sapling we ended up with internal abstractions tha
 
 The easiest way to understand the basic usage of Sapling is to see it in action. Below we clone a repo, make some commits/amends, undo some changes, and push the work.
 
-```bash
+```sl-shell-example
 # Clones the repository into the sapling directory.
 # For git support, it uses git under the hood for clone/push/pull.
 $ sl clone --git https://github.com/facebookexperimental/sapling

--- a/website/docs/overview/basic-commands.md
+++ b/website/docs/overview/basic-commands.md
@@ -43,7 +43,7 @@ Many of these examples use the `sl smartlog` output to explain the repo state. S
 
 Clone the repo using the `sl clone` command.
 
-```bash
+```sl-shell-example
 # Clones into a 'sapling' directory.
 $ sl clone https://github.com/facebook/sapling
 remote: Enumerating objects: 640374, done.
@@ -72,7 +72,7 @@ Related topics: [Push/Pull](push-pull.md), Sparse
 
 `sl goto` or `sl go` allows you to checkout a specific commit.  See the [Navigation](navigation.md) document for a variety of other ways to move around your repository.
 
-```bash
+```sl-shell-example
 # You can checkout commits by their long or short hash.
 # '@' in smartlog indicates your current checkout location.
 $ sl goto 71f7ac009
@@ -110,7 +110,7 @@ Related topics: [Navigation](navigation.md), [top/bottom](navigation.md#topbotto
 
 `sl status` or `sl st` shows a list of your current uncommitted files.
 
-```bash
+```sl-shell-example
 $ vim build.sh
 $ sl st
 M build.sh
@@ -139,7 +139,7 @@ Notable options:
 
 `sl diff` shows you the diff output for your current uncommitted changes.
 
-```bash
+```sl-shell-example
 $ sl diff
 diff --git a/build.sh b/build.sh
 --- a/build.sh
@@ -166,7 +166,7 @@ Related topics: [Show](basic-commands.md#show)
 
 `sl add/remove/forget` are used to add new files, remove old files, and undo added files, respectively. Only files marked M/A/R will be committed during `sl commit`.
 
-```bash
+```sl-shell-example
 $ sl st
 ? new_file.txt
 
@@ -194,7 +194,7 @@ R old_file.txt
 
 `sl mv/cp` can be used to rename or copy a file.
 
-```bash
+```sl-shell-example
 $ sl mv old_name.txt new_name.txt
 $ sl st
 A new_name.txt
@@ -215,7 +215,7 @@ Related topics: AutoMove
 
 `sl purge` deletes any untracked files (`?` in status) in your working copy.
 
-```bash
+```sl-shell-example
 $ sl st
 ? temp_file
 
@@ -227,7 +227,7 @@ $ sl st
 
 `sl revert` will revert any pending changes in your working copy.
 
-```bash
+```sl-shell-example
 $ sl st
 M build.sh
 
@@ -247,7 +247,7 @@ Notable options:
 
 `sl commit` commits your pending changes and prompts you for a commit message.  While there is no staging area, the powerful `--interactive` option is used to select specific files or lines you want committed.
 
-```bash
+```sl-shell-example
 $ sl st
 M build.sh
 $ sl commit
@@ -277,7 +277,7 @@ Related: [smartlog](smartlog.md)
 
 `sl show` shows the log message and textual diff for the current or given commit.
 
-```bash
+```sl-shell-example
 $ sl show
 commit:   c178f2e7ff20447532370599051c1f1939f9dcb6   (@)
 parent:   b8422460814900d8f978a8a34a99ae83c6735a70
@@ -309,7 +309,7 @@ $ sl show COMMIT
 
 Unlike in Git and Mercurial, the `log` command in Sapling is rarely used. Instead, `smartlog` is preferred for day-to-day development and understanding your repository.  `sl log` is really only used when inspecting the deeper history of the repository or a file.
 
-```bash
+```sl-shell-example
 $ sl log
 changeset:   c178f2e7ff20447532370599051c1f1939f9dcb6   (@)
 user:        Mary Smith <mary@example.com>

--- a/website/docs/overview/bookmarks.md
+++ b/website/docs/overview/bookmarks.md
@@ -36,7 +36,7 @@ bookmarks are shown in `smartlog` output. In this example,
 a local bookmark.
 
 
-```bash
+```sl-shell-example
 $ sl
 o  b84224608  13 minutes ago  remote/main
 ╷

--- a/website/docs/overview/hide-unhide.md
+++ b/website/docs/overview/hide-unhide.md
@@ -27,7 +27,7 @@ from their mistakes.
 safely hide and recover commits.
 
 
-```bash
+```sl-shell-example
 $ sl
 @  b84224608  Yesterday at 16:04  john  remote/main
 │  Updating submodules

--- a/website/docs/overview/navigation.md
+++ b/website/docs/overview/navigation.md
@@ -9,7 +9,7 @@ Sapling’s emphasis on editing stacks of commits means users move between commi
 
 `sl goto COMMIT` or `sl go COMMIT` is the standard way to checkout a commit in your repository.
 
-```bash
+```sl-shell-example
 # The '@' indicates your currently checked out commit.
 $ sl
 @  b84224608  13 minutes ago  remote/main
@@ -52,7 +52,7 @@ To trigger an auto-pull, you must specify the `remote/` prefix.
 
 When working with a stack of commits, you can use `sl next` and `sl prev` to move up and down your stack with ease.
 
-```
+```sl-shell-example
 # The '@' indicates your currently checked out commit.
 $ sl
 o  5abffb82f  Wednesday at 09:39  remote/main
@@ -86,7 +86,7 @@ Note, if a commit has multiple children or parents, `next` and `prev` may alert 
 
 When in a stack, you can jump directly to the top or bottom using `sl goto top` and `sl goto bottom`.
 
-```
+```sl-shell-example
 # The '@' indicates your currently checked out commit.
 $ sl
 o  5abffb82f  Wednesday at 09:39  remote/main

--- a/website/docs/overview/push-pull.md
+++ b/website/docs/overview/push-pull.md
@@ -15,7 +15,7 @@ you specify `--rebase`.
 Note, this is different from `git pull` which generally pulls all branches and
 automatically tries to merge/rebase your changes with the new branches.
 
-```bash
+```sl-shell-example
 $ sl
   @  9f73762dd  62 minutes ago  mary
   │  Commit Two
@@ -55,7 +55,7 @@ o  59125794a  20 seconds ago  remote/main
 
 Use the push command to push local commits to remote. Specify the `--to` to specify the remote branch/bookmark to push commits to. Specify `-r` to specify local commit you want pushed. If `-r` is ommitted, the currently checked out commit is pushed.
 
-```bash
+```sl-shell-example
 # Push current commit stack to the remote main bookmark.
 $ sl push -r . --to main
 ```

--- a/website/docs/overview/rebase.md
+++ b/website/docs/overview/rebase.md
@@ -18,7 +18,7 @@ Rebasing requires two pieces of information:
 To illustrate the different types of rebases, assume we start with the following
 commit graph. Note that we are currently on Commit C, as indicated by the `@`
 symbol.
-```
+```sl-shell-example
 $ sl
 o  d78f66e01  106 seconds ago  remote/main
 ╷
@@ -55,7 +55,7 @@ descendants.
 Note that `sl rebase -b . -d XXX` is the same as `sl rebase -d XXX`, as `-b .`
 is the default behavior.
 
-```
+```sl-shell-example
 # Move entire current subtree onto main.
 $ sl rebase -b . -d main
   o  91ecebda8  12 seconds ago  mary
@@ -88,7 +88,7 @@ rebase a given commit and all of its descendants.
 Below we use `-s .` to rebase the current commit, `.`, and its descendant
 `Commit D` onto `main`. All other commits are left behind.
 
-```
+```sl-shell-example
 # Move current commit and its descendants onto main.
 $ sl rebase -s . -d main
   o  aa40b4d44  44 seconds ago  mary
@@ -121,7 +121,7 @@ exactly the commits we specified.
 Below we move the commit we're on by specifying `.` as the argument to `-r`.  We
 move it onto `main` by specifying `main` as the argument to `-d`.
 
-```
+```sl-shell-example
 # Move just the current commit to be based on main
 $ sl rebase -r . -d main
 rebasing 6f782187aa42 "Commit C"
@@ -161,7 +161,7 @@ because commit D did not get rebased.
 #### Other
 The rebase command can move multiple stacks and subtrees in a single invocation. The tree structure will be retained across the rebase. For example, one can use the `draft()` revset to rebase all of your local commits onto a newer base commit.
 
-```
+```sl-shell-example
 $ sl
 o  b5d600552  27 seconds ago  remote/main
 ╷

--- a/website/docs/overview/shelve.md
+++ b/website/docs/overview/shelve.md
@@ -10,7 +10,7 @@ The Sapling <Command name="shelve" /> command allows you to temporarily put pend
 
 It is similar to the `git stash` command.
 
-```bash
+```sl-shell-example
 $ vim myproject.cpp
 $ sl status
 M myproject.cpp
@@ -21,7 +21,7 @@ $ sl status
 
 You can either use `sl unshelve` to restore the latest shelved change to the working copy, or `sl unshelve [shelved name]` to specify a change to unshelve.
 
-```bash
+```sl-shell-example
 $ sl status
 
 $ sl unshelve

--- a/website/docs/overview/stacks.md
+++ b/website/docs/overview/stacks.md
@@ -12,7 +12,7 @@ Sapling provides first-class support for editing and manipulating stacks of comm
 You can edit any commit in your stack by going to that commit (via <Command name="goto" />), making the desired modifications, and then running <Command name="amend" /> to edit the commit. Keep in mind that if you make a mistake, you can always [Undo](undo.md) your changes!
 
 
-```bash
+```sl-shell-example
 $ sl
   o  d9a5aa3c7  3 seconds ago  mary
   │  feature two
@@ -43,7 +43,7 @@ new file mode 100644
 
 If you have a stack of commits, you can fold commits down into a single commit with the <Command name="fold" /> command. You can either specify `--from <commit id>` to specify a range of commits from your current commit to fold together or specify `--exact <list of commit ids>` to specify exact adjacent commits to fold together.
 
-```bash
+```sl-shell-example
 $ sl
   o 5dbd8043f 82 seconds ago mary
   │ commit five
@@ -89,7 +89,7 @@ o ea609e1ef Today at 14:34 remote/main
 Use Sapling’s interactive editor interface to split the changes in one commit into two or more smaller commits.
 
 
-```bash
+```sl-shell-example
 $ sl
   @ b86c5cb40 2 seconds ago mary
 ╭─╯ feature one + two
@@ -128,7 +128,7 @@ o ea609e1ef Today at 14:34 remote/main
 
 If you make changes while working at the top of a stack, the <Command name="absorb" /> command allows you to automatically amend those changes to commits lower in the stack. If there is an unambiguous commit which introduced the edited lines, the absorb command will prompt to apply those changes to that commit.
 
-```bash
+```sl-shell-example
 $ sl
   @ a305c853a 41 seconds ago mary
   │ feature two
@@ -179,7 +179,7 @@ o ea609e1ef Today at 14:34 remote/main
 ### Amend --to
 Sometimes absorb cannot predict an appropriate commit to apply changes to. In this case you can try the command `sl amend --to` to specify exactly which commit to apply pending changes to.
 
-```bash
+```sl-shell-example
 $ sl
   @  f656ac8c6  30 minutes ago  mary
   │  feature two

--- a/website/docs/overview/undo.md
+++ b/website/docs/overview/undo.md
@@ -6,7 +6,7 @@ sidebar_position: 90
 
 Since Sapling keeps a full record of the mutation history of commits, most Sapling commands that modify commits can be easily undone.  The `sl undo` command will revert the commit graph to its state prior to the last run command.
 
-```bash
+```sl-shell-example
 $ sl
   @  e75394bbb  16 minutes ago  mary
   │  Commit Two
@@ -53,7 +53,7 @@ o  774057207  Today at 10:48  remote/stable
 Running the command again will undo the command run before the last undone command. Use the `sl redo` command to reverse the undo command.
 
 
-```bash
+```sl-shell-example
 # Undo change #1.
 $ sl undo
 $ sl
@@ -96,7 +96,7 @@ view and recover the commit.
 The undo command is limited to undoing changes to the commit graph. To undo changes related to the working copy, like a commit or amend, use `sl uncommit` and `sl unamend`.
 
 
-```bash
+```sl-shell-example
 $ sl
   @  1a22ba0e9  83 seconds ago  mary
 ╭─╯  my feature

--- a/website/src/theme/prism-include-languages.js
+++ b/website/src/theme/prism-include-languages.js
@@ -1,0 +1,20 @@
+import siteConfig from '@generated/docusaurus.config';
+export default function prismIncludeLanguages(PrismObject) {
+  const {
+    themeConfig: {prism},
+  } = siteConfig;
+  const {additionalLanguages} = prism;
+  // Prism components work on the Prism instance on the window, while prism-
+  // react-renderer uses its own Prism instance. We temporarily mount the
+  // instance onto window, import components to enhance it, then remove it to
+  // avoid polluting global namespace.
+  // You can mutate PrismObject: registering plugins, deleting languages... As
+  // long as you don't re-assign it
+  globalThis.Prism = PrismObject;
+  additionalLanguages.forEach((lang) => {
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    require(`prismjs/components/prism-${lang}`);
+  });
+  require(`./prism-sl-shell-example`);
+  delete globalThis.Prism;
+}

--- a/website/src/theme/prism-sl-shell-example.js
+++ b/website/src/theme/prism-sl-shell-example.js
@@ -1,0 +1,65 @@
+(function (Prism) {
+
+	// CAREFUL!
+	// The following patterns are concatenated, so the group referenced by a back reference is non-obvious!
+
+	var strings = [
+		// normal string
+		/"(?:\\[\s\S]|\$\([^)]+\)|\$(?!\()|`[^`]+`|[^"\\`$])*"/.source,
+		/'[^']*'/.source,
+		/\$'(?:[^'\\]|\\[\s\S])*'/.source,
+
+		// here doc
+		// 2 capturing groups
+		/<<-?\s*(["']?)(\w+)\1\s[\s\S]*?[\r\n]\2/.source
+	].join('|');
+
+	Prism.languages['sl-shell-example'] = {
+		'command': {
+			pattern: RegExp(
+				// user info
+				/^/.source +
+				'(?:' +
+				(
+					// <user> ":" ( <path> )?
+					/[^\s@:$%*!/\\]+@[^\r\n@:$%*!/\\]+(?::[^\0-\x1F$%*?"<>:;|]+)?/.source +
+					'|' +
+					// <path>
+					// Since the path pattern is quite general, we will require it to start with a special character to
+					// prevent false positives.
+					/[/~.][^\0-\x1F$%*?"<>@:;|]*/.source
+				) +
+				')?' +
+				// shell symbol
+				/[$%](?=\s)/.source +
+				// bash command
+				/(?:[^\\\r\n \t'"<$]|[ \t](?:(?!#)|#.*$)|\\(?:[^\r]|\r\n?)|\$(?!')|<(?!<)|<<str>>)+/.source.replace(/<<str>>/g, function () { return strings; }),
+				'm'
+			),
+			greedy: true,
+			inside: {
+				'info': {
+					// foo@bar:~/files$ exit
+					// foo@bar$ exit
+					// ~/files$ exit
+					pattern: /^[^$%]+/,
+					alias: 'punctuation',
+					inside: {
+						'user': /^[^\s@:$%*!/\\]+@[^\r\n@:$%*!/\\]+/,
+						'punctuation': /:/,
+						'path': /[\s\S]+/
+					}
+				},
+				'shell-command': {
+					pattern: /(^[$%]\s*)\S[\s\S]*/,
+					lookbehind: true,
+				},
+				'shell-prompt': {
+					pattern: /^[$%]/,
+				}
+			}
+		},
+		'comment': /#.*/,
+		'output': /.(?:.*(?:[\r\n]|.$))*/,
+	};
+}(Prism));


### PR DESCRIPTION
Stack created with [Sapling]
* #270
* #267
* #266
* __->__ #264

[docs] add sl-shell-example syntax-highlighting language

Summary: Right now the example sl sessions have no hightlighting, or sometimes they pretend to be bash, which kind-of-half-works but also half doesn't work and is ugly (See the "Before" example - there is random highlighting for some numbers in the middle of command output, the ".." in "..." is randomly highlighted as a directory, etc)

This diff adds a new custom Prism language called "sl-shell-example" which does syntax highlighting specifically tailored for our example sessions with these main parts:

```
# comment
$ shell command
~/my/subdir $ shell command in a specific subdirectory
output
```

<img width="495" alt="Screenshot 2022-11-24 at 16 15 08" src="https://user-images.githubusercontent.com/40659/203828858-592f3bbd-27bb-42c5-a762-881baed3ac21.png">

(For the record, Prism already has a language called "shell-session", but that language doesn't support comments (which is something we make heavy use of), and also it tries to be clever by highlighting random words in the middle of shell commands (which is just distracting in the context of sapling docs))

Test Plan:

Before:
<img width="667" alt="Screenshot 2022-11-24 at 15 54 27" src="https://user-images.githubusercontent.com/40659/203827808-2dd856ef-4a94-4afe-ac79-f053925f3e59.png">

After:
<img width="668" alt="Screenshot 2022-11-24 at 15 54 39" src="https://user-images.githubusercontent.com/40659/203827793-3d1cee6b-0c68-4a99-9db9-821162db530e.png">

