### PR TITLE
FreeBSD: Make run-isl.sh portable

### DIFF
--- a/addons/isl/release/run-isl.template.sh
+++ b/addons/isl/release/run-isl.template.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+SCRIPT_DIR=$( cd -- "$( dirname -- "$0" )" &> /dev/null && pwd )
 # Facilitate redefining NODE in terms of SCRIPT_DIR via a regex.
 NODE=node
 

--- a/eden/scm/lib/fsinfo/src/lib.rs
+++ b/eden/scm/lib/fsinfo/src/lib.rs
@@ -18,6 +18,8 @@ use self::freebsd::fstype as fstype_imp;
 use self::linux::fstype as fstype_imp;
 #[cfg(target_os = "macos")]
 use self::macos::fstype as fstype_imp;
+#[cfg(target_os = "freebsd")]
+use self::freebsd::fstype as fstype_imp;
 #[cfg(windows)]
 use self::windows::fstype as fstype_imp;
 


### PR DESCRIPTION
FreeBSD: Make run-isl.sh portable

Summary:
Remove dependency on bash-specific environment variable so ISL can start on
systems without it, such as FreeBSD.  We don't need to use $BASH_SOURCE[0]
instead of $0 because we're running the script rather than sourcing it.

Test Plan:
% gmake install-oss
% sl web

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/515).
* #516
* __->__ #515
* #514
