### PR TITLE
feat(build): Use git to set sl version number

### DIFF
--- a/eden/scm/setup.py
+++ b/eden/scm/setup.py
@@ -382,6 +382,18 @@ def hgtemplate(template, cast=None):
         result = cast(result)
     return result
 
+def gitversion():
+    hgenv = localhgenv()
+    format = "%cd-h%h"
+    date_format = "format:%Y%m%d-%H%M%S"
+    try:
+        retcode, out, err = runcmd(["git", "-c", "core.abbrev=8", "show", "-s",
+                         f"--format={format}", f"--date={date_format}"], os.environ)
+        if retcode or err:
+            return None
+        return out.decode("utf-8")
+    except EnvironmentError as e:
+        return None
 
 def pickversion():
     # Respect SAPLING_VERSION set by GitHub workflows.
@@ -392,7 +404,7 @@ def pickversion():
     # This is duplicated a bit from build_rpm.py:auto_release_str()
     template = r'{sub("([:+-]|\d\d\d\d$)", "",date|isodatesec)} {node|short}'
     # if hg is not found, fallback to a fixed version
-    out = hgtemplate(template) or ""
+    out = hgtemplate(template) or gitversion() or ""
     # Some tools parse this number to figure out if they support this version of
     # Mercurial, so prepend with 4.4.2.
     # ex. 4.4.2_20180105_214829_58fda95a0202

--- a/eden/scm/setup.py
+++ b/eden/scm/setup.py
@@ -311,7 +311,7 @@ def filterhgerr(err):
     return b"\n".join(b"  " + e for e in err)
 
 
-def findhg():
+def findhg(vcname: str):
     """Try to figure out how we should invoke hg for examining the local
     repository contents.
 
@@ -328,7 +328,7 @@ def findhg():
     # and disable localization for the same reasons.
     hgenv["HGPLAIN"] = "1"
     hgenv["LANGUAGE"] = "C"
-    hgcmd = ["hg"]
+    hgcmd = [vcname]
     # Run a simple "hg log" command just to see if using hg from the user's
     # path works and can successfully interact with this repository.
     check_cmd = ["log", "-r.", "-Ttest"]
@@ -341,7 +341,7 @@ def findhg():
 
     # Fall back to trying the local hg installation.
     hgenv = localhgenv()
-    hgcmd = [sys.executable, "hg"]
+    hgcmd = [sys.executable, vcname]
     try:
         retcode, out, err = runcmd(hgcmd + check_cmd, hgenv)
     except EnvironmentError:
@@ -372,9 +372,7 @@ def localhgenv():
         env["SystemRoot"] = os.environ["SystemRoot"]
     return env
 
-
-hg = None if ossbuild else findhg()
-
+hg = findhg("hg") or findhg("sl")
 
 def hgtemplate(template, cast=None):
     if not hg:


### PR DESCRIPTION
feat(build): Use git to set sl version number

Summary: When building Sapling using `make oss`, the version number is only set
to the date and commit when in an sl or hg repo.  This commit adds the version
number when Sapling is cloned with git

Test plan:
$ git clone git@github.com:facebook/sapling.git
# apply this patch
$ cd sapling/eden/scm
$ make oss
$ ./sl --version

On my machine:
Sapling 4.4.2_20230204-131549-hf454128c

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/522).
*  __->__ #522
* #440
