### PR TITLE
(build): Use Sapling HEAD for sl version by default in `make oss`

### DIFF
--- a/eden/scm/setup.py
+++ b/eden/scm/setup.py
@@ -311,7 +311,7 @@ def filterhgerr(err):
     return b"\n".join(b"  " + e for e in err)
 
 
-def findhg():
+def findhg(vcname: str):
     """Try to figure out how we should invoke hg for examining the local
     repository contents.
 
@@ -328,7 +328,7 @@ def findhg():
     # and disable localization for the same reasons.
     hgenv["HGPLAIN"] = "1"
     hgenv["LANGUAGE"] = "C"
-    hgcmd = ["hg"]
+    hgcmd = [vcname]
     # Run a simple "hg log" command just to see if using hg from the user's
     # path works and can successfully interact with this repository.
     check_cmd = ["log", "-r.", "-Ttest"]
@@ -341,7 +341,7 @@ def findhg():
 
     # Fall back to trying the local hg installation.
     hgenv = localhgenv()
-    hgcmd = [sys.executable, "hg"]
+    hgcmd = [sys.executable, vcname]
     try:
         retcode, out, err = runcmd(hgcmd + check_cmd, hgenv)
     except EnvironmentError:
@@ -372,9 +372,7 @@ def localhgenv():
         env["SystemRoot"] = os.environ["SystemRoot"]
     return env
 
-
-hg = None if ossbuild else findhg()
-
+hg = findhg("hg") or findhg("sl")
 
 def hgtemplate(template, cast=None):
     if not hg:


### PR DESCRIPTION
(build): Use Sapling HEAD for sl version by default in `make oss`

Summary: Currently, following the recommended documentation for building
Sapling will always set the sapling version to the upstream Mercurial version
(which has been 4.4.2 for years)

```sh
❯ sl --version
Sapling 4.4.2
```

This isn't very useful when debugging Sapling, and is inconsistenct with the
distributed versions of sl.  This commit aligns the sl version with the sl
version in the distributed versions of sl

Test Plan: manual

```sh
❯ (cd eden/scm && make oss && ./sl --version)
Sapling 0.2.20230107-190820-h75ace1ad
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/440).
* #522
* __->__ #440
