### PR TITLE
add config option to disable mention of ReviewStack in PR bodies

### DIFF
--- a/eden/scm/edenscm/ext/github/pull_request_body.py
+++ b/eden/scm/edenscm/ext/github/pull_request_body.py
@@ -16,6 +16,7 @@ def create_pull_request_title_and_body(
     pr_numbers_and_num_commits: List[Tuple[int, int]],
     pr_numbers_index: int,
     repository: Repository,
+    skip_reviewstack_tag: False,
 ) -> Tuple[str, str]:
     r"""Returns (title, body) for the pull request.
 
@@ -55,9 +56,15 @@ def create_pull_request_title_and_body(
         ]
     )
     title = firstline(commit_msg)
-    body = f"""{commit_msg}
+    if skip_reviewstack_tag == False:
+        body = f"""{commit_msg}
 {_HORIZONTAL_RULE}
 Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack]({reviewstack_url}).
+{bulleted_list}
+"""
+    else:
+        body = f"""{commit_msg}
+{_HORIZONTAL_RULE}
 {bulleted_list}
 """
     return title, body

--- a/eden/scm/edenscm/ext/github/submit.py
+++ b/eden/scm/edenscm/ext/github/submit.py
@@ -288,6 +288,7 @@ async def rewrite_pull_request_body(
         pr_numbers_and_num_commits,
         index,
         repository,
+        skip_reviewstack_tag=(ui.configbool("ui", "skip_reviewstack_tag"))
     )
     pr = head_commit_data.pr
     assert pr


### PR DESCRIPTION
add config option to disable mention of ReviewStack in PR bodies

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/431).
* __->__ #431
