### PR TITLE
[sl] ci: bump dependencies (python 3.11 to 3.11.2, openssl 1.1.1.s to 1.1.1.t)

### DIFF
--- a/.github/workflows/sapling-cli-homebrew-macos-arm64-release.yml
+++ b/.github/workflows/sapling-cli-homebrew-macos-arm64-release.yml
@@ -19,9 +19,9 @@ jobs:
     - name: Prepare build environment
       run: 'eden/scm/packaging/mac/prepare_environment.py \
 
-        -s c11b17c8b78efa46dac2d213cd7a7b3fff75f6f5e6d2ef2248345cd4a900b1c6 -f openssl@1.1 \
+        -s 524ec08838d2826793e26b2ed084efdefec931e1aaa6dea01455aa77409b86c8 -f openssl@1.1 \
 
-        -s 54c7eb00a23451b956abe4797a759e29824d33953fb57715bde6b9abb2500555 -f python@3.11 \
+        -s cde36624e734632be009e3aa28d9bd07f4fa681c7caa270e7efb416b287c1e72 -f python@3.11 \
 
         -t aarch64-apple-darwin \
 

--- a/.github/workflows/sapling-cli-homebrew-macos-x86-release.yml
+++ b/.github/workflows/sapling-cli-homebrew-macos-x86-release.yml
@@ -19,9 +19,9 @@ jobs:
     - name: Prepare build environment
       run: 'eden/scm/packaging/mac/prepare_environment.py \
 
-        -s d915175bedb146e38d7a2c95e86888a60a5058a5cd21f835813d43d1372a29d9 -f openssl@1.1 \
+        -s 43c00851b8447bd5d1fba3e8140b74ca3d4a5b19343e64ec50bafae376f95454 -f openssl@1.1 \
 
-        -s b668909b679a54930bd35a9a2738a27ef1d545db8a4d889b8d9a475e85519116 -f python@3.11 \
+        -s 1760c64881403847ad39e6df648ff0845fab321b638715734fe0264dfe7bcbda -f python@3.11 \
 
         -t x86_64-apple-darwin \
 

--- a/ci/gen_workflows.py
+++ b/ci/gen_workflows.py
@@ -42,13 +42,13 @@ UBUNTU_DEPS = [
 MACOS_RELEASES = {
     "x86": {
         "target": "x86_64-apple-darwin",
-        "python_bottle_hash": "b668909b679a54930bd35a9a2738a27ef1d545db8a4d889b8d9a475e85519116",
-        "openssl_bottle_hash": "d915175bedb146e38d7a2c95e86888a60a5058a5cd21f835813d43d1372a29d9",
+        "python_bottle_hash": "1760c64881403847ad39e6df648ff0845fab321b638715734fe0264dfe7bcbda",
+        "openssl_bottle_hash": "43c00851b8447bd5d1fba3e8140b74ca3d4a5b19343e64ec50bafae376f95454",
     },
     "arm64": {
         "target": "aarch64-apple-darwin",
-        "python_bottle_hash": "54c7eb00a23451b956abe4797a759e29824d33953fb57715bde6b9abb2500555",
-        "openssl_bottle_hash": "c11b17c8b78efa46dac2d213cd7a7b3fff75f6f5e6d2ef2248345cd4a900b1c6",
+        "python_bottle_hash": "cde36624e734632be009e3aa28d9bd07f4fa681c7caa270e7efb416b287c1e72",
+        "openssl_bottle_hash": "524ec08838d2826793e26b2ed084efdefec931e1aaa6dea01455aa77409b86c8",
     },
 }
 

--- a/eden/scm/packaging/mac/prepare_environment.py
+++ b/eden/scm/packaging/mac/prepare_environment.py
@@ -88,7 +88,7 @@ def get_bottle(bottle_name: str, bottle_hash: str, tmpdir: str):
     The hash corresponds to the hash of some bottle (which can be specified in
     the bottle section of homebrew formulas).
 
-    https://github.com/Homebrew/homebrew-core/blob/75bac0ef0c7a68d3607fc5d7e94ef417d93df138/Formula/python%403.11.rb#L14
+    https://github.com/Homebrew/homebrew-core/blob/38fbd0c91238c4c1ab88936cf4c3205b3c400f90/Formula/python@3.11.rb#L16
     is an example of this.
     """
     auth_url = f"https://ghcr.io/v2/homebrew/core/{bottle_name.replace('@', '/')}/blobs/sha256:{bottle_hash}"
@@ -128,7 +128,7 @@ def set_up_downloaded_crates(tmpdir):
     print(f"LOCATION IS {brew_location}")
     dylib_location = os.path.join(
         brew_location,
-        "python@3.11/3.11.1/Frameworks/Python.framework/Versions/3.11/lib/libpython3.11.dylib",
+        "python@3.11/3.11.2_1/Frameworks/Python.framework/Versions/3.11/lib/libpython3.11.dylib",
     )
     run_cmd(
         [
@@ -137,14 +137,14 @@ def set_up_downloaded_crates(tmpdir):
             os.path.join(tmpdir, "python@3.11.bottle.tar.gz"),
             "-C",
             tmpdir,
-            "python@3.11/3.11.1/Frameworks/Python.framework/Versions/3.11/Python",
+            "python@3.11/3.11.2_1/Frameworks/Python.framework/Versions/3.11/Python",
         ]
     )
     os.remove(dylib_location)
     shutil.copy(
         os.path.join(
             tmpdir,
-            "python@3.11/3.11.1/Frameworks/Python.framework/Versions/3.11/Python",
+            "python@3.11/3.11.2_1/Frameworks/Python.framework/Versions/3.11/Python",
         ),
         dylib_location,
     )


### PR DESCRIPTION
[sl] ci: bump python3.11 to 3.11.2

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/540).
* __->__ #540
