### PR TITLE
Allow `sl init --git` in non-empty directory

### DIFF
--- a/eden/scm/edenscm/git.py
+++ b/eden/scm/edenscm/git.py
@@ -115,10 +115,10 @@ def clone(ui, url, destpath=None, update=True, pullnames=None):
 
     if os.path.lexists(destpath):
         if os.path.isdir(destpath):
-            if os.listdir(destpath):
+            if os.listdir(destpath) and url != "":
                 raise error.Abort(_("destination '%s' is not empty") % destpath)
         else:
-            raise error.Abort(_("destination '%s' already exists") % destpath)
+            raise error.Abort(_("destination '%s' exists and is not a directory") % destpath)
 
     try:
         repo = createrepo(ui, url, destpath)

--- a/eden/scm/tests/test-git-init.t
+++ b/eden/scm/tests/test-git-init.t
@@ -1,0 +1,11 @@
+#debugruntest-compatible
+#require git no-windows
+
+Can init with --git in an existing directory
+  $ cd
+  $ mkdir init-git-nonempty
+  $ cd init-git-nonempty
+  $ printf hello > hello
+  $ hg init --git .
+  $ hg status
+  ? hello


### PR DESCRIPTION
Allow `sl init --git` in non-empty directory

Summary: Currently, running `sl init --git` for a nonempty directory gives the
follwing error:
```
destination <..> already exists
```
This seems like an arbitary restriction to me, so I removed it.

It looks like this restriction was put in place because `sl init` and
`sl clone` share similar logic.  Is there any other reason for not allowing
`sl init` in non-empty directories?

Also, this commit fixes an imprecise error message when `init`ing a repository
in a non-directory (i.e. a file)

Test plan: Blocked by #447
manually tested with

(should pass, but didn't before)
```sh
DIR=/tmp/sl-clone-test zsh -c 'rm -rf $DIR; mkdir $DIR && cd $DIR && touch hi && CHGDISABLE=1 sl init --git .'
```

(should still fail)
```sh
DIR=/tmp/sl-clone-test REPO=git@github.com:97-things/97-things-every-programmer-should-know.git zsh -c 'rm -rf $DIR; mkdir $DIR && cd $DIR && CHGDISABLE=1 sl clone $REPO && CHGDISABLE=1 sl clone $REPO'
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/463).
* __->__ #463
