### PR TITLE
FreeBSD: Implement fstype

### DIFF
--- a/eden/scm/edenscm/fscap.py
+++ b/eden/scm/edenscm/fscap.py
@@ -51,6 +51,13 @@ _FS_CAP_TABLE = {
     },
     "HFS": {SYMLINK: True, HARDLINK: True, EXECBIT: True, ALWAYSCASESENSITIVE: False},
     "XFS": _ALL_CAPS,
+    "UFS": _ALL_CAPS,
+    "ZFS": {
+        SYMLINK: True,
+        HARDLINK: True,
+        EXECBIT: True,
+        ALWAYSCASESENSITIVE: False,
+    },
     "tmpfs": _ALL_CAPS,
 }
 

--- a/eden/scm/lib/vfs/src/vfs.rs
+++ b/eden/scm/lib/vfs/src/vfs.rs
@@ -460,6 +460,7 @@ fn case_sensitive(root: &Path, fs_type: &FsType) -> Result<bool> {
         FsType::BTRFS => return Ok(true),
         FsType::EXT4 => return Ok(true),
         FsType::XFS => return Ok(true),
+        FsType::UFS => return Ok(true),
         FsType::TMPFS => return Ok(true),
         _ => {}
     }


### PR DESCRIPTION
FreeBSD: Implement fstype

Summary:
Adds an fstype implementation for FreeBSD's UFS and ZFS filesystems.  It is
uncommon but possible to configure ZFS filesystems to run in case-insensitive
mode, so we don't make assumptions about ZFS's case sensitivity.

Test Plan:
% cd eden/scm/lib/fsinfo/src
% ln -s ../examples/fstype.rs main.rs
% cd ..
% cargo run $PATH_TO_DIR_ON_UFS_OR_ZFS

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/514).
* #516
* #515
* __->__ #514
