### PR TITLE
🐛(chg): don't crash when user has more than 16 groups on macOS

### DIFF
--- a/eden/scm/setup.py
+++ b/eden/scm/setup.py
@@ -1669,6 +1669,12 @@ if not iswindows:
                 "depends": [versionhashpath],
                 "include_dirs": ["contrib/chg"] + include_dirs,
                 "extra_args": filter(None, cflags + chgcflags + [STDC99, WALL, PIC]),
+                # chg uses libc::unistd/getgroups() to check that chg and the
+                # sl cli have the same permissions (see D43676809).
+                # However, on macOS, getgroups() is limited to NGROUPS_MAX (16) groups by default.
+                # We can work around this by defining _DARWIN_UNLIMITED_GETGROUPS
+                # see https://opensource.apple.com/source/xnu/xnu-3247.1.106/bsd/man/man2/getgroups.2.auto.html
+                "macros": [("_DARWIN_UNLIMITED_GETGROUPS", "1")]
             },
         )
     )


### PR DESCRIPTION
🐛(chg): don't crash when user has more than 16 groups on macOS

Summary:
D43676809 (OSS: 49ee17f2bfad) introduced a check for whether the chg server and
sl process have different permissions.  We run `getgroups` in two different
places:
1. using `os.getgroups` in sl client in Python
2. using libc's `unistd/getgroups` in chg server in C

Essentially the way this works is we call `os.getgroups` in the client (Python)
and `unistd/getgroups` on the chg server (C).  Then, the server compares the
results.  If they're the same, then both processes have the same permissions,
otherwise they might be different.

However, `getgroups` on macOS has a key limitation that it will only return a
max of `NGROUPS_MAX` groups (16 groups on my machine, defined in
`sys/param.h`).  You can remove this limit by defining
`_DARWIN_UNLIMITED_GETGROUPS` or `_DARWIN_C_SOURCE`[^1].

`os.getgroups` in Python is compiled with `_DARWIN_C_SOURCE`[^2] but chg does
not, meaning that the result of `getgroups` is different in our Python and C
code.

This commit defines `_DARWIN_UNLIMITED_GETGROUPS` for chg so `getgroups` will
have consistent behavior. (the alternative is patching CPython to unset
`_DARWIN_C_SOURCE` which is worse)

Special thanks to @strager for helping me debug this 👍🏻

Test plan:
1. have user with <=16 groups
2. run `sl --version`
3. confirm it works

4. have user with >16 groups
5. run `sl --version`
6. notice sl failing with error "chg: abort: too many redirections."

7. apply this patch
8. repeat steps 4-5
9. confirm it works

[^1]: https://opensource.apple.com/source/xnu/xnu-3247.1.106/bsd/man/man2/getgroups.2.auto.html
[^2]: https://github.com/python/cpython/blob/28d369e070652e8f2274101d72131e3140dfadf7/configure.ac#L267


Co-authored-by: strager <Strager.nds@gmail.com>
