### PR TITLE
github: respect 'default-push' path if present

### DIFF
--- a/addons/isl-server/src/analytics/serverSideTracker.ts
+++ b/addons/isl-server/src/analytics/serverSideTracker.ts
@@ -24,7 +24,7 @@ class ServerSideContext {
   }
 }
 
-const noOp = () => {
+const noOp = (...args: any[]) => {
   /* In open source builds, analytics tracking is completely disabled/removed. */
 };
 

--- a/addons/isl/src/analytics/index.ts
+++ b/addons/isl/src/analytics/index.ts
@@ -7,7 +7,6 @@
 
 import type {TrackDataWithEventName} from 'isl-server/src/analytics/types';
 
-import serverAPI from '../ClientToServerAPI';
 import {Tracker} from 'isl-server/src/analytics/tracker';
 
 /** Client-side global analytics tracker */
@@ -16,7 +15,7 @@ export const tracker = new Tracker(sendDataToServer, {});
 /**
  * The client side sends data to the server-side to actually get tracked.
  */
-function sendDataToServer(data: TrackDataWithEventName) {
+function sendDataToServer(_data: TrackDataWithEventName) {
   // In open source, we don't even need to bother sending these messages to the server,
   // since we don't track anything anyway.
   // prettier-ignore

--- a/eden/scm/.gitignore
+++ b/eden/scm/.gitignore
@@ -30,6 +30,7 @@ fb/tests/*.err
 tests/htmlcov
 tests/getdb.sh
 tests/testutil/getdb.py
+tests/__pycache__/
 contrib/chg/chg
 contrib/chg/libchg.a
 contrib/hgsh/hgsh

--- a/eden/scm/edenscm/ext/github/mock_utils.py
+++ b/eden/scm/edenscm/ext/github/mock_utils.py
@@ -366,14 +366,15 @@ class GetRepositoryRequest(MockRequest):
     ):
         data = {
             "data": {
-                "repository": {
-                    "id": repo_id,
-                    "owner": {"id": owner_id, "login": self._owner},
-                    "name": self._name,
-                    "isFork": is_fork,
-                    "defaultBranchRef": {"name": default_branch_ref},
-                    "parent": parent,
-                }
+                "repository": make_repository_for_response(
+                    repo_id=repo_id,
+                    repo_name=self._name,
+                    owner_id=owner_id,
+                    owner_login=self._owner,
+                    default_branch_ref=default_branch_ref,
+                    is_fork=is_fork,
+                    parent=parent,
+                ),
             }
         }
         self._response = Ok(data)
@@ -599,3 +600,22 @@ def create_request_key(
 def gen_hash_hexdigest(s: str) -> str:
     """generate sha1 digit hex string for input `s`"""
     return hashlib.sha1(s.encode()).hexdigest()
+
+
+def make_repository_for_response(
+    repo_id: str,
+    repo_name: str,
+    owner_id: str,
+    owner_login: str,
+    default_branch_ref: str = "main",
+    is_fork: bool = False,
+    parent: Optional[Any] = None,
+) -> Dict:
+    return {
+        "id": repo_id,
+        "owner": {"id": owner_id, "login": owner_login},
+        "name": repo_name,
+        "isFork": is_fork,
+        "defaultBranchRef": {"name": default_branch_ref},
+        "parent": parent,
+    }

--- a/eden/scm/edenscm/ext/github/submit.py
+++ b/eden/scm/edenscm/ext/github/submit.py
@@ -600,9 +600,11 @@ async def get_repository_for_origin(origin: str, hostname: str) -> Repository:
 def get_origin(ui) -> str:
     test_url = os.environ.get("SL_TEST_GH_URL")
     if test_url:
-        origin = test_url
-    else:
-        origin = ui.config("paths", "default")
+        return test_url
+    origin = ui.config("paths", "default-push")
+    if origin:
+        return origin
+    origin = ui.config("paths", "default")
     if origin:
         return origin
     else:

--- a/eden/scm/edenscm/ext/remotenames.py
+++ b/eden/scm/edenscm/ext/remotenames.py
@@ -854,7 +854,9 @@ def expushcmd(orig, ui, repo, dest=None, **opts):
     dest, opts = adjust_push_dest_opts(ui, dest, opts)
     if git.isgitpeer(repo):
         if dest is None:
-            dest = "default"
+            dest = "default-push"
+            if dest not in ui.paths:
+                dest = "default"
         force = opts.get("force")
         delete = opts.get("delete")
         if delete:

--- a/eden/scm/tests/github/mock_create_one_pr_from_contributor_repo.py
+++ b/eden/scm/tests/github/mock_create_one_pr_from_contributor_repo.py
@@ -1,0 +1,102 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This software may be used and distributed according to the terms of the
+# GNU General Public License version 2.
+
+from edenscm import extensions
+from edenscm.ext.github import submit
+from edenscm.ext.github.mock_utils import make_repository_for_response, mock_run_git_command, MockGitHubServer
+from edenscm.ext.github.pull_request_body import firstline
+from ghstack import github_gh_cli
+
+# An extension to mock network requests by replacing the `github_gh_cli.make_request`
+# and `submit.run_git_command` with the corresponding wrapper functions. Check `uisetup`
+# function for how wrapper functions are registered.
+
+
+def setup_mock_github_server() -> MockGitHubServer:
+    """Setup mock GitHub Server for testing happy case of `sl pr submit` command."""
+    github_server = MockGitHubServer()
+
+    UPSTREAM_OWNER = "facebook"
+    UPSTREAM_OWNER_ID = "U_facebook_id"
+    UPSTREAM_REPO_NAME = "test_github_repo"
+    UPSTREAM_REPO_ID = "R_facebook_test_github_repo"
+
+    DOWNSTREAM_OWNER = "contributor"
+    DOWNSTREAM_OWNER_ID = "U_contributor_id"
+    DOWNSTREAM_REPO_NAME = "fork_github_repo"
+    DOWNSTREAM_REPO_ID = "R_contributor_fork_github_repo"
+
+    USER_NAME = "facebook_username"
+
+    github_server.expect_get_repository_request(
+        owner=DOWNSTREAM_OWNER,
+        name=DOWNSTREAM_REPO_NAME,
+    ).and_respond(
+        repo_id=DOWNSTREAM_REPO_ID,
+        owner_id=DOWNSTREAM_OWNER_ID,
+        is_fork=True,
+        parent=make_repository_for_response(
+            repo_id=UPSTREAM_REPO_ID,
+            repo_name=UPSTREAM_REPO_NAME,
+            owner_id=UPSTREAM_OWNER_ID,
+            owner_login=UPSTREAM_OWNER,
+            is_fork=False,
+        ),
+    )
+
+    github_server.expect_get_repository_request(
+        owner=UPSTREAM_OWNER,
+        name=UPSTREAM_REPO_NAME,
+    ).and_respond(
+        repo_id=UPSTREAM_REPO_ID,
+        owner_id=UPSTREAM_OWNER_ID,
+        is_fork=False,
+    )
+
+    next_pr_number = 42
+    github_server.expect_guess_next_pull_request_number().and_respond()
+
+    body = "addfile\n"
+    title = firstline(body)
+    github_server.expect_create_pr_request(
+        body=body,
+        title=title,
+        owner=UPSTREAM_OWNER,
+        name=UPSTREAM_REPO_NAME,
+        head=f"{DOWNSTREAM_OWNER}:pr{next_pr_number}",
+    ).and_respond(number=next_pr_number)
+
+    pr_id = f"PR_id_{next_pr_number}"
+    github_server.expect_get_pr_details_request(
+        next_pr_number,
+        owner=UPSTREAM_OWNER,
+        name=UPSTREAM_REPO_NAME,
+    ).and_respond(pr_id)
+
+    github_server.expect_update_pr_request(
+        pr_id,
+        next_pr_number,
+        body,
+        owner=UPSTREAM_OWNER,
+        name=UPSTREAM_REPO_NAME,
+    ).and_respond()
+    github_server.expect_get_username_request().and_respond()
+
+    head = "3a120a3a153f7d2960967ce6f1d52698a4d3a436"
+    github_server.expect_merge_into_branch(
+        head,
+        username=USER_NAME,
+        repo_id=DOWNSTREAM_REPO_ID,
+    ).and_respond()
+
+    return github_server
+
+
+def uisetup(ui):
+    mock_github_server = setup_mock_github_server()
+    extensions.wrapfunction(
+        github_gh_cli, "_make_request", mock_github_server.make_request
+    )
+    extensions.wrapfunction(submit, "run_git_command", mock_run_git_command)

--- a/eden/scm/tests/test-ext-github-pr-submit.t
+++ b/eden/scm/tests/test-ext-github-pr-submit.t
@@ -3,13 +3,13 @@
 #inprocess-hg-incompatible
 
   $ enable github
-  $ export SL_TEST_GH_URL=https://github.com/facebook/test_github_repo.git
   $ . $TESTDIR/git.sh
 
 build up a github repo
 
   $ sl init --git repo1
   $ cd repo1
+  $ setconfig paths.default=https://github.com/facebook/test_github_repo.git
   $ echo a > a1
   $ sl ci -Am addfile
   adding a1
@@ -21,5 +21,13 @@ confirm it is a 'github_repo'
 test sending pr
   $ sl pr submit --config extensions.pr_submit=$TESTDIR/github/mock_create_one_pr.py
   pushing 1 to https://github.com/facebook/test_github_repo.git
+  created new pull request: https://github.com/facebook/test_github_repo/pull/42
+  updated body for https://github.com/facebook/test_github_repo/pull/42
+
+test sending pr with a 'default-push' path
+  $ setconfig paths.default-push=https://github.com/contributor/fork_github_repo.git
+  $ sl pr unlink -r .
+  $ sl pr submit --config extensions.pr_submit=$TESTDIR/github/mock_create_one_pr_from_contributor_repo.py
+  pushing 1 to https://github.com/contributor/fork_github_repo.git
   created new pull request: https://github.com/facebook/test_github_repo/pull/42
   updated body for https://github.com/facebook/test_github_repo/pull/42

--- a/eden/scm/tests/test-git-push-default-push.t
+++ b/eden/scm/tests/test-git-push-default-push.t
@@ -1,0 +1,42 @@
+#chg-compatible
+#require git
+#debugruntest-compatible
+
+  $ . $TESTDIR/git.sh
+
+Initialize the server repos.
+
+  $ git init -q --bare -b main repo-1.git
+  $ git init -q --bare -b main repo-2.git
+
+Initialize the Sapling repo.
+
+  $ hg clone -q --git "$TESTTMP/repo-1.git" client-repo
+  $ cd client-repo
+  $ hg paths --add default-push "$TESTTMP/repo-2.git"
+  $ touch testfile
+  $ hg add testfile
+  $ hg commit testfile -m testcommit
+
+Pushing without specifying a path pushes to the 'default-push' path.
+
+  $ hg push -q -r . --to main --create
+
+  $ GIT_DIR="$TESTTMP/repo-1.git" git log --pretty=format:%s%n
+  fatal: your current branch 'main' does not have any commits yet
+  [128]
+
+  $ GIT_DIR="$TESTTMP/repo-2.git" git log --pretty=format:%s%n
+  testcommit
+
+After deleting the 'default-push' path,
+pushing without specifying a path pushes to the 'default' path
+
+  $ hg paths --delete default-push
+  $ hg push -q -r . --to main --create
+
+  $ GIT_DIR="$TESTTMP/repo-1.git" git log --pretty=format:%s%n
+  testcommit
+
+  $ GIT_DIR="$TESTTMP/repo-2.git" git log --pretty=format:%s%n
+  testcommit


### PR DESCRIPTION
github: respect 'default-push' path if present

Summary:
'hg push' (without an explicit path) pushes to the 'default-push' path if
present, falling back to the 'default' path.

'sl pr submit' always pushes to the 'default' path. 'default-push' is ignored.

Teach 'sl pr submit' to push to 'default-push' if present, similar to how it
works with 'sl push'.

Test Plan:

    $ (cd tests && python run-tests.py test-ext-github-pr-submit.t)

    $ # Submit the PR you are looking at now:
    $ ./sl paths
    default = https://github.com/facebook/sapling.git
    default-push = ssh://git@github.com/strager/sapling.git
    $ CHGDISABLE=1 ./sl pr submit
