### PR TITLE
Back out "vendor abomonation with smallvec support"

### DIFF
--- a/eden/fs/Cargo.toml
+++ b/eden/fs/Cargo.toml
@@ -1,5 +1,4 @@
 [patch.crates-io]
-abomonation = { git = "https://github.com/markbt/abomonation", rev = "0f43346d2afa2aedc64d61f3f4273e8d1e454642" }
 aes-gcm-siv = { git = "https://github.com/lei2022/AEADs", rev = "d9d03399fbc1347a1c2941801c0743e847980757" }
 bindgen = { git = "https://github.com/fbsource/bindgen", rev = "65cde6d7eed1b6785d3c4186f326b4470a680e7b" }
 bindgen-cli = { git = "https://github.com/fbsource/bindgen", rev = "65cde6d7eed1b6785d3c4186f326b4470a680e7b" }

--- a/eden/mononoke/Cargo.toml
+++ b/eden/mononoke/Cargo.toml
@@ -132,7 +132,6 @@ tokio-stream = { version = "0.1.4", features = ["fs", "io-util", "net", "signal"
 toml = "=0.5.8"
 
 [patch.crates-io]
-abomonation = { git = "https://github.com/markbt/abomonation", rev = "0f43346d2afa2aedc64d61f3f4273e8d1e454642" }
 aes-gcm-siv = { git = "https://github.com/lei2022/AEADs", rev = "d9d03399fbc1347a1c2941801c0743e847980757" }
 bindgen = { git = "https://github.com/fbsource/bindgen", rev = "65cde6d7eed1b6785d3c4186f326b4470a680e7b" }
 bindgen-cli = { git = "https://github.com/fbsource/bindgen", rev = "65cde6d7eed1b6785d3c4186f326b4470a680e7b" }

--- a/eden/mononoke/blobstore/Cargo.toml
+++ b/eden/mononoke/blobstore/Cargo.toml
@@ -12,7 +12,7 @@ name = "blobstore_test"
 path = "test/main.rs"
 
 [dependencies]
-abomonation = { version = "0.7", features = ["smallvec"] }
+abomonation = "0.7"
 abomonation_derive = "0.5"
 anyhow = "1.0.65"
 async-trait = "0.1.58"

--- a/eden/mononoke/blobstore/ephemeral_blobstore/Cargo.toml
+++ b/eden/mononoke/blobstore/ephemeral_blobstore/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 license = "GPLv2+"
 
 [dependencies]
-abomonation = { version = "0.7", features = ["smallvec"] }
+abomonation = "0.7"
 abomonation_derive = "0.5"
 anyhow = "1.0.65"
 async-stream = "0.3"

--- a/eden/mononoke/bonsai_globalrev_mapping/Cargo.toml
+++ b/eden/mononoke/bonsai_globalrev_mapping/Cargo.toml
@@ -12,7 +12,7 @@ name = "bonsai_globalrev_mapping_test"
 path = "test/main.rs"
 
 [dependencies]
-abomonation = { version = "0.7", features = ["smallvec"] }
+abomonation = "0.7"
 abomonation_derive = "0.5"
 anyhow = "1.0.65"
 async-trait = "0.1.58"

--- a/eden/mononoke/bonsai_hg_mapping/Cargo.toml
+++ b/eden/mononoke/bonsai_hg_mapping/Cargo.toml
@@ -12,7 +12,7 @@ name = "bonsai_hg_mapping_test"
 path = "test/main.rs"
 
 [dependencies]
-abomonation = { version = "0.7", features = ["smallvec"] }
+abomonation = "0.7"
 abomonation_derive = "0.5"
 anyhow = "1.0.65"
 async-trait = "0.1.58"

--- a/eden/mononoke/bonsai_svnrev_mapping/Cargo.toml
+++ b/eden/mononoke/bonsai_svnrev_mapping/Cargo.toml
@@ -12,7 +12,7 @@ name = "bonsai_svnrev_mapping_test"
 path = "test/main.rs"
 
 [dependencies]
-abomonation = { version = "0.7", features = ["smallvec"] }
+abomonation = "0.7"
 abomonation_derive = "0.5"
 anyhow = "1.0.65"
 async-trait = "0.1.58"

--- a/eden/mononoke/changesets/Cargo.toml
+++ b/eden/mononoke/changesets/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 license = "GPLv2+"
 
 [dependencies]
-abomonation = { version = "0.7", features = ["smallvec"] }
+abomonation = "0.7"
 abomonation_derive = "0.5"
 anyhow = "1.0.65"
 async-trait = "0.1.58"

--- a/eden/mononoke/changesets/changesets_impl/Cargo.toml
+++ b/eden/mononoke/changesets/changesets_impl/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 license = "GPLv2+"
 
 [dependencies]
-abomonation = { version = "0.7", features = ["smallvec"] }
+abomonation = "0.7"
 abomonation_derive = "0.5"
 anyhow = "1.0.65"
 async-trait = "0.1.58"

--- a/eden/mononoke/common/path_hash/Cargo.toml
+++ b/eden/mononoke/common/path_hash/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 license = "GPLv2+"
 
 [dependencies]
-abomonation = { version = "0.7", features = ["smallvec"] }
+abomonation = "0.7"
 abomonation_derive = "0.5"
 mononoke_types = { version = "0.1.0", path = "../../mononoke_types" }
 sql = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }

--- a/eden/mononoke/common/rust/caching_ext/Cargo.toml
+++ b/eden/mononoke/common/rust/caching_ext/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 license = "GPLv2+"
 
 [dependencies]
-abomonation = { version = "0.7", features = ["smallvec"] }
+abomonation = "0.7"
 anyhow = "1.0.65"
 async-trait = "0.1.58"
 auto_impl = "0.4"

--- a/eden/mononoke/common/rust/sql_ext/Cargo.toml
+++ b/eden/mononoke/common/rust/sql_ext/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 license = "GPLv2+"
 
 [dependencies]
-abomonation = { version = "0.7", features = ["smallvec"] }
+abomonation = "0.7"
 abomonation_derive = "0.5"
 anyhow = "1.0.65"
 arc-swap = "1.5"

--- a/eden/mononoke/git/git_types/Cargo.toml
+++ b/eden/mononoke/git/git_types/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 license = "GPLv2+"
 
 [dependencies]
-abomonation = { version = "0.7", features = ["smallvec"] }
+abomonation = "0.7"
 abomonation_derive = "0.5"
 anyhow = "1.0.65"
 async-trait = "0.1.58"

--- a/eden/mononoke/mercurial/mutation/Cargo.toml
+++ b/eden/mononoke/mercurial/mutation/Cargo.toml
@@ -12,7 +12,7 @@ name = "mercurial_mutation_test"
 path = "test/main.rs"
 
 [dependencies]
-abomonation = { version = "0.7", features = ["smallvec"] }
+abomonation = "0.7"
 abomonation_derive = "0.5"
 anyhow = "1.0.65"
 async-trait = "0.1.58"

--- a/eden/mononoke/mercurial/types/Cargo.toml
+++ b/eden/mononoke/mercurial/types/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 license = "GPLv2+"
 
 [dependencies]
-abomonation = { version = "0.7", features = ["smallvec"] }
+abomonation = "0.7"
 abomonation_derive = "0.5"
 anyhow = "1.0.65"
 ascii = "1.0"

--- a/eden/mononoke/mononoke_types/Cargo.toml
+++ b/eden/mononoke/mononoke_types/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 license = "GPLv2+"
 
 [dependencies]
-abomonation = { version = "0.7", features = ["smallvec"] }
+abomonation = "0.7"
 abomonation_derive = "0.5"
 anyhow = "1.0.65"
 ascii = "1.0"

--- a/eden/mononoke/mutable_renames/Cargo.toml
+++ b/eden/mononoke/mutable_renames/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 license = "GPLv2+"
 
 [dependencies]
-abomonation = { version = "0.7", features = ["smallvec"] }
+abomonation = "0.7"
 abomonation_derive = "0.5"
 anyhow = "1.0.65"
 async-trait = "0.1.58"

--- a/eden/mononoke/newfilenodes/Cargo.toml
+++ b/eden/mononoke/newfilenodes/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 license = "GPLv2+"
 
 [dependencies]
-abomonation = { version = "0.7", features = ["smallvec"] }
+abomonation = "0.7"
 abomonation_derive = "0.5"
 anyhow = "1.0.65"
 async-trait = "0.1.58"

--- a/eden/mononoke/phases/Cargo.toml
+++ b/eden/mononoke/phases/Cargo.toml
@@ -12,7 +12,7 @@ name = "tests"
 path = "tests/src/main.rs"
 
 [dependencies]
-abomonation = { version = "0.7", features = ["smallvec"] }
+abomonation = "0.7"
 abomonation_derive = "0.5"
 anyhow = "1.0.65"
 async-trait = "0.1.58"

--- a/eden/mononoke/phases/sqlphases/Cargo.toml
+++ b/eden/mononoke/phases/sqlphases/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPLv2+"
 autotests = false
 
 [dependencies]
-abomonation = { version = "0.7", features = ["smallvec"] }
+abomonation = "0.7"
 abomonation_derive = "0.5"
 anyhow = "1.0.65"
 ascii = "1.0"

--- a/eden/mononoke/segmented_changelog/Cargo.toml
+++ b/eden/mononoke/segmented_changelog/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 license = "GPLv2+"
 
 [dependencies]
-abomonation = { version = "0.7", features = ["smallvec"] }
+abomonation = "0.7"
 abomonation_derive = "0.5"
 anyhow = "1.0.65"
 async-trait = "0.1.58"

--- a/eden/scm/lib/dag/dag-types/Cargo.toml
+++ b/eden/scm/lib/dag/dag-types/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-abomonation = { version = "0.7", features = ["smallvec"] }
+abomonation = "0.7"
 abomonation_derive = "0.5"
 minibytes = { version = "0.1.0", path = "../../minibytes", default-features = false }
 quickcheck = { version = "1.0", optional = true }


### PR DESCRIPTION
Back out "vendor abomonation with smallvec support"

ca851e8 caused compilation errors for me when running the oss build.

```sh
$ make -j oss

SAPLING_OSS_BUILD=true HGNAME=sl \
	  /usr/local/bin/python3.8 setup.py  \
	  build_py -c -d . \
	  build_clib  \
	  build_ext  -i \
	  build_rust_ext -i -l --debug \
	  build_pyzip -i \
	  build_mo
setup.py:1720: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
#...
warning: /Users/m0c0j7y/workspace/github.com/facebook/sapling/eden/scm/lib/zstdelta/Cargo.toml: version requirement `2.0.1+zstd.1.5.2` for dependency `zstd-sys` includes semver metadata which will be ignored, removing the metadata is recommended to avoid confusion
error: failed to select a version for `abomonation`.
    ... required by package `dag-types v0.1.0 (/Users/m0c0j7y/workspace/github.com/facebook/sapling/eden/scm/lib/dag/dag-types)`
    ... which satisfies path dependency `dag-types` (locked to 0.1.0) of package `edenapi_types v0.1.0 (/Users/m0c0j7y/workspace/github.com/facebook/sapling/eden/scm/lib/edenapi/types)`
    ... which satisfies path dependency `edenapi_types` (locked to 0.1.0) of package `edenapi v0.1.0 (/Users/m0c0j7y/workspace/github.com/facebook/sapling/eden/scm/lib/edenapi)`
    ... which satisfies path dependency `edenapi` (locked to 0.1.0) of package `repo v0.1.0 (/Users/m0c0j7y/workspace/github.com/facebook/sapling/eden/scm/lib/repo)`
    ... which satisfies path dependency `repo` (locked to 0.1.0) of package `clidispatch v0.1.0 (/Users/m0c0j7y/workspace/github.com/facebook/sapling/eden/scm/lib/clidispatch)`
    ... which satisfies path dependency `clidispatch` (locked to 0.1.0) of package `hgmain v0.1.0 (/Users/m0c0j7y/workspace/github.com/facebook/sapling/eden/scm/exec/hgmain)`
versions that meet the requirements `^0.7` (locked to 0.7.3) are: 0.7.3

the package `dag-types` depends on `abomonation`, with features: `smallvec` but `abomonation` does not have these features.


failed to select a version for `abomonation` which could resolve this conflict
error: compilation of Rust target 'conch_parser' failed
make: *** [oss] Error 1
```

reproduction steps:
1. versions
  - macOS 13.1
  - cargo 1.65.0
2. goto any commit in ca851e8c::1a5756ce2
3. `(cd eden/scm && make oss)`

Please let me know if you need any other info for reproduction

I'd be happy to work on another solution than just reverting this changeset if
you'd rather.

Test Plan:
- originally found with `sl bisect`
- manually confirmed `ca851e~1` builds and `ca851e` does not
- confirmed backing out ca851e worked by running `cd eden/scm && make oss`

Fixes #483

Original commit changeset: ca851e8c179f

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/478).
* __->__ #478
