### PR TITLE
[github] have `pr link` link the current rev by default

### DIFF
--- a/eden/scm/edenscm/ext/github/link.py
+++ b/eden/scm/edenscm/ext/github/link.py
@@ -24,7 +24,7 @@ def link(ui, repo, *args, **opts):
     if not pull_request:
         raise error.Abort(_("could not resolve pull request: '%%s'") % pr_arg)
 
-    ctx = scmutil.revsingle(repo, opts.get("rev"), None)
+    ctx = scmutil.revsingle(repo, opts.get("rev"))
     pr_store = PullRequestStore(repo)
     pr_store.map_commit_to_pull_request(ctx.node(), pull_request)
 


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/280).
* __->__ #280

[github] have `pr link` link the current rev by default

Summary: The docs seem to imply that `--rev` is optional, but right now if you don't specify a rev, you get a crash with unexpected `None`

Test Plan:

Before:
```
$ sl pr link 148
...
  File "/Users/shish2k/sapling/eden/scm/edenscm/util.py", line 1285, in check
    return func(*args, **kwargs)
  File "/Users/shish2k/sapling/eden/scm/edenscm/ext/github/__init__.py", line 78, in link_cmd
    return link.link(ui, repo, *args, **opts)
  File "/Users/shish2k/sapling/eden/scm/edenscm/ext/github/link.py", line 31, in link
    pr_store.map_commit_to_pull_request(ctx.node(), pull_request)
  File "/Users/shish2k/sapling/eden/scm/edenscm/ext/github/pullrequeststore.py", line 41, in map_commit_to_pull_request
    self._write_mappings(mappings)
  File "/Users/shish2k/sapling/eden/scm/edenscm/ext/github/pullrequeststore.py", line 64, in _write_mappings
    commits[hex(node)] = entry
TypeError: descriptor 'hex' for 'bytes' objects doesn't apply to a 'NoneType' object
```

After:
```
$ sl pr link 148

$ sl
  @  5a1bc01b8  Yesterday at 17:30  shish  #148
╭─╯  Chomecast support
...
```

