### PR TITLE
website: arch linux installation instructions

### DIFF
--- a/website/docs/introduction/installation.md
+++ b/website/docs/introduction/installation.md
@@ -134,6 +134,12 @@ Then install:
 sudo apt install -y ./{ubuntu20.name}
 </CodeBlock>
 
+#### Arch Linux (AUR)
+
+<CodeBlock>
+yay -S sapling-scm-bin
+</CodeBlock>
+
 #### Other Linux distros
 
 Sapling can be installed from Homebrew on Linux. First install Homebrew on your machine, then run


### PR DESCRIPTION
now easy to install sapling on Arch Linux distros with AUR enabled. 
https://aur.archlinux.org/packages/sapling-scm-bin
