### PR TITLE
ghstack: use `.` instead of `max(decendents(.))` for HEAD

### DIFF
--- a/eden/scm/ghstack/sapling_shell.py
+++ b/eden/scm/ghstack/sapling_shell.py
@@ -68,7 +68,7 @@ class SaplingShell(ghstack.shell.Shell):
         # not be able to resolve arguments like HEAD, so we must resolve those
         # to a full hash before running Git.
         if 'HEAD' in args:
-            top = self._run_sapling_command(['log', '-r', 'max(descendants(.))', '-T', '{node}'])
+            top = self._run_sapling_command(['log', '-r', '.', '-T', '{node}'])
             for index, arg in enumerate(args):
                 if arg == 'HEAD':
                     args[index] = top


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/310).
* __->__ #310

ghstack: use `.` instead of `max(decendents(.))` for HEAD

The original ghstack used HEAD to represent the current commit in the stack for submitting prs.  When adapting to sl HEAD was replaced with `max(decedants(.))` which means operations will occur on everything in the stack which isn't desirable.  This changed HEAD to mean the current revision `.` which seems to be more lile what should be intended.

Test Plan:

```
$ sl
o  5492cbc35  1 second ago  brandonbennett
│  qux
│
@  90e41acf3  1 second ago  brandonbennett
│  bar
│
o  3f858f7d7  2 seconds ago  brandonbennett
│  foo
│
o  b3cd6c01e  Nov 29 at 09:30  remote/main

$ sl ghstack submit -v
$ /opt/homebrew/bin/sl config paths.default
$ /opt/homebrew/bin/sl log -T '{node}' -r 'ancestor(., main)'
$ /opt/homebrew/bin/sl log -r 'max(descendants(.))' -T '{node}'
$ git --git-dir /Users/brandonbennett/Code/testsap/.sl/store/git rev-list --header '^b3cd6c01e96f7b2a50294d97cb8a60f327cd9875' 5492cbc354beb62cd332afb10580a196fc40842f
$ git --git-dir /Users/brandonbennett/Code/testsap/.sl/store/git rev-list --header '^b3cd6c01e96f7b2a50294d97cb8a60f327cd9875^@' b3cd6c01e96f7b2a50294d97cb8a60f327cd9875
$ git --git-dir /Users/brandonbennett/Code/testsap/.sl/store/git rev-parse '3f858f7d739ea8e0a7569f257a1e65669669e7fc~^{tree}'
$ git --git-dir /Users/brandonbennett/Code/testsap/.sl/store/git config --get commit.gpgsign
$ git --git-dir /Users/brandonbennett/Code/testsap/.sl/store/git commit-tree -p b3cd6c01e96f7b2a50294d97cb8a60f327cd9875 dae37a0b9fecafee09c60547d255659eb9b5ed44
$ /opt/homebrew/bin/sl config paths.default
$ git --git-dir /Users/brandonbennett/Code/testsap/.sl/store/git push https://github.com/nemith/testsap.git f4cfcabfbd9332ecee2963d798356d2150f1e2f7:refs/heads/gh/nemith/13/head b3cd6c01e96f7b2a50294d97cb8a60f327cd9875:refs/heads/gh/nemith/13/base
^Cinterrupted!
 brandonbennett  HQ-QX0FQ102LC  ~  Code  testsap  %  sl ghstack submit -v
 brandonbennett  HQ-QX0FQ102LC  ~  Code  testsap  %  CHGDISABLE=1 ../sapling/eden/scm/sl ghstack submit -v
$ /Users/brandonbennett/Code/testsap/../sapling/eden/scm/sl config paths.default
$ /Users/brandonbennett/Code/testsap/../sapling/eden/scm/sl log -T '{node}' -r 'ancestor(., main)'
$ /Users/brandonbennett/Code/testsap/../sapling/eden/scm/sl log -r . -T '{node}'
$ git --git-dir /Users/brandonbennett/Code/testsap/.sl/store/git rev-list --header '^b3cd6c01e96f7b2a50294d97cb8a60f327cd9875' 90e41acf3e07f943e069e2e9f0986966dc618950
$ git --git-dir /Users/brandonbennett/Code/testsap/.sl/store/git rev-list --header '^b3cd6c01e96f7b2a50294d97cb8a60f327cd9875^@' b3cd6c01e96f7b2a50294d97cb8a60f327cd9875
$ git --git-dir /Users/brandonbennett/Code/testsap/.sl/store/git rev-parse '3f858f7d739ea8e0a7569f257a1e65669669e7fc~^{tree}'
$ git --git-dir /Users/brandonbennett/Code/testsap/.sl/store/git config --get commit.gpgsign
$ git --git-dir /Users/brandonbennett/Code/testsap/.sl/store/git commit-tree -p b3cd6c01e96f7b2a50294d97cb8a60f327cd9875 dae37a0b9fecafee09c60547d255659eb9b5ed44
$ /Users/brandonbennett/Code/testsap/../sapling/eden/scm/sl config paths.default
$ git --git-dir /Users/brandonbennett/Code/testsap/.sl/store/git push https://github.com/nemith/testsap.git 48a4ce09bc3d1541c8961f7d0d1bf893d677ae96:refs/heads/gh/nemith/13/head b3cd6c01e96f7b2a50294d97cb8a60f327cd9875:refs/heads/gh/nemith/13/base
To https://github.com/nemith/testsap.git
 * [new branch]      48a4ce09bc3d1541c8961f7d0d1bf893d677ae96 -> gh/nemith/13/head
 * [new branch]      b3cd6c01e96f7b2a50294d97cb8a60f327cd9875 -> gh/nemith/13/base
Opened PR #16
$ /Users/brandonbennett/Code/testsap/../sapling/eden/scm/sl metaedit -q -T '{nodechanges|json}' -r 3f858f7d739ea8e0a7569f257a1e65669669e7fc -m 'foo

ghstack-source-id: dae37a0b9fecafee09c60547d255659eb9b5ed44
Pull Request resolved: https://github.com/nemith/testsap/pull/16'
$ git --git-dir /Users/brandonbennett/Code/testsap/.sl/store/git rev-list --header '7a2207df4337649d2525adfc47b79ae4f9e068c7^..e18ffe0b3c2e68e44ae62c1a76d3f699da8b77bb'
$ git --git-dir /Users/brandonbennett/Code/testsap/.sl/store/git rev-parse 'e18ffe0b3c2e68e44ae62c1a76d3f699da8b77bb~^{tree}'
$ git --git-dir /Users/brandonbennett/Code/testsap/.sl/store/git commit-tree -p 48a4ce09bc3d1541c8961f7d0d1bf893d677ae96 defbe41b8836c18ffeaa72c5c748cdd1e0095911
$ /Users/brandonbennett/Code/testsap/../sapling/eden/scm/sl config paths.default
$ git --git-dir /Users/brandonbennett/Code/testsap/.sl/store/git push https://github.com/nemith/testsap.git 9850b01b776593f4cee46d805ea77738cc10fc1c:refs/heads/gh/nemith/14/head 48a4ce09bc3d1541c8961f7d0d1bf893d677ae96:refs/heads/gh/nemith/14/base
To https://github.com/nemith/testsap.git
 * [new branch]      9850b01b776593f4cee46d805ea77738cc10fc1c -> gh/nemith/14/head
 * [new branch]      48a4ce09bc3d1541c8961f7d0d1bf893d677ae96 -> gh/nemith/14/base
Opened PR #17
$ /Users/brandonbennett/Code/testsap/../sapling/eden/scm/sl metaedit -q -T '{nodechanges|json}' -r e18ffe0b3c2e68e44ae62c1a76d3f699da8b77bb -m 'bar

ghstack-source-id: defbe41b8836c18ffeaa72c5c748cdd1e0095911
Pull Request resolved: https://github.com/nemith/testsap/pull/17'
$ git --git-dir /Users/brandonbennett/Code/testsap/.sl/store/git rev-list --header 'd3fb6cff6249f5bfe563633418864b07e7cb636d^..d3fb6cff6249f5bfe563633418864b07e7cb636d'
# Updating https://github.com/nemith/testsap/pull/16
# Updating https://github.com/nemith/testsap/pull/17
$ /Users/brandonbennett/Code/testsap/../sapling/eden/scm/sl config paths.default
$ git --git-dir /Users/brandonbennett/Code/testsap/.sl/store/git push https://github.com/nemith/testsap.git --force 7a2207df4337649d2525adfc47b79ae4f9e068c7:refs/heads/gh/nemith/13/orig d3fb6cff6249f5bfe563633418864b07e7cb636d:refs/heads/gh/nemith/14/orig
To https://github.com/nemith/testsap.git
 * [new branch]      7a2207df4337649d2525adfc47b79ae4f9e068c7 -> gh/nemith/13/orig
 * [new branch]      d3fb6cff6249f5bfe563633418864b07e7cb636d -> gh/nemith/14/orig

# Summary of changes (ghstack 0.6.0.sapling)

 - Created https://github.com/nemith/testsap/pull/17
 - Created https://github.com/nemith/testsap/pull/16

Facebook employees can import your changes by running
(on a Facebook machine):

    ghimport -s https://github.com/nemith/testsap/pull/17

If you want to work on this diff stack on another machine:

    ghstack checkout https://github.com/nemith/testsap/pull/17
```



Fixes:  #283

