### PR TITLE
prefer fsPath to path when working with vscode.Uri

### DIFF
--- a/addons/vscode/extension/DiffContentProvider.ts
+++ b/addons/vscode/extension/DiffContentProvider.ts
@@ -58,9 +58,9 @@ export class SaplingDiffContentProvider implements vscode.TextDocumentContentPro
         const fixed = [];
         for (const encoded of unownedComparisons.values()) {
           const encodedUri = vscode.Uri.parse(encoded);
-          const path = decodeSaplingDiffUri(encodedUri).originalUri.path;
+          const {fsPath} = decodeSaplingDiffUri(encodedUri).originalUri;
           for (const root of knownRoots) {
-            if (path === root || path.startsWith(ensureTrailingPathSep(root))) {
+            if (fsPath === root || fsPath.startsWith(ensureTrailingPathSep(root))) {
               fixed.push(encodedUri);
               break;
             }
@@ -133,9 +133,9 @@ export class SaplingDiffContentProvider implements vscode.TextDocumentContentPro
   ): Promise<string | null> {
     const encodedUriString = encodedUri.toString();
     const data = decodeSaplingDiffUri(encodedUri);
-    const path = data.originalUri.path;
+    const {fsPath} = data.originalUri;
 
-    const repo = repositoryCache.cachedRepositoryForPath(path);
+    const repo = repositoryCache.cachedRepositoryForPath(fsPath);
 
     // remember that this URI was requested.
     const activeUrisSet = this.activeUrisByRepo.get(repo ?? 'unknown') ?? new Set();
@@ -157,7 +157,7 @@ export class SaplingDiffContentProvider implements vscode.TextDocumentContentPro
 
     // fall back to fetching from the repo
     const fetchedFileContent = await repo
-      .cat(path, revset)
+      .cat(fsPath, revset)
       // An error during `cat` usually means the right side of the comparison was added since the left,
       // so `cat` claims `no such file` at that revset.
       // TODO: it would be more accurate to check that the error is due to this, and return null if not.

--- a/addons/vscode/extension/VSCodeRepo.ts
+++ b/addons/vscode/extension/VSCodeRepo.ts
@@ -31,12 +31,12 @@ export function watchAndCreateRepositoriesForWorkspaceFolders(logger: Logger): v
     removed: ReadonlyArray<vscode.WorkspaceFolder>,
   ) {
     for (const add of added) {
-      const path = add.uri.path;
-      if (knownRepos.has(path)) {
-        throw new Error(`Attempted to add workspace folder path twice: ${path}`);
+      const {fsPath} = add.uri;
+      if (knownRepos.has(fsPath)) {
+        throw new Error(`Attempted to add workspace folder path twice: ${fsPath}`);
       }
-      const repoReference = repositoryCache.getOrCreate(getCLICommand(), logger, path);
-      knownRepos.set(path, repoReference);
+      const repoReference = repositoryCache.getOrCreate(getCLICommand(), logger, fsPath);
+      knownRepos.set(fsPath, repoReference);
       repoReference.promise.then(repo => {
         if (repo instanceof Repository) {
           const root = repo?.info.repoRoot;
@@ -54,10 +54,10 @@ export function watchAndCreateRepositoriesForWorkspaceFolders(logger: Logger): v
       });
     }
     for (const remove of removed) {
-      const path = remove.uri.path;
-      const repo = knownRepos.get(path);
+      const {fsPath} = remove.uri;
+      const repo = knownRepos.get(fsPath);
       repo?.unref();
-      knownRepos.delete(path);
+      knownRepos.delete(fsPath);
     }
   }
   if (vscode.workspace.workspaceFolders) {

--- a/addons/vscode/extension/commands.ts
+++ b/addons/vscode/extension/commands.ts
@@ -52,14 +52,15 @@ export function registerCommands(): Array<vscode.Disposable> {
 }
 
 function openDiffView(uri: vscode.Uri, comparison: Comparison): void {
-  const repo = repositoryCache.cachedRepositoryForPath(uri.path);
+  const {fsPath} = uri;
+  const repo = repositoryCache.cachedRepositoryForPath(fsPath);
   if (repo == null) {
-    vscode.window.showErrorMessage(t(`No repository found for file ${uri.path}`));
+    vscode.window.showErrorMessage(t(`No repository found for file ${fsPath}`));
     return;
   }
   const left = encodeSaplingDiffUri(uri, comparison);
   const right = uri;
-  const title = `${path.basename(uri.path)} (${t(labelForComparison(comparison))})`;
+  const title = `${path.basename(fsPath)} (${t(labelForComparison(comparison))})`;
 
   vscode.commands.executeCommand('vscode.diff', left, right, title);
 }


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/305).
* __->__ #305

prefer fsPath to path when working with vscode.Uri
It turns out that `vscode.Uri.prototype.path` is problematic on
Windows because it is not a "canonical path." For example,
for the same folder, `.path` could be reported as either:

```
"/C:/Users/micha/src/sapling/LICENSE"
```

or:

```
"/c:/Users/micha/src/sapling/LICENSE"
```

which means that basic string `===` tests for equality will not
work. However, both will report the same value for `.fsPath`:

```
"c:\\Users\\micha\\src\\sapling\\VERSION"
```

As noted on https://code.visualstudio.com/api/references/vscode-api#Uri.fsPath:

> The string representing the corresponding file system path of this Uri.
>
> Will handle UNC paths and normalize windows drive letters to lower-case. Also uses the platform specific path separator.

Because this issue arises only on Windows, the ideal fix is to
introduce a linter that prohibits the use of `.fsPath`.

