### PR TITLE
fsmonitor: fix empty path in dirfilter

### DIFF
--- a/eden/scm/edenscm/ext/fsmonitor/__init__.py
+++ b/eden/scm/edenscm/ext/fsmonitor/__init__.py
@@ -446,6 +446,8 @@ def _innerwalk(self, match, event, span):
         ignorevisitdir = self.dirstate._ignore.visitdir
 
         def dirfilter(path):
+            if path == "":
+                return False
             result = ignorevisitdir(path.rstrip("/"))
             return result == "all"
 

--- a/eden/scm/tests/test-gitignore.t
+++ b/eden/scm/tests/test-gitignore.t
@@ -70,3 +70,19 @@
   ? exp/.gitignore
   ? exp/i.tmp
   ? x.pyc
+
+# Test exclusion patterns
+
+  $ cat > .gitignore << 'EOF'
+  > /*
+  > !/build
+  > EOF
+
+  $ rm -rf build/
+  $ mkdir build
+  $ touch build/libfoo.so t.tmp Makefile
+
+  $ hg status
+  ? build/libfoo.so
+  $ hg status
+  ? build/libfoo.so

--- a/eden/scm/tests/test-status-root-ignored-py.t
+++ b/eden/scm/tests/test-status-root-ignored-py.t
@@ -1,0 +1,16 @@
+#debugruntest-compatible
+#require fsmonitor
+
+  $ configure modernclient
+  $ setconfig status.use-rust=False workingcopy.ruststatus=False
+  $ newrepo
+
+Ensure that, when files in the root are ignored and there is an exclusion, that hg status returns the correct value
+  $ echo -e "/*\n!/foobar" > .gitignore
+  $ hg status
+  $ mkdir foobar
+  $ touch root-file foobar/foo # adds files to root and to foobar
+  $ hg status
+  ? foobar/foo
+  $ hg status # run it a second time to ensure that we didn't accidentally exclude the file
+  ? foobar/foo


### PR DESCRIPTION
## Summary

Fixes the bug discussed in Discord here: https://discord.com/channels/1042527964224557107/1042527965256364157/1095764831480590467

Running the ignore matcher on an empty path produces incorrect results. In the rust implementation, this isn't an issue, because there are directory matchers that run on the directory result. In the Python treestate bindings, we don't have that functionality, so it returns an empty string.

This makes this logic match the code in `dirstate.py` ([line ~925](https://github.com/facebook/sapling/blob/main/eden/scm/edenscm/dirstate.py#L925-L926)) where we check for path being an empty string.

This fixes `sl status` (and related functionality) when fsmonitor is enabled and there's a complex gitignore file that ignores files in the root directory.

## Test Plan

Added Mercurial integration test and manually tested locally