### PR TITLE
bump Python in Github macOS actions to 3.11

### DIFF
--- a/.github/workflows/sapling-cli-homebrew-macos-arm64-release.yml
+++ b/.github/workflows/sapling-cli-homebrew-macos-arm64-release.yml
@@ -21,7 +21,7 @@ jobs:
 
         -s c11b17c8b78efa46dac2d213cd7a7b3fff75f6f5e6d2ef2248345cd4a900b1c6 -f openssl@1.1 \
 
-        -s 3e95fbf0f18b59af7aeaa957be4499a9c521ec199f2ec2a419b8a7b9ac627a3a -f python@3.8 \
+        -s 4e968bd8f28aee189bd829c2b9feabeb8c5edd95b949cf327ea2f1f62ac76e66 -f python@3.11 \
 
         -t aarch64-apple-darwin \
 

--- a/.github/workflows/sapling-cli-homebrew-macos-x86-release.yml
+++ b/.github/workflows/sapling-cli-homebrew-macos-x86-release.yml
@@ -21,7 +21,7 @@ jobs:
 
         -s d915175bedb146e38d7a2c95e86888a60a5058a5cd21f835813d43d1372a29d9 -f openssl@1.1 \
 
-        -s c247a261048c510b963705acfbea23b09cc193b5d4256a5d10b42d199a8f8869 -f python@3.8 \
+        -s 919aeadea2828aad7ccd95538e4db27943f8c1fc3c185e5d19d4afd89b1a79ad -f python@3.11 \
 
         -t x86_64-apple-darwin \
 

--- a/ci/gen_workflows.py
+++ b/ci/gen_workflows.py
@@ -42,12 +42,12 @@ UBUNTU_DEPS = [
 MACOS_RELEASES = {
     "x86": {
         "target": "x86_64-apple-darwin",
-        "python_bottle_hash": "c247a261048c510b963705acfbea23b09cc193b5d4256a5d10b42d199a8f8869",
+        "python_bottle_hash": "919aeadea2828aad7ccd95538e4db27943f8c1fc3c185e5d19d4afd89b1a79ad",
         "openssl_bottle_hash": "d915175bedb146e38d7a2c95e86888a60a5058a5cd21f835813d43d1372a29d9",
     },
     "arm64": {
         "target": "aarch64-apple-darwin",
-        "python_bottle_hash": "3e95fbf0f18b59af7aeaa957be4499a9c521ec199f2ec2a419b8a7b9ac627a3a",
+        "python_bottle_hash": "4e968bd8f28aee189bd829c2b9feabeb8c5edd95b949cf327ea2f1f62ac76e66",
         "openssl_bottle_hash": "c11b17c8b78efa46dac2d213cd7a7b3fff75f6f5e6d2ef2248345cd4a900b1c6",
     },
 }
@@ -360,7 +360,7 @@ RUN rm -rf /tmp/repo
                     "name": "Prepare build environment",
                     "run": "eden/scm/packaging/mac/prepare_environment.py \\\n"
                     + f"-s {openssl_bottle_hash} -f openssl@1.1 \\\n"
-                    + f"-s {python_bottle_hash} -f python@3.8 \\\n"
+                    + f"-s {python_bottle_hash} -f python@3.11 \\\n"
                     + f"-t {target} \\\n"
                     + "-r ${{ env.SAPLING_VERSION }} \\\n"
                     + "-o $(brew tap-info homebrew/core | sed -n '2p' | awk '{printf $1}')/Formula/sapling.rb",

--- a/eden/scm/packaging/mac/prepare_environment.py
+++ b/eden/scm/packaging/mac/prepare_environment.py
@@ -88,7 +88,7 @@ def get_bottle(bottle_name: str, bottle_hash: str, tmpdir: str):
     The hash corresponds to the hash of some bottle (which can be specified in
     the bottle section of homebrew formulas).
 
-    https://github.com/Homebrew/homebrew-core/blob/75bac0ef0c7a68d3607fc5d7e94ef417d93df138/Formula/python%403.8.rb#L14
+    https://github.com/Homebrew/homebrew-core/blob/75bac0ef0c7a68d3607fc5d7e94ef417d93df138/Formula/python%403.11.rb#L14
     is an example of this.
     """
     auth_url = f"https://ghcr.io/v2/homebrew/core/{bottle_name.replace('@', '/')}/blobs/sha256:{bottle_hash}"
@@ -109,7 +109,7 @@ def get_bottle(bottle_name: str, bottle_hash: str, tmpdir: str):
             url = line.split()[1]
             break
     if url is None:
-        raise RuntimeException(f"Unable to get actual url when querying {auth_url}")
+        raise RuntimeError(f"Unable to get actual url when querying {auth_url}")
     cmd = [
         "curl",
         "--location",
@@ -128,22 +128,22 @@ def set_up_downloaded_crates(tmpdir):
     print(f"LOCATION IS {brew_location}")
     dylib_location = os.path.join(
         brew_location,
-        "python@3.8/3.8.15/Frameworks/Python.framework/Versions/3.8/lib/libpython3.8.dylib",
+        "python@3.11/3.11.0/Frameworks/Python.framework/Versions/3.11/lib/libpython3.11.dylib",
     )
     run_cmd(
         [
             "tar",
             "-zxvf",
-            os.path.join(tmpdir, "python@3.8.bottle.tar.gz"),
+            os.path.join(tmpdir, "python@3.11.bottle.tar.gz"),
             "-C",
             tmpdir,
-            "python@3.8/3.8.15/Frameworks/Python.framework/Versions/3.8/Python",
+            "python@3.11/3.11.0/Frameworks/Python.framework/Versions/3.11/Python",
         ]
     )
     os.remove(dylib_location)
     shutil.copy(
         os.path.join(
-            tmpdir, "python@3.8/3.8.15/Frameworks/Python.framework/Versions/3.8/Python"
+            tmpdir, "python@3.11/3.11.0/Frameworks/Python.framework/Versions/3.11/Python"
         ),
         dylib_location,
     )
@@ -200,8 +200,8 @@ if __name__ == "__main__":
         print("Number of hashes and formulas to download must be the same")
         exit(1)
 
-    if "python@3.8" not in args.formula or "openssl@1.1" not in args.formula:
-        print("Must specify both python3.8 and openssl@1.1 bottles to download")
+    if "python@3.11" not in args.formula or "openssl@1.1" not in args.formula:
+        print("Must specify both python3.11 and openssl@1.1 bottles to download")
         exit(1)
 
     tmpdir = tempfile.mkdtemp()


### PR DESCRIPTION
Summary:

The latest Homebrew bottles for Apple Sillicon macOS built by our Github Actions were broken, as mentioned in #315 . This was caused due to updating the Formula template used by our Github actions to 3.11 but not updating the Github actions themselves to Python 3.11. This commit fixes that last part.

Test plan:

Triggered a [build on a fork of the sapling repo](https://github.com/sggutier/sapling/releases/tag/0.1.20221211-120017-rcd410769), downloaded the bottle built by it, and checked that it ran properly on my M1 mac:

```
$ sl --version
Sapling 0.1.20221211-120017-rcd410769

$ file $(which sl)
/Users/sggutier/homebrew/bin/sl: Mach-O 64-bit executable arm64

$ otool -L $(which sl)
/Users/sggutier/homebrew/bin/sl:
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1311.100.3)
        /usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
        /System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 60158.100.133)
        /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1858.112.0)
        /Users/sggutier/homebrew/opt/openssl@1.1/lib/libssl.1.1.dylib (compatibility version 1.1.0, current version 1.1.0)
        /Users/sggutier/homebrew/opt/openssl@1.1/lib/libcrypto.1.1.dylib (compatibility version 1.1.0, current version 1.1.0)
        /System/Library/Frameworks/SystemConfiguration.framework/Versions/A/SystemConfiguration (compatibility version 1.0.0, current version 1163.100.19)
        /usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
        /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices (compatibility version 1.0.0, current version 1141.1.0)
        /Users/sggutier/homebrew/opt/python@3.11/Frameworks/Python.framework/Versions/3.11/Python (compatibility version 3.11.0, current version 3.11.0)
        /usr/lib/libresolv.9.dylib (compatibility version 1.0.0, current version 1.0.0)

$ sl dbsh -c "import sys; print(sys.version)"
3.11.0 (main, Nov 28 2022, 13:49:33) [Clang 14.0.0 (clang-1400.0.29.202)]  

$ sl clone https://github.com/sggutier/sapling/ saplingtest && cd saplingtest && sl
remote: Enumerating objects: 677771, done.
remote: Counting objects: 100% (2847/2847), done.
remote: Compressing objects: 100% (1469/1469), done.
remote: Total 677771 (delta 1396), reused 2692 (delta 1261), pack-reused 674924
Receiving objects: 100% (677771/677771), 175.60 MiB | 2.59 MiB/s, done.
Resolving deltas: 100% (454743/454743), done.
From https://github.com/sggutier/sapling
 * [new ref]               2857ac6b96035d44a198b3dcf0f6638b6ceff705 -> remote/main
6535 files updated, 0 files merged, 0 files removed, 0 files unresolved
@  2857ac6b9  Today at 11:33  mbolin  #317  remote/main
│  Add build instructions for Windows (#317)
~

$ touch something && sl st
warning: watchman has recently started (pid 1093) - operation will be slower than usual
? something

$ cd eden/scm && sl root
/Users/sggutier/saplingtest
```