### PR TITLE
[isl] ci: fix linter issues related to dismissBugDropdown

### DIFF
--- a/addons/isl/src/BugButton.tsx
+++ b/addons/isl/src/BugButton.tsx
@@ -52,7 +52,7 @@ function BugDropdown({dismiss}: {dismiss: () => void}) {
           <Icon icon="book" slot="start" />
           <T>View Documentation</T>
         </VSCodeButton>
-        <FileABug dismissBugDropdown={dismiss} />
+        <FileABug _dismissBugDropdown={dismiss} />
       </div>
       {/*
       // TODO: enable these debug actions
@@ -79,7 +79,7 @@ function BugDropdown({dismiss}: {dismiss: () => void}) {
   );
 }
 
-function FileABug({dismissBugDropdown}: {dismissBugDropdown: () => void}) {
+function FileABug({_dismissBugDropdown}: {_dismissBugDropdown: () => void}) {
   return (
     // prettier-ignore
     // @fb-only


### PR DESCRIPTION
[isl] ci: fix linter issues related to dismissBugDropdown

Summary:

Curretnly the OSS CI is broken due to `dismissBugDropdown` not being used in the `FileABug` function. This diff fixes this.

Test plan:

## Before

```
$ ./verify-addons-folder.py
verifying prettier
verifying shared/
verifying textmate/
verifying ISL
verifying reviewstack/
OK prettier in 10.56s
verifying reviewstack.dev/
OK shared/ in 16.47s
OK textmate/ in 17.37s
[stdout]
yarn run v1.22.19
$ node ./build.js
Creating an optimized production build...
Failed to compile.

[eslint]
src/BugButton.tsx
  Line 82:20:  'dismissBugDropdown' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars
```

## After

```
$ ./verify-addons-folder.py
verifying prettier
verifying shared/
verifying textmate/
verifying ISL
verifying reviewstack/
OK prettier in 10.18s
verifying reviewstack.dev/
OK shared/ in 15.94s
OK textmate/ in 16.91s
OK ISL in 55.81s
OK reviewstack.dev/ in 42.12s
OK reviewstack/ in 56.62s
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/518).
* __->__ #518
