### PR TITLE
[isl] add clickable context menu

### DIFF
--- a/addons/isl/src/CommitTreeList.css
+++ b/addons/isl/src/CommitTreeList.css
@@ -125,6 +125,12 @@
   opacity: 0.5;
 }
 
+.commit-preview-hidden-root > .commit-title,
+.commit-preview-hidden-descendant > .commit-title {
+  opacity: 0.5;
+  text-decoration: line-through;
+}
+
 .commit-inline-operation-progress {
   display: flex;
   flex-direction: row;

--- a/addons/isl/src/operations/HideOperation.ts
+++ b/addons/isl/src/operations/HideOperation.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type {ApplyPreviewsFuncType, PreviewContext} from '../previews';
+import type {Hash} from '../types';
+
+import {CommitPreview} from '../previews';
+import {SucceedableRevset} from '../types';
+import {Operation} from './Operation';
+
+export class HideOperation extends Operation {
+  constructor(private source: Hash) {
+    super();
+  }
+
+  static opName = 'Hide';
+
+  getArgs() {
+    return ['hide', '-r', SucceedableRevset(this.source)];
+  }
+
+  makePreviewApplier(_context: PreviewContext): ApplyPreviewsFuncType | undefined {
+    console.log('Creating applier');
+    const func: ApplyPreviewsFuncType = (tree, previewType, childPreviewType) => {
+      if (tree.info.hash === this.source) {
+        console.log(`Applier created to ${tree.info.hash}`);
+        return {
+          info: tree.info,
+          children: tree.children,
+          previewType: CommitPreview.HIDDEN_ROOT,
+          childPreviewType: CommitPreview.HIDDEN_DESCENDANT,
+        };
+      }
+      return {
+        info: tree.info,
+        children: tree.children,
+        previewType,
+        childPreviewType,
+      };
+    };
+    return func;
+  }
+
+  makeOptimisticApplier(context: PreviewContext): ApplyPreviewsFuncType | undefined {
+    const {treeMap} = context;
+    const originalSourceNode = treeMap.get(this.source);
+    if (originalSourceNode == null) {
+      return undefined;
+    }
+
+    const func: ApplyPreviewsFuncType = (tree, previewType, childPreviewType) => {
+      if (tree.info.hash === this.source) {
+        return {
+          info: null,
+        };
+      }
+      return {
+        info: tree.info,
+        children: tree.children,
+        previewType,
+        childPreviewType,
+      };
+    };
+    return func;
+  }
+}

--- a/addons/isl/src/previews.ts
+++ b/addons/isl/src/previews.ts
@@ -30,6 +30,8 @@ export enum CommitPreview {
   REBASE_OPTIMISTIC_DESCENDANT = 'rebase-optimistic-descendant',
   GOTO_DESTINATION = 'goto-destination',
   GOTO_PREVIOUS_LOCATION = 'goto-previous-location',
+  HIDDEN_ROOT = 'hidden-root',
+  HIDDEN_DESCENDANT = 'hidden-descendant',
 }
 
 /**


### PR DESCRIPTION
[isl] add clickable context menu

Summary:

Adds a hide button for doing `sl hide` from within ISL.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/517).
* __->__ #517
