### PR TITLE
[sapling] Remove Cargo.lock on `make clean`

### DIFF
--- a/eden/scm/Makefile
+++ b/eden/scm/Makefile
@@ -143,6 +143,7 @@ cleanbutpackages:
 	if test -d .hg; then rm -f edenscm/__version__.py; fi
 	rm -rf build/*
 	rm -rf build edenscm/locale
+	rm -f Cargo.lock
 ifeq ($(OS),Windows_NT)
 	$(RM) -r hg-python $(HGNAME).exe python27.dll
 else


### PR DESCRIPTION
[sapling] Remove Cargo.lock on `make clean`

Summary:
The help text for `make clean` says:

> remove files created by other targets
> (except installed files or dist source tarball)

So I'd expect it to remove any non-installed built state like Cargo.toml.

Concretely, I was surprised by this behavior when the build failed after
pulling in updates, even after running `gmake clean`.  My Cargo.lock from a
previous build had pinned the watchman_client crate to an old version, but the
updated workingcopy crate relied on the addition of `BytesNameField` to
watchman_client@main.

I think it would be better if autocargo generated a Cargo.lock for us from the
Buck versions of dependencies, but as long as it's being generated as a build
artifact it should be removed by `make clean`.

Test Plan:
```
% cd eden/scm
% gmake oss
% ls Cargo.lock
Cargo.lock
% gmake clean
% ls Cargo.lock
% ls: Cargo.lock: No such file or directory
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/534).
* __->__ #534
