### PR TITLE
[sl] ci: fix Windows OS CI due to path length

### DIFF
--- a/.github/workflows/sapling-cli-windows-amd64-release.yml
+++ b/.github/workflows/sapling-cli-windows-amd64-release.yml
@@ -15,6 +15,8 @@ jobs:
       run: git config --global --add safe.directory "$PWD"
     - name: rustup
       run: rustup default stable
+    - name: Support longpaths
+      run: git config --system core.longpaths true
     - name: openssl
       run: vcpkg install openssl:x64-windows-static-md
     - name: integrate vcpkg

--- a/ci/gen_workflows.py
+++ b/ci/gen_workflows.py
@@ -297,6 +297,7 @@ RUN rm -rf /tmp/repo
                 {"name": "Checkout Code", "uses": "actions/checkout@v3"},
                 grant_repo_access(),
                 {"name": "rustup", "run": "rustup default stable"},
+                {"name": "Support longpaths", "run": "git config --system core.longpaths true"},
                 # The "x64-windows-static-md" triple is what the Rust openssl
                 # crate expects on Windows when it goes looking for the vcpkg
                 # install.


### PR DESCRIPTION
[sl] ci: fix Windows OS CI due to path length

Summary:

Currently our OSS CI on Windows is failing due to some paths being too long (e.g., `C:/Users/runneradmin/.cargo/git/checkouts/fbthrift-abf000ee5c7fcc50/c757ec4/thrift/website/src/json/ref/cpp/f/struct/special/structapache_1_1thrift_1_1op_1_1detail_1_1AnyOp_3_01type_1_1cpp__type_3_01T_00_01type_1_1map_3_01KTag_00_01VTag_01_4_01_4_01_4/assign.json`)

Since the length of that path is just above the Windows max length (263 vs. 260). This diff tries to alleviate that by moving the `CARGO_HOME` directory to `C:\cargo`, which should be enough to shave off some characters to make the CI work again.

Test Plan:

Ran GitHub actions on a personal fork of the repo.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/500).
* __->__ #500
