### PR TITLE
oss: make 'make tests' run Python tests

### DIFF
--- a/eden/scm/Makefile
+++ b/eden/scm/Makefile
@@ -171,6 +171,11 @@ test-getdeps: install-getdeps
 
 check: tests
 
+.PHONY: tests
+tests:
+	cd tests && PYTHON_SYS_EXECUTABLE=$(shell $(PYTHON3) contrib/pick_python.py $(PYTHON3)) \
+	    $(shell $(PYTHON3) contrib/pick_python.py $(PYTHON3)) run-tests.py
+
 update-pot: i18n/hg.pot
 
 i18n/hg.pot: $(PYFILES) $(DOCFILES) i18n/posplit i18n/hggettext

--- a/eden/scm/tests/run-tests.py
+++ b/eden/scm/tests/run-tests.py
@@ -694,19 +694,21 @@ def parseargs(args, parser):
             os.path.isfile(options.with_hg) and os.access(options.with_hg, os.X_OK)
         ):
             parser.error("--with-hg must specify an executable hg script")
-    if options.local:
+    if options.local and not options.with_hg:
         testdir = os.path.dirname(canonpath(sys.argv[0]))
         reporootdir = os.path.dirname(testdir)
-        pathandattrs = [("hg", "with_hg")]
-        for relpath, attr in pathandattrs:
-            if getattr(options, attr, None):
-                continue
-            binpath = os.path.join(reporootdir, relpath)
-            if os.name != "nt" and not os.access(binpath, os.X_OK):
-                parser.error(
-                    "--local specified, but %r not found or not executable" % binpath
-                )
-            setattr(options, attr, binpath)
+        exe_names = ("sl", "hg")
+        if os.name == "nt":
+            exe_names = ("sl", "sl.exe", "hg", "hg.exe")
+        for exe_name in exe_names:
+            binpath = os.path.join(reporootdir, exe_name)
+            if os.access(binpath, os.X_OK):
+                options.with_hg = binpath
+                break
+        if not options.with_hg:
+            parser.error(
+                "--local specified, but %s not found in %r or not executable" % (" or ".join(exe_names), reporootdir)
+            )
 
     if options.chg and os.name == "nt":
         parser.error("chg does not work on %s" % os.name)


### PR DESCRIPTION
oss: make 'make tests' run Python tests

Summary:
'make check' tries to run 'make tests', but despite being documented, the
'tests' target does not exist in the Makefile.

Create a 'tests' target which runs the Python test suite.

Test Plan:

    $ make oss
    $ make check
    [bunch of failures]
    $ (cd tests && python run-tests.py test-debugcheckcasecollisions.t)
    ----------------------------------------------------------------------
    # Ran 1 tests, 0 skipped, 0 failed.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/458).
* #459
* __->__ #458
