### PR TITLE
Add UI Icon on the editor bar for open-isl command

### DIFF
--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -48,7 +48,11 @@
       {
         "command": "sapling.open-isl",
         "title": "%sapling.open-isl-command%",
-        "category": "%sapling.command-category%"
+        "category": "%sapling.command-category%",
+        "icon": {
+          "light": "resources/Sapling_favicon-light-green.svg",
+          "dark": "resources/Sapling_favicon-light-green.svg"
+        }
       },
       {
         "command": "sapling.open-file-diff-uncommitted",
@@ -65,7 +69,15 @@
         "title": "%sapling.open-diff-stack-command%",
         "category": "%sapling.command-category%"
       }
-    ]
+    ],
+    "menus":{
+      "editor/title": [
+        {
+          "command": "sapling.open-isl",
+          "group": "navigation"
+        }
+      ]
+    }
   },
   "scripts": {
     "eslint": "eslint extension webview --ext .ts --ext .tsx",


### PR DESCRIPTION
Hi Everyone. This is not really any ground breaking change but I added an icon using the .svg logo of sapling on the title bar of the editor. I think this is a nice alternative to hitting F2 and typing the command. Ideally it would be better if it was on the side bar as an Activitybar ( why not both ? ) but it appears that is not something trivial ( still havent found a way to make it work)

![Screenshot 2022-12-13 184053](https://user-images.githubusercontent.com/56932790/207392849-a42a61a6-0c53-41c0-8af4-81a1dccd97ed.png)

Tested by running yarn build-extension and copying the files outputed in dist/ as well as the project.json on the extensions folder of the vscode installation.