### PR TITLE
util: add zsh prompt

### DIFF
--- a/eden/scm/contrib/scm-prompt.sh
+++ b/eden/scm/contrib/scm-prompt.sh
@@ -243,6 +243,9 @@ _scm_prompt() {
     elif [[ -d "$dir/.hg" ]]; then
       br="$(_hg_prompt "$dir/.hg")"
       break
+    elif [[ -d "$dir/.sl" ]]; then
+      br="$(_hg_prompt "$dir/.sl")"
+      break
     fi
     [[ "$dir" = "/" ]] && break
     # portable "realpath" equivalent


### PR DESCRIPTION
util: add zsh prompt

Summary: Add shell prompt for Sapling.  The current prompt only supports git
and hg, but not sl.  Since the `hg` prompt should work the same for `sl`, use
`_hg_prompt` for Sapling if a `.sl` directory exists

Test Plan: Blocked by #447
TODO: copy `.hg` testcases from `eden/scm/tests/test-fb-ext-scm-prompt-hg.t`

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/348).
* #349
* __->__ #348
