### PR TITLE
git: respect 'default-push' path if present

### DIFF
--- a/addons/isl-server/src/analytics/serverSideTracker.ts
+++ b/addons/isl-server/src/analytics/serverSideTracker.ts
@@ -24,7 +24,7 @@ class ServerSideContext {
   }
 }
 
-const noOp = () => {
+const noOp = (...args: any[]) => {
   /* In open source builds, analytics tracking is completely disabled/removed. */
 };
 

--- a/addons/isl/src/analytics/index.ts
+++ b/addons/isl/src/analytics/index.ts
@@ -7,7 +7,6 @@
 
 import type {TrackDataWithEventName} from 'isl-server/src/analytics/types';
 
-import serverAPI from '../ClientToServerAPI';
 import {Tracker} from 'isl-server/src/analytics/tracker';
 
 /** Client-side global analytics tracker */
@@ -16,7 +15,7 @@ export const tracker = new Tracker(sendDataToServer, {});
 /**
  * The client side sends data to the server-side to actually get tracked.
  */
-function sendDataToServer(data: TrackDataWithEventName) {
+function sendDataToServer(_data: TrackDataWithEventName) {
   // In open source, we don't even need to bother sending these messages to the server,
   // since we don't track anything anyway.
   // prettier-ignore

--- a/eden/scm/.gitignore
+++ b/eden/scm/.gitignore
@@ -30,6 +30,7 @@ fb/tests/*.err
 tests/htmlcov
 tests/getdb.sh
 tests/testutil/getdb.py
+tests/__pycache__/
 contrib/chg/chg
 contrib/chg/libchg.a
 contrib/hgsh/hgsh

--- a/eden/scm/edenscm/ext/remotenames.py
+++ b/eden/scm/edenscm/ext/remotenames.py
@@ -854,7 +854,9 @@ def expushcmd(orig, ui, repo, dest=None, **opts):
     dest, opts = adjust_push_dest_opts(ui, dest, opts)
     if git.isgitpeer(repo):
         if dest is None:
-            dest = "default"
+            dest = "default-push"
+            if dest not in ui.paths:
+                dest = "default"
         force = opts.get("force")
         delete = opts.get("delete")
         if delete:

--- a/eden/scm/tests/test-git-push-default-push.t
+++ b/eden/scm/tests/test-git-push-default-push.t
@@ -1,0 +1,42 @@
+#chg-compatible
+#require git
+#debugruntest-compatible
+
+  $ . $TESTDIR/git.sh
+
+Initialize the server repos.
+
+  $ git init -q --bare -b main repo-1.git
+  $ git init -q --bare -b main repo-2.git
+
+Initialize the Sapling repo.
+
+  $ hg clone -q --git "$TESTTMP/repo-1.git" client-repo
+  $ cd client-repo
+  $ hg paths --add default-push "$TESTTMP/repo-2.git"
+  $ touch testfile
+  $ hg add testfile
+  $ hg commit testfile -m testcommit
+
+Pushing without specifying a path pushes to the 'default-push' path.
+
+  $ hg push -q -r . --to main --create
+
+  $ GIT_DIR="$TESTTMP/repo-1.git" git log --pretty=format:%s%n
+  fatal: your current branch 'main' does not have any commits yet
+  [128]
+
+  $ GIT_DIR="$TESTTMP/repo-2.git" git log --pretty=format:%s%n
+  testcommit
+
+After deleting the 'default-push' path,
+pushing without specifying a path pushes to the 'default' path
+
+  $ hg paths --delete default-push
+  $ hg push -q -r . --to main --create
+
+  $ GIT_DIR="$TESTTMP/repo-1.git" git log --pretty=format:%s%n
+  testcommit
+
+  $ GIT_DIR="$TESTTMP/repo-2.git" git log --pretty=format:%s%n
+  testcommit


### PR DESCRIPTION
git: respect 'default-push' path if present

Summary:
In non-Git mode, 'hg push' (without an explicit path) pushes to the
'default-push' path if present, falling back to the 'default' path.

In Git mode, 'sl push' (without an explicit path) always pushes to the 'default'
path. 'default-push' is ignored.

Teach Git mode to push to 'default-push' if present, similar to how it works in
non-Git mode.

This commit only affects 'sl push'. 'sl pr submit' still ignores the
'default-push' path.

Test Plan:

    $ (cd tests && python run-tests.py test-git-push-default-push.t)
