### PR TITLE
[sl] ci: update caniuse-lite to 1.0.30001449

### DIFF
--- a/addons/yarn.lock
+++ b/addons/yarn.lock
@@ -3886,9 +3886,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001335, caniuse-lite@^1.0.30001366:
-  version "1.0.30001370"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001370.tgz#0a30d4f20d38b9e108cc5ae7cc62df9fe66cd5ba"
-  integrity sha512-3PDmaP56wz/qz7G508xzjx8C+MC2qEm4SYhSEzC9IBROo+dGXFWRuaXkWti0A9tuI00g+toiriVqxtWMgl350g==
+  version "1.0.30001449"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001449.tgz"
+  integrity sha512-CPB+UL9XMT/Av+pJxCKGhdx+yg1hzplvFJQlJ2n68PyQGMz9L/E2zCyLdOL8uasbouTUgnPl+y0tccI/se+BEw==
 
 capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #504
* #503
* #502
* #501

Summary:

Currently our CI is failing due to various issues related to the `verify-addons-folder.py` script.

This commit fixes an issue related to having an oudated list of browsers when running `yarn build` by updating `caniuse-lite` to 1.0.30001449.

Test plan:

## Before

Ran `./verify-addons-folder.py`, and failed with

```
[stderr]
Browserslist: caniuse-lite is outdated.
```

## After

Ran `./verify-addons-folder.py`, and now failed with
```
[eslint]
src/analytics/index.ts
  Line 10:8:  'serverAPI' is defined but never used                                   @typescript-eslint/no-unused-vars
  Line 20:3:  'data' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars
```