### PR TITLE
✨(clone): set publicheads to remote HEAD when cloning

### DIFF
--- a/eden/scm/edenscm/git.py
+++ b/eden/scm/edenscm/git.py
@@ -153,6 +153,12 @@ def clone(ui, url, destpath=None, update=True, pullnames=None):
                     # If `git ls-remote --symref <url> HEAD` failed to yield a name,
                     # fall back to the using the names in the config.
                     pullnames = bookmod.selectivepullbookmarknames(repo)
+                default_publicheads = repo.ui.configlist('remotenames', 'publicheads') # ['remote/master', 'remote/main']
+                remote_publicheads = ['remote/' + path for path in pullnames]
+                all_publicheads = ','.join(sorted(set(default_publicheads + remote_publicheads)))
+
+                repo.update_and_persist_config('remotenames', 'publicheads',
+                                               all_publicheads)
 
                 # Make sure we pull "update". If it looks like a hash, add to
                 # "nodes", otherwise to "names".

--- a/eden/scm/edenscm/localrepo.py
+++ b/eden/scm/edenscm/localrepo.py
@@ -61,6 +61,7 @@ from . import (
     progress,
     pushkey,
     pycompat,
+    rcutil,
     repository,
     revset,
     revsetlang,
@@ -3195,6 +3196,12 @@ class localrepository(object):
 
     def metalog(self):
         return self.svfs.metalog
+
+    def update_and_persist_config(self, section, name, value):
+        """edit config and save it to the repo's config file"""
+        configfilename = self.ui.identity.configrepofile() # config
+        configfilepath = self.localvfs.join(configfilename) # <reporoot>/.hg/config
+        rcutil.editconfig(self.ui, configfilepath, section, name, value)
 
 
 # used to avoid circular references so destructors work

--- a/eden/scm/tests/test-git-clone-sets-publicheads.t
+++ b/eden/scm/tests/test-git-clone-sets-publicheads.t
@@ -1,0 +1,30 @@
+#debugruntest-compatible
+#chg-compatible
+#require git no-windows
+
+  $ . $TESTDIR/git.sh
+
+Prepare a git repo:
+
+  $ git init -q gitrepo
+  $ cd gitrepo
+  $ git config core.autocrlf false
+  $ echo 1 > alpha
+  $ git add alpha
+  $ git commit -q -malpha
+
+  $ git switch -c foo
+  Switched to a new branch 'foo'
+
+  $ echo 2 > beta
+  $ git add beta
+  $ git commit -q -mbeta
+
+Test git clone sets publicheads
+  $ hg clone --git "$TESTTMP/gitrepo" cloned
+  From $TESTTMP/gitrepo
+   * [new ref]         3f5848713286c67b8a71a450e98c7fa66787bde2 -> remote/foo
+  2 files updated, 0 files merged, 0 files removed, 0 files unresolved
+  $ cd cloned
+  $ hg config remotenames.publicheads
+  remote/foo,remote/main,remote/master


### PR DESCRIPTION
✨(clone): set publicheads to remote HEAD when cloning

Summary:
c8b66c68991066b3e added support for cloning the remote git repo's HEAD (in this
case `develop`), instead of main/master by default.

However, this doesn't mark `remote/develop` and its ancestors as public
commits.

This commit will also set remote git repo's HEAD as a public commit

Closes #600

Pull Request resolved: #607

Test Plan:
- Added test `test-git-clone-sets-publicheads.t`
