### PR TITLE
Add build instructions for Windows

### DIFF
--- a/website/docs/introduction/installation.md
+++ b/website/docs/introduction/installation.md
@@ -144,4 +144,14 @@ make oss
 `}
 </pre>
 
+Though the Windows build is slightly different:
+
+<pre>{`\
+git clone ${gitHubRepo}
+cd ${gitHubRepoName}/eden/scm
+python3 .\\packaging\\windows\\build_windows_zip.py
+.\\build\\embedded\\sl.exe --help
+`}
+</pre>
+
 Once you have Sapling installed, follow the [Getting Started](./getting-started.md) instructions.


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/317).
* __->__ #317

Add build instructions for Windows

Summary:

Fixes https://github.com/facebook/sapling/issues/316

Test Plan:

http://localhost:3000/docs/introduction/installation

