### PR TITLE
Update Repository.ts

### DIFF
--- a/addons/isl-server/src/Repository.ts
+++ b/addons/isl-server/src/Repository.ts
@@ -889,6 +889,7 @@ function splitLine(line: string): Array<string> {
  * in various formats:
  * https://github.com/owner/repo
  * https://github.com/owner/repo.git
+ * github.com/owner/repo.git
  * git@github.com:owner/repo.git
  * ssh:git@github.com:owner/repo.git
  * ssh://git@github.com/owner/repo.git
@@ -901,7 +902,7 @@ export function extractRepoInfoFromUrl(
   url: string,
 ): {repo: string; owner: string; hostname: string} | null {
   const match =
-    /(?:https:\/\/(.*)\/|(?:git\+ssh:\/\/|ssh:\/\/)?git@([^:/]*)[:/])([^/]+)\/(.+?)(?:\.git)?$/.exec(
+    /(?:https:\/\/(.*)\/|(?:git\+ssh:\/\/|ssh:\/\/)?(?:git@)?([^:/]*)[:/])([^/]+)\/(.+?)(?:\.git)?$/.exec(
       url,
     );
 


### PR DESCRIPTION
Github also allows repos of the form `github.com:owner/repo.git`

This updates the regex to support those.