### PR TITLE
Update website release data

### DIFF
--- a/website/src/rawReleaseData.ts
+++ b/website/src/rawReleaseData.ts
@@ -8,77 +8,77 @@
  */
 
 /*
- * @generated SignedSource<<73354cc731f2559ab95c001e563b13fb>>
+ * @generated SignedSource<<2645840e2d4643d954fdc8c61c4f5c49>>
  * Run `./scripts/gen_release_data.py` to regenerate.
  */
 
 export const latestReleaseAssets = {
   "assets": [
     {
-      "apiUrl": "https://api.github.com/repos/facebook/sapling/releases/assets/97517464",
+      "apiUrl": "https://api.github.com/repos/facebook/sapling/releases/assets/105485791",
       "contentType": "application/x-gtar",
-      "createdAt": "2023-02-28T23:16:55Z",
+      "createdAt": "2023-04-26T22:52:34Z",
       "downloadCount": 3,
-      "id": "RA_kwDOA3c_bc4Fz_-Y",
+      "id": "RA_kwDOA3c_bc4GSZXf",
       "label": "",
-      "name": "sapling_0.2.20230228-144002-h9440b05e.arm64_monterey.bottle.tar.gz",
-      "size": 25041030,
+      "name": "sapling_0.2.20230426-145232+7ea1f245.arm64_monterey.bottle.tar.gz",
+      "size": 25749363,
       "state": "uploaded",
-      "updatedAt": "2023-02-28T23:16:56Z",
-      "url": "https://github.com/facebook/sapling/releases/download/0.2.20230228-144002-h9440b05e/sapling_0.2.20230228-144002-h9440b05e.arm64_monterey.bottle.tar.gz"
+      "updatedAt": "2023-04-26T22:52:36Z",
+      "url": "https://github.com/facebook/sapling/releases/download/0.2.20230426-145232%2B7ea1f245/sapling_0.2.20230426-145232%2B7ea1f245.arm64_monterey.bottle.tar.gz"
     },
     {
-      "apiUrl": "https://api.github.com/repos/facebook/sapling/releases/assets/97517739",
+      "apiUrl": "https://api.github.com/repos/facebook/sapling/releases/assets/105486045",
       "contentType": "application/x-gtar",
-      "createdAt": "2023-02-28T23:19:43Z",
-      "downloadCount": 2,
-      "id": "RA_kwDOA3c_bc4F0ACr",
+      "createdAt": "2023-04-26T22:54:19Z",
+      "downloadCount": 1,
+      "id": "RA_kwDOA3c_bc4GSZbd",
       "label": "",
-      "name": "sapling_0.2.20230228-144002-h9440b05e.monterey.bottle.tar.gz",
-      "size": 25598450,
+      "name": "sapling_0.2.20230426-145232+7ea1f245.monterey.bottle.tar.gz",
+      "size": 26363335,
       "state": "uploaded",
-      "updatedAt": "2023-02-28T23:19:44Z",
-      "url": "https://github.com/facebook/sapling/releases/download/0.2.20230228-144002-h9440b05e/sapling_0.2.20230228-144002-h9440b05e.monterey.bottle.tar.gz"
+      "updatedAt": "2023-04-26T22:54:19Z",
+      "url": "https://github.com/facebook/sapling/releases/download/0.2.20230426-145232%2B7ea1f245/sapling_0.2.20230426-145232%2B7ea1f245.monterey.bottle.tar.gz"
     },
     {
-      "apiUrl": "https://api.github.com/repos/facebook/sapling/releases/assets/97516649",
+      "apiUrl": "https://api.github.com/repos/facebook/sapling/releases/assets/105484758",
       "contentType": "application/x-debian-package",
-      "createdAt": "2023-02-28T23:07:03Z",
+      "createdAt": "2023-04-26T22:39:11Z",
       "downloadCount": 0,
-      "id": "RA_kwDOA3c_bc4Fz_xp",
+      "id": "RA_kwDOA3c_bc4GSZHW",
       "label": "",
-      "name": "sapling_0.2.20230228-144002-h9440b05e_amd64.Ubuntu20.04.deb",
-      "size": 18921436,
+      "name": "sapling_0.2.20230426-145232+7ea1f245_amd64.Ubuntu20.04.deb",
+      "size": 19511716,
       "state": "uploaded",
-      "updatedAt": "2023-02-28T23:07:05Z",
-      "url": "https://github.com/facebook/sapling/releases/download/0.2.20230228-144002-h9440b05e/sapling_0.2.20230228-144002-h9440b05e_amd64.Ubuntu20.04.deb"
+      "updatedAt": "2023-04-26T22:39:12Z",
+      "url": "https://github.com/facebook/sapling/releases/download/0.2.20230426-145232%2B7ea1f245/sapling_0.2.20230426-145232%2B7ea1f245_amd64.Ubuntu20.04.deb"
     },
     {
-      "apiUrl": "https://api.github.com/repos/facebook/sapling/releases/assets/97516660",
+      "apiUrl": "https://api.github.com/repos/facebook/sapling/releases/assets/105484814",
       "contentType": "application/x-debian-package",
-      "createdAt": "2023-02-28T23:07:13Z",
-      "downloadCount": 2,
-      "id": "RA_kwDOA3c_bc4Fz_x0",
+      "createdAt": "2023-04-26T22:40:10Z",
+      "downloadCount": 39,
+      "id": "RA_kwDOA3c_bc4GSZIO",
       "label": "",
-      "name": "sapling_0.2.20230228-144002-h9440b05e_amd64.Ubuntu22.04.deb",
-      "size": 20370688,
+      "name": "sapling_0.2.20230426-145232+7ea1f245_amd64.Ubuntu22.04.deb",
+      "size": 20887380,
       "state": "uploaded",
-      "updatedAt": "2023-02-28T23:07:19Z",
-      "url": "https://github.com/facebook/sapling/releases/download/0.2.20230228-144002-h9440b05e/sapling_0.2.20230228-144002-h9440b05e_amd64.Ubuntu22.04.deb"
+      "updatedAt": "2023-04-26T22:40:11Z",
+      "url": "https://github.com/facebook/sapling/releases/download/0.2.20230426-145232%2B7ea1f245/sapling_0.2.20230426-145232%2B7ea1f245_amd64.Ubuntu22.04.deb"
     },
     {
-      "apiUrl": "https://api.github.com/repos/facebook/sapling/releases/assets/97518312",
+      "apiUrl": "https://api.github.com/repos/facebook/sapling/releases/assets/105486633",
       "contentType": "application/zip",
-      "createdAt": "2023-02-28T23:29:40Z",
-      "downloadCount": 2,
-      "id": "RA_kwDOA3c_bc4F0ALo",
+      "createdAt": "2023-04-26T23:02:59Z",
+      "downloadCount": 3,
+      "id": "RA_kwDOA3c_bc4GSZkp",
       "label": "",
-      "name": "sapling_windows_0.2.20230228-144002-h9440b05e_amd64.zip",
-      "size": 44637621,
+      "name": "sapling_windows_0.2.20230426-145232+7ea1f245_amd64.zip",
+      "size": 46837919,
       "state": "uploaded",
-      "updatedAt": "2023-02-28T23:29:43Z",
-      "url": "https://github.com/facebook/sapling/releases/download/0.2.20230228-144002-h9440b05e/sapling_windows_0.2.20230228-144002-h9440b05e_amd64.zip"
+      "updatedAt": "2023-04-26T23:03:01Z",
+      "url": "https://github.com/facebook/sapling/releases/download/0.2.20230426-145232%2B7ea1f245/sapling_windows_0.2.20230426-145232%2B7ea1f245_amd64.zip"
     }
   ],
-  "name": "0.2.20230228-144002-h9440b05e"
+  "name": "0.2.20230426-145232+7ea1f245"
 };


### PR DESCRIPTION
Update website release data

Updated release information by running `./scripts/gen_release_data.py` for the newest release 0.2.20230426-145232+7ea1f245

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/619).
* __->__ #619
