### PR TITLE
util: show all dirty status indicators

### DIFF
--- a/eden/scm/contrib/scm-prompt.sh
+++ b/eden/scm/contrib/scm-prompt.sh
@@ -243,6 +243,9 @@ _scm_prompt() {
     elif [[ -d "$dir/.hg" ]]; then
       br="$(_hg_prompt "$dir/.hg")"
       break
+    elif [[ -d "$dir/.sl" ]]; then
+      br="$(_hg_prompt "$dir/.sl")"
+      break
     fi
     [[ "$dir" = "/" ]] && break
     # portable "realpath" equivalent

--- a/eden/scm/contrib/scm-prompt.sh
+++ b/eden/scm/contrib/scm-prompt.sh
@@ -162,10 +162,12 @@ _hg_prompt() {
 # cf. https://www.internalfb.com/intern/qa/4964/how-do-i-show-the-mercurial-bookmarkgit-branch-in?answerID=540621130023036
 _hg_dirty() {
   if [ -n "${SHOW_DIRTY_STATE}" ] &&
-     [ "$(hg config shell.showDirtyState)" != "false" ]; then
-    command hg status 2> /dev/null \
-    | command awk '$1 == "?" { print "?" } $1 != "?" { print "*" }' \
-    | command sort | command uniq | command head -c1
+     [ "$(command sl config shell.showDirtyState)" != "false" ]; then
+       command sl status 2> /dev/null \
+         | command awk '{print $1}'\
+         | command sort\
+         | command uniq\
+         | command paste -sd ' ' -
   fi
 }
 


### PR DESCRIPTION
Summary: Instead of just showing `?` or `*`, show one of each symbol in the
dirty status.  This means there will be a maximum of 5 characters at the end of
the prompt, which is fine.

Test Plan: blocked by #447

Question for reviewer: I am having trouble running the test suite for Sapling.
I'd appreciate some help getting this working.  I can provide more details if
you wouldn't mind helping