### PR TITLE
Handle a slash instead of a colon in an SSH URI

### DIFF
--- a/addons/isl-server/src/Repository.ts
+++ b/addons/isl-server/src/Repository.ts
@@ -877,6 +877,7 @@ function splitLine(line: string): Array<string> {
  * https://github.com/owner/repo.git
  * git@github.com:owner/repo.git
  * ssh:git@github.com:owner/repo.git
+ * ssh:git@github.com/owner/repo.git
  * git+ssh:git@github.com:owner/repo.git
  *
  * or similar urls with GitHub Enterprise hostnames:
@@ -886,7 +887,7 @@ export function extractRepoInfoFromUrl(
   url: string,
 ): {repo: string; owner: string; hostname: string} | null {
   const match =
-    /(?:https:\/\/(.*)\/|(?:git\+ssh:\/\/|ssh:\/\/)?git@(.*):)([^/]+)\/(.+?)(?:\.git)?$/.exec(url);
+    /(?:https:\/\/(.*)\/|(?:git\+ssh:\/\/|ssh:\/\/)?git@(.*)(?:\/|:))([^/]+)\/(.+?)(?:\.git)?$/.exec(url);
 
   if (match == null) {
     return null;

--- a/addons/isl-server/src/__tests__/Repository.test.ts
+++ b/addons/isl-server/src/__tests__/Repository.test.ts
@@ -437,6 +437,13 @@ describe('extractRepoInfoFromUrl', () => {
         hostname: 'github.com',
       });
     });
+    it('handles ssh with slash', () => {
+      expect(extractRepoInfoFromUrl('ssh://git@github.com/myUsername/myRepo.git')).toEqual({
+        owner: 'myUsername',
+        repo: 'myRepo',
+        hostname: 'github.com',
+      });
+    });
     it('handles git+ssh', () => {
       expect(extractRepoInfoFromUrl('git+ssh://git@github.com:myUsername/myRepo.git')).toEqual({
         owner: 'myUsername',


### PR DESCRIPTION
This fixes Sapling to support both `git@github.com:organization/repo.git` and `git@github.com/organization/repo.git`.

I am not super clear on how this happens but if I run

```
$ sl clone git@github.com:organization/repo.git
remote: Enumerating objects: 18254, done.
remote: Counting objects: 100% (1473/1473), done.
remote: Compressing objects: 100% (632/632), done.
remote: Total 18254 (delta 990), reused 1156 (delta 824), pack-reused 16781
Receiving objects: 100% (18254/18254), 441.77 MiB | 41.49 MiB/s, done.
Resolving deltas: 100% (10225/10225), done.
From ssh://github.com/organization/repo
 * [new ref]           e5e60e62758f90fe179ce9a6ed851c2cdbd50993 -> remote/main
3527 files updated, 0 files merged, 0 files removed, 0 files unresolved
```

I end up with a `.sl/config` that looks like
```
%include builtin:git.rc

[paths]
default = ssh://git@github.com/organization/repo.git
```

(note that `github.com:organization` has become `github.com/organization`.)