### PR TITLE
fix no default branch message for GHE

### DIFF
--- a/eden/scm/ghstack/github_utils.py
+++ b/eden/scm/ghstack/github_utils.py
@@ -97,7 +97,7 @@ This repository has no default branch. This is likely because it is empty.
 
 Consider using %s to initialize your
 repository.
-""") % f"https://github.com/{owner}/{name}/new/main")
+""") % f"https://{github_url}/{owner}/{name}/new/main")
 
     return {
         "name_with_owner": name_with_owner,


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/291).
* __->__ #291

fix no default branch message for GHE

