### PR TITLE
(build): Support sapling in tag-name.sh

### DIFF
--- a/ci/tag-name.sh
+++ b/ci/tag-name.sh
@@ -6,5 +6,9 @@
 
 DIR=$(dirname -- "$0")
 VERSION=$(<"$DIR"/../SAPLING_VERSION)
-COMMIT_INFO=$(git -c "core.abbrev=8" show -s "--format=%cd-h%h" "--date=format:%Y%m%d-%H%M%S")
+
+# Create the commit info using either sl or git, whichever way we cloned this repo
+COMMIT_INFO=$(sl log --rev . --template '{date(date, "%Y%m%d-%H%M%S")}-h{shortest(node, 8)}') \
+  || $(git -c "core.abbrev=8" show -s "--format=%cd-h%h" "--date=format:%Y%m%d-%H%M%S")
+
 echo "$VERSION"."$COMMIT_INFO"


### PR DESCRIPTION
(build): Support sapling in tag-name.sh

Summary: Currently, tag-name.sh only works with git.  This is fine, because
it's only used in GitHub CI, but I also want to use this script for local
builds (which will be in a future commit).  This commit will use either sl or
git for creating tag names.

Test-Plan: Automated testing blocked on #447

```sh
❯ ./ci/tag-name.sh
0.2.20230107-190233-hc1336fcb
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/439).
* #440
* __->__ #439
