### PR TITLE
[sl] bump macOS python CI to 3.11.3

### DIFF
--- a/.github/workflows/sapling-cli-homebrew-macos-arm64-release.yml
+++ b/.github/workflows/sapling-cli-homebrew-macos-arm64-release.yml
@@ -1,12 +1,10 @@
 name: Release - Homebrew macOS-arm64
-on:
+'on':
   workflow_dispatch: null
   push:
     tags:
     - v*
     - test-release-*
-env:
-  HOMEBREW_FAIL_LOG_LINES: 50000
 jobs:
   build:
     runs-on: macos-12
@@ -23,7 +21,7 @@ jobs:
 
         -s c11b17c8b78efa46dac2d213cd7a7b3fff75f6f5e6d2ef2248345cd4a900b1c6 -f openssl@1.1 \
 
-        -s cde36624e734632be009e3aa28d9bd07f4fa681c7caa270e7efb416b287c1e72 -f python@3.11 \
+        -s 270d1f7c56978757922b246dfd8bccead979c3d30a8e95d77a7b7b644050e6cd -f python@3.11 \
 
         -t aarch64-apple-darwin \
 

--- a/.github/workflows/sapling-cli-homebrew-macos-x86-release.yml
+++ b/.github/workflows/sapling-cli-homebrew-macos-x86-release.yml
@@ -1,12 +1,10 @@
 name: Release - Homebrew macOS-x86
-on:
+'on':
   workflow_dispatch: null
   push:
     tags:
     - v*
     - test-release-*
-env:
-  HOMEBREW_FAIL_LOG_LINES: 50000
 jobs:
   build:
     runs-on: macos-12
@@ -23,7 +21,7 @@ jobs:
 
         -s d915175bedb146e38d7a2c95e86888a60a5058a5cd21f835813d43d1372a29d9 -f openssl@1.1 \
 
-        -s 1760c64881403847ad39e6df648ff0845fab321b638715734fe0264dfe7bcbda -f python@3.11 \
+        -s e86210ffc0380bf4ccff3e3081e4dbd9c9ee3c2f72574d41498a817050f1ef86 -f python@3.11 \
 
         -t x86_64-apple-darwin \
 

--- a/.github/workflows/sapling-cli-ubuntu-20.04-ci.yml
+++ b/.github/workflows/sapling-cli-ubuntu-20.04-ci.yml
@@ -1,5 +1,5 @@
 name: CI - Ubuntu 20.04
-on: workflow_dispatch
+'on': workflow_dispatch
 jobs:
   build-deb:
     runs-on: ubuntu-latest

--- a/.github/workflows/sapling-cli-ubuntu-20.04-image.yml
+++ b/.github/workflows/sapling-cli-ubuntu-20.04-image.yml
@@ -1,5 +1,5 @@
 name: Docker Image - ubuntu:20.04
-on:
+'on':
   workflow_dispatch: null
   schedule:
   - cron: 0 1 * * mon

--- a/.github/workflows/sapling-cli-ubuntu-20.04-release.yml
+++ b/.github/workflows/sapling-cli-ubuntu-20.04-release.yml
@@ -1,5 +1,5 @@
 name: Release - Ubuntu 20.04
-on:
+'on':
   workflow_dispatch: null
   push:
     tags:

--- a/.github/workflows/sapling-cli-ubuntu-22.04-ci.yml
+++ b/.github/workflows/sapling-cli-ubuntu-22.04-ci.yml
@@ -1,5 +1,5 @@
 name: CI - Ubuntu 22.04
-on: workflow_dispatch
+'on': workflow_dispatch
 jobs:
   build-deb:
     runs-on: ubuntu-latest

--- a/.github/workflows/sapling-cli-ubuntu-22.04-image.yml
+++ b/.github/workflows/sapling-cli-ubuntu-22.04-image.yml
@@ -1,5 +1,5 @@
 name: Docker Image - ubuntu:22.04
-on:
+'on':
   workflow_dispatch: null
   schedule:
   - cron: 0 1 * * mon

--- a/.github/workflows/sapling-cli-ubuntu-22.04-release.yml
+++ b/.github/workflows/sapling-cli-ubuntu-22.04-release.yml
@@ -1,5 +1,5 @@
 name: Release - Ubuntu 22.04
-on:
+'on':
   workflow_dispatch: null
   push:
     tags:

--- a/.github/workflows/sapling-cli-windows-amd64-release.yml
+++ b/.github/workflows/sapling-cli-windows-amd64-release.yml
@@ -1,5 +1,5 @@
 name: Release - Windows amd64
-on:
+'on':
   workflow_dispatch: null
   push:
     tags:

--- a/ci/gen_workflows.py
+++ b/ci/gen_workflows.py
@@ -42,12 +42,12 @@ UBUNTU_DEPS = [
 MACOS_RELEASES = {
     "x86": {
         "target": "x86_64-apple-darwin",
-        "python_bottle_hash": "1760c64881403847ad39e6df648ff0845fab321b638715734fe0264dfe7bcbda",
+        "python_bottle_hash": "e86210ffc0380bf4ccff3e3081e4dbd9c9ee3c2f72574d41498a817050f1ef86",
         "openssl_bottle_hash": "d915175bedb146e38d7a2c95e86888a60a5058a5cd21f835813d43d1372a29d9",
     },
     "arm64": {
         "target": "aarch64-apple-darwin",
-        "python_bottle_hash": "cde36624e734632be009e3aa28d9bd07f4fa681c7caa270e7efb416b287c1e72",
+        "python_bottle_hash": "270d1f7c56978757922b246dfd8bccead979c3d30a8e95d77a7b7b644050e6cd",
         "openssl_bottle_hash": "c11b17c8b78efa46dac2d213cd7a7b3fff75f6f5e6d2ef2248345cd4a900b1c6",
     },
 }

--- a/eden/scm/packaging/mac/prepare_environment.py
+++ b/eden/scm/packaging/mac/prepare_environment.py
@@ -128,7 +128,7 @@ def set_up_downloaded_crates(tmpdir):
     print(f"LOCATION IS {brew_location}")
     dylib_location = os.path.join(
         brew_location,
-        "python@3.11/3.11.2_1/Frameworks/Python.framework/Versions/3.11/lib/libpython3.11.dylib",
+        "python@3.11/3.11.3/Frameworks/Python.framework/Versions/3.11/lib/libpython3.11.dylib",
     )
     run_cmd(
         [
@@ -137,14 +137,14 @@ def set_up_downloaded_crates(tmpdir):
             os.path.join(tmpdir, "python@3.11.bottle.tar.gz"),
             "-C",
             tmpdir,
-            "python@3.11/3.11.2_1/Frameworks/Python.framework/Versions/3.11/Python",
+            "python@3.11/3.11.3/Frameworks/Python.framework/Versions/3.11/Python",
         ]
     )
     os.remove(dylib_location)
     shutil.copy(
         os.path.join(
             tmpdir,
-            "python@3.11/3.11.2_1/Frameworks/Python.framework/Versions/3.11/Python",
+            "python@3.11/3.11.3/Frameworks/Python.framework/Versions/3.11/Python",
         ),
         dylib_location,
     )


### PR DESCRIPTION
[sl] bump macOS python CI to 3.11.3

Summary:

We still depend on pointing to the specific Python combination that GitHub CI and Homebrew have, which currently is 3.11.3.

Hashes were taken from https://github.com/Homebrew/homebrew-core/blob/d39875e2128e83333aa12728b715fd932c52a1f4/Formula/python@3.11.rb

Test plan:

CI

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/605).
* #606
* __->__ #605