### PR TITLE
fix fallback logic for missing translation

### DIFF
--- a/addons/isl/src/i18n/index.tsx
+++ b/addons/isl/src/i18n/index.tsx
@@ -136,7 +136,7 @@ function translate(
   }
   if (!result) {
     result =
-      langs[currentLanguage][i18nKeyOrEnText] ?? langs.en[i18nKeyOrEnText] ?? i18nKeyOrEnText;
+      langs[currentLanguage]?.[i18nKeyOrEnText] ?? langs.en[i18nKeyOrEnText] ?? i18nKeyOrEnText;
   }
   if (options?.replace) {
     // if we split with a regexp match group, the value will stay in the array,


### PR DESCRIPTION
fix fallback logic for missing translation

Use optional chaining to handle the case when `currentLanguage` is not in `langs`.

Fixes https://github.com/facebook/sapling/issues/362

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/372).
* __->__ #372
