### PR TITLE
docs(shelve): Fix typo

### DIFF
--- a/eden/scm/edenscm/ext/shelve.py
+++ b/eden/scm/edenscm/ext/shelve.py
@@ -1182,7 +1182,7 @@ def shelvecmd(ui, repo, *pats, **opts):
     the modifications to a bundle (a shelved change), and reverts the
     files to a clean state in the working copy.
 
-    To restore the changes to the working copy, using :prog:`unshelve`,
+    To restore the changes to the working copy, use :prog:`unshelve`
     regardless of your current commit.
 
     When no files are specified, :prog:`shelve` saves all not-clean


### PR DESCRIPTION
docs(shelve): Fix typo

Summary: I believe the proper grammar is `use sl shelve`.
Also, remove an unneeded comma

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/523).
* __->__ #523
