### PR TITLE
Add completion for sapling

### DIFF
--- a/eden/scm/contrib/zsh_completion
+++ b/eden/scm/contrib/zsh_completion
@@ -1,4 +1,4 @@
-#compdef hg
+#compdef hg sl=hg
 
 # Zsh completion script for mercurial.  Rename this file to _hg and copy
 # it into your zsh function path (/usr/share/zsh/site-functions for


### PR DESCRIPTION
Add completion for sapling

Summary: Make completion work for `sl` by adding `sl=hg` to the compdef

Test Plan:
Manually
```sh
$ ln -sv ~+/eden/scm/contrib/zsh_completion /usr/local/share/zsh/site-functions
$ exec zsh # might have to clear compinit cache
$ sl g
gc       githelp  goto     graft    grep
```
(and this does not work on main at the time of writing)


Automated tests blocked by #447

Question for Review: I am having trouble running Sapling's test suite.  I'd
appreciate some assistance here

off-topic: I can run the unit tests for completion, but because of how
sapling's test runner works I get the same result on main and this commit,
meaning the results are not relevant

```sh
$ (cd tests && python run-tests.py test-completion.t)
```

```diff
--- test-completion.t
+++ test-completion.t.err
@@ -19,6 +19,7 @@
   clean
   clone
   commit
+  config
   configfile
   continue
   copy
@@ -30,6 +31,7 @@
   fs
   gc
   githelp
+  goto
   graft
   grep
   heads
@@ -68,7 +70,6 @@
   unbundle
   uncommit
   uncopy -  update
   verify
   verifyremotefilelog
   version
@@ -107,7 +108,6 @@
   debugcommands
   debugcompactmetalog
   debugcomplete
-  debugconfig
   debugcreatestreamclonebundle
   debugdag
   debugdata
@@ -317,7 +317,6 @@

 Show aliases with -v
   $ hg debugcomplete update -v
-  update checkout co goto

   $ hg debugcomplete -v
   add
@@ -327,13 +326,14 @@
   backout
   bisect
   blackbox
-  bookmark bookmarks
+  bookmark
   branch
   bundle
   cat
   clean purge
   clone
   commit ci
+  config
   configfile
   continue
   copy cp
@@ -345,6 +345,7 @@
   fs
   gc
   githelp
+  goto
   graft
   grep
   heads
@@ -355,7 +356,7 @@
   import patch
   init
   locate
-  log history
+  log
   manifest
   merge
   parents
@@ -383,7 +384,6 @@
   unbundle
   uncommit
   uncopy
-  update checkout co goto
   verify
   verifyremotefilelog
   version
@@ -393,7 +393,7 @@
 Show an error if we use --options with an ambiguous abbreviation
   $ hg debugcomplete --options s
   unknown command 's'
-  (use 'hg help' to get help)
+  (use 'sl help' to get help)
   [255]

 Show all commands + options
@@ -547,6 +547,7 @@
   fs:
   gc:
   githelp:
+  goto: clean, check, merge, date, rev, inactive, continue, tool
   graft: rev, continue, abort, edit, log, force, currentdate, currentuser, date, user, tool, dry-run
   grep: after-context, before-context, context, ignore-case, files-with-matches, line-number, invert-match, word-regexp, extended-regexp, fixed-strings, perl-regexp, include, exclude
   heads: rev, topo, active, closed, style, template
@@ -585,7 +586,6 @@
   unbundle: update
   uncommit: keep, include, exclude
   uncopy: include, exclude, dry-run
-  update: clean, check, merge, date, rev, inactive, continue, tool
   verify: rev, dag
   verifyremotefilelog: decompress
   version: template

ERROR: test-completion.t output changed

----------------------------------------------------------------------
Failed 1 tests (output changed and returned error code 1):
  test-completion.t

# Ran 1 tests, 0 skipped, 1 failed.
python hash seed: 2485669182
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/369).
* __->__ #369
