### PR TITLE
do not strip the final newline when running `sl cat`

### DIFF
--- a/addons/isl-server/src/Repository.ts
+++ b/addons/isl-server/src/Repository.ts
@@ -597,7 +597,10 @@ export class Repository {
   /** Return file content at a given revset, e.g. hash or `.` */
   public cat(file: AbsolutePath, rev: Revset): Promise<string> {
     return this.catLimiter.enqueueRun(async () => {
-      return (await this.runCommand(['cat', file, '--rev', rev])).stdout;
+      // For `sl cat`, we want the output of the command verbatim.
+      const options = {stripFinalNewline: false};
+      return (await this.runCommand(['cat', file, '--rev', rev], /*cwd=*/ undefined, options))
+        .stdout;
     });
   }
 


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/321).
* __->__ #321

do not strip the final newline when running `sl cat`

