### PR TITLE
[sl] ci: bump python3.11.0 to python3.11.1

### DIFF
--- a/.github/workflows/sapling-cli-homebrew-macos-arm64-release.yml
+++ b/.github/workflows/sapling-cli-homebrew-macos-arm64-release.yml
@@ -21,7 +21,7 @@ jobs:
 
         -s c11b17c8b78efa46dac2d213cd7a7b3fff75f6f5e6d2ef2248345cd4a900b1c6 -f openssl@1.1 \
 
-        -s 4e968bd8f28aee189bd829c2b9feabeb8c5edd95b949cf327ea2f1f62ac76e66 -f python@3.11 \
+        -s 54c7eb00a23451b956abe4797a759e29824d33953fb57715bde6b9abb2500555 -f python@3.11 \
 
         -t aarch64-apple-darwin \
 

--- a/.github/workflows/sapling-cli-homebrew-macos-x86-release.yml
+++ b/.github/workflows/sapling-cli-homebrew-macos-x86-release.yml
@@ -21,7 +21,7 @@ jobs:
 
         -s d915175bedb146e38d7a2c95e86888a60a5058a5cd21f835813d43d1372a29d9 -f openssl@1.1 \
 
-        -s 919aeadea2828aad7ccd95538e4db27943f8c1fc3c185e5d19d4afd89b1a79ad -f python@3.11 \
+        -s b668909b679a54930bd35a9a2738a27ef1d545db8a4d889b8d9a475e85519116 -f python@3.11 \
 
         -t x86_64-apple-darwin \
 

--- a/ci/gen_workflows.py
+++ b/ci/gen_workflows.py
@@ -42,12 +42,12 @@ UBUNTU_DEPS = [
 MACOS_RELEASES = {
     "x86": {
         "target": "x86_64-apple-darwin",
-        "python_bottle_hash": "919aeadea2828aad7ccd95538e4db27943f8c1fc3c185e5d19d4afd89b1a79ad",
+        "python_bottle_hash": "b668909b679a54930bd35a9a2738a27ef1d545db8a4d889b8d9a475e85519116",
         "openssl_bottle_hash": "d915175bedb146e38d7a2c95e86888a60a5058a5cd21f835813d43d1372a29d9",
     },
     "arm64": {
         "target": "aarch64-apple-darwin",
-        "python_bottle_hash": "4e968bd8f28aee189bd829c2b9feabeb8c5edd95b949cf327ea2f1f62ac76e66",
+        "python_bottle_hash": "54c7eb00a23451b956abe4797a759e29824d33953fb57715bde6b9abb2500555",
         "openssl_bottle_hash": "c11b17c8b78efa46dac2d213cd7a7b3fff75f6f5e6d2ef2248345cd4a900b1c6",
     },
 }

--- a/eden/scm/packaging/mac/prepare_environment.py
+++ b/eden/scm/packaging/mac/prepare_environment.py
@@ -128,7 +128,7 @@ def set_up_downloaded_crates(tmpdir):
     print(f"LOCATION IS {brew_location}")
     dylib_location = os.path.join(
         brew_location,
-        "python@3.11/3.11.0/Frameworks/Python.framework/Versions/3.11/lib/libpython3.11.dylib",
+        "python@3.11/3.11.1/Frameworks/Python.framework/Versions/3.11/lib/libpython3.11.dylib",
     )
     run_cmd(
         [
@@ -137,14 +137,14 @@ def set_up_downloaded_crates(tmpdir):
             os.path.join(tmpdir, "python@3.11.bottle.tar.gz"),
             "-C",
             tmpdir,
-            "python@3.11/3.11.0/Frameworks/Python.framework/Versions/3.11/Python",
+            "python@3.11/3.11.1/Frameworks/Python.framework/Versions/3.11/Python",
         ]
     )
     os.remove(dylib_location)
     shutil.copy(
         os.path.join(
             tmpdir,
-            "python@3.11/3.11.0/Frameworks/Python.framework/Versions/3.11/Python",
+            "python@3.11/3.11.1/Frameworks/Python.framework/Versions/3.11/Python",
         ),
         dylib_location,
     )


### PR DESCRIPTION
[sl] ci: bump python3.11.0 to python3.11.1

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/496).
* __->__ #496
