### PR TITLE
chore: ignore build output for make oss

### DIFF
--- a/addons/.gitignore
+++ b/addons/.gitignore
@@ -2,3 +2,5 @@ node_modules
 isl-server/coverage
 shared/coverage/
 vscode-build/
+.yarn
+.yarnrc.yml


### PR DESCRIPTION
chore: ignore build output for make oss
