### PR TITLE
FreeBSD: Implement fstype

### DIFF
--- a/addons/isl-server/src/analytics/serverSideTracker.ts
+++ b/addons/isl-server/src/analytics/serverSideTracker.ts
@@ -24,7 +24,7 @@ class ServerSideContext {
   }
 }
 
-const noOp = () => {
+const noOp = (...args: any[]) => {
   /* In open source builds, analytics tracking is completely disabled/removed. */
 };
 

--- a/addons/isl/src/analytics/index.ts
+++ b/addons/isl/src/analytics/index.ts
@@ -7,7 +7,6 @@
 
 import type {TrackDataWithEventName} from 'isl-server/src/analytics/types';
 
-import serverAPI from '../ClientToServerAPI';
 import {Tracker} from 'isl-server/src/analytics/tracker';
 
 /** Client-side global analytics tracker */
@@ -16,7 +15,7 @@ export const tracker = new Tracker(sendDataToServer, {});
 /**
  * The client side sends data to the server-side to actually get tracked.
  */
-function sendDataToServer(data: TrackDataWithEventName) {
+function sendDataToServer(_data: TrackDataWithEventName) {
   // In open source, we don't even need to bother sending these messages to the server,
   // since we don't track anything anyway.
   // prettier-ignore

--- a/eden/scm/edenscm/fscap.py
+++ b/eden/scm/edenscm/fscap.py
@@ -51,6 +51,13 @@ _FS_CAP_TABLE = {
     },
     "HFS": {SYMLINK: True, HARDLINK: True, EXECBIT: True, ALWAYSCASESENSITIVE: False},
     "XFS": _ALL_CAPS,
+    "UFS": _ALL_CAPS,
+    "ZFS": {
+        SYMLINK: True,
+        HARDLINK: True,
+        EXECBIT: True,
+        ALWAYSCASESENSITIVE: False,
+    },
     "tmpfs": _ALL_CAPS,
 }
 

--- a/eden/scm/lib/vfs/src/vfs.rs
+++ b/eden/scm/lib/vfs/src/vfs.rs
@@ -460,6 +460,7 @@ fn case_sensitive(root: &Path, fs_type: &FsType) -> Result<bool> {
         FsType::BTRFS => return Ok(true),
         FsType::EXT4 => return Ok(true),
         FsType::XFS => return Ok(true),
+        FsType::UFS => return Ok(true),
         FsType::TMPFS => return Ok(true),
         _ => {}
     }


### PR DESCRIPTION
FreeBSD: Implement fstype

Summary:
Adds an fstype implementation for FreeBSD's UFS and ZFS filesystems.  It is
uncommon, but possible, to configure ZFS filesystems to run in case-insensitive
mode, so we don't make assumptions about ZFS's case sensitivity.

Test Plan:
% cd eden/scm/lib/fsinfo/src
% ln -s ../examples/fstype.rs main.rs
% cd ..
% cargo run $PATH_TO_DIR_ON_UFS_OR_ZFS
