### PR TITLE
add Troubleshooting section for GitHub page

### DIFF
--- a/website/docs/git/intro.md
+++ b/website/docs/git/intro.md
@@ -53,3 +53,26 @@ See the dedicated [ghstack](./ghstack.md) page for more information.
 
 - Can only be used if you have _write_ access to the repository.
 - You will NOT be able to merge these pull requests using the normal GitHub UI.
+
+## Troubleshooting
+
+### `could not read Username` error when trying to `git push`
+
+If you see an error like the following:
+
+```
+stderr: fatal: could not read Username for 'https://github.com': No such device or address
+```
+
+Then you likely need to run [`gh auth setup-git [--hostname HOST]`](https://cli.github.com/manual/gh_auth_setup-git) to configure `gh` as a Git credential helper. This will add the following to your `.gitconfig` (though the host will be different if you used `--hostname` to specify your GitHub Enterprise hostname):
+
+```
+[credential "https://github.com"]
+	helper =
+	helper = !/usr/bin/gh auth git-credential
+[credential "https://gist.github.com"]
+	helper =
+	helper = !/usr/bin/gh auth git-credential
+```
+
+See [gh issue #3796](https://github.com/cli/cli/issues/3796) for details


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/294).
* __->__ #294

add Troubleshooting section for GitHub page

I just ran into an issue where `sl pr` failed to run because I
did not have `gh` configured as my Git credential helper.
It took me a bit of time to figure this out, so I thought I would
add it to the website, though the docs related to GitHub
integration are somewhat spread out, so I'm not sure whether this
is the best place for it. A dedicated Troubleshooting page might
be more appropriate, though such a page should probably have at
least two entries?

Though perhaps an even better solution is updating the code to
recognize this sort of failure and then suggest `gh auth setup-git`
directly when it happens.

Test Plan:

http://localhost:3000/docs/git/intro

