### PR TITLE
underscore for unused var in cmdutil.findcmd

### DIFF
--- a/eden/scm/edenscm/cmdutil.py
+++ b/eden/scm/edenscm/cmdutil.py
@@ -850,7 +850,7 @@ def getcmdanddefaultopts(cmdname, table):
 
 def findcmd(cmd, table):
     """Return (aliases, command table entry) for command string."""
-    choice, allcmds = findpossible(cmd, table)
+    choice, _ = findpossible(cmd, table)
 
     if cmd in choice:
         return choice[cmd]


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/345).
* __->__ #345

underscore for unused var in cmdutil.findcmd

