### PR TITLE
Add better loading state for pull request viewing

### DIFF
--- a/addons/reviewstack/src/DiffView.tsx
+++ b/addons/reviewstack/src/DiffView.tsx
@@ -26,6 +26,7 @@ export default function DiffView({diff, isPullRequest}: {diff: Diff; isPullReque
         </Box>
       );
     });
+    // TODO: Add SuspenseList here so files can load in individually
     return <div>{children}</div>;
   } else {
     return <div>commit not found or fetched from GitHub URL above</div>;
@@ -76,6 +77,8 @@ function AddedFile({
       }
     }
     case 'loading': {
+      // Trigger suspense while loading
+      blobLoadable.getValue();
       return <div>{`loading patch for ${path}`}</div>;
     }
     case 'hasError': {
@@ -97,6 +100,8 @@ function RemovedFile({basePath, name, oid}: {basePath: string; name: string; oid
       );
     }
     case 'loading': {
+      // Trigger suspense while loading
+      blobLoadable.getValue();
       return <div>{`loading patch for ${path}`}</div>;
     }
     case 'hasError': {
@@ -142,6 +147,8 @@ function ModifiedFile({modify, isPullRequest}: {modify: ModifyChange; isPullRequ
       }
     }
     case 'loading': {
+      // Trigger suspense while loading
+      fileModLoadable.getValue();
       return <div>{`loading patch for ${path}`}</div>;
     }
     case 'hasError': {

--- a/addons/reviewstack/src/PullRequest.tsx
+++ b/addons/reviewstack/src/PullRequest.tsx
@@ -141,10 +141,15 @@ function PullRequestDetails() {
 
 function PullRequestVersionDiff() {
   const loadable = useRecoilValueLoadable(gitHubPullRequestVersionDiff);
-  const diff = loadable.valueMaybe();
+  const diff = loadable.getValue();
 
   if (diff != null) {
-    return <DiffView diff={diff.diff} isPullRequest={true} />;
+    return (
+      <Suspense
+        fallback={<CenteredSpinner message={'Loading ' + diff.diff.length + ' changes...'} />}>
+        <DiffView diff={diff.diff} isPullRequest={true} />
+      </Suspense>
+    );
   } else {
     return null;
   }

--- a/addons/reviewstack/src/SplitDiffView.tsx
+++ b/addons/reviewstack/src/SplitDiffView.tsx
@@ -106,26 +106,22 @@ export default function SplitDiffView({
     ]),
   );
 
-  if (loadable.state === 'hasValue') {
-    const [{patch, tokenization}, allThreads, newCommentInputCallbacks, commitIDs] =
-      loadable.contents;
-    return (
-      <Box borderWidth="1px" borderStyle="solid" borderColor="border.default" borderRadius={2}>
-        <FileHeader path={path} />
-        <SplitDiffViewTable
-          path={path}
-          beforeOID={before}
-          tokenization={tokenization}
-          patch={patch}
-          allThreads={allThreads}
-          newCommentInputCallbacks={newCommentInputCallbacks}
-          commitIDs={commitIDs}
-        />
-      </Box>
-    );
-  } else {
-    return <div />;
-  }
+  const [{patch, tokenization}, allThreads, newCommentInputCallbacks, commitIDs] =
+    loadable.getValue();
+  return (
+    <Box borderWidth="1px" borderStyle="solid" borderColor="border.default" borderRadius={2}>
+      <FileHeader path={path} />
+      <SplitDiffViewTable
+        path={path}
+        beforeOID={before}
+        tokenization={tokenization}
+        patch={patch}
+        allThreads={allThreads}
+        newCommentInputCallbacks={newCommentInputCallbacks}
+        commitIDs={commitIDs}
+      />
+    </Box>
+  );
 }
 
 const SplitDiffViewTable = React.memo(


### PR DESCRIPTION
Add better loading state for pull request viewing

Updates the PR page to show the spinner while blobs/diffs are loading. Currently, the Suspense wrapping this is never triggered, leading to two big issues:
1. The page appears empty while loading (there is no indication of loading)
2. As the diffs load, they will appear in random order, causing layout shift until all diffs have loaded.

The only concern of this PR is that every diff must load to see anything now, but it was unusable before anyway as the layout would shift until all diffs were loaded anyway. I'm not sure why the loaders weren't using .getValue() before (and instead manually checking state to avoid suspense), so open to any discussion around that. I left some of that logic around, but could probably be cleaned up.

|Before|After|
|--|--|
|![Screen Shot 2023-05-25 at 12 50 15 PM](https://github.com/facebook/sapling/assets/77301670/e3ae0bc8-bd44-4a3c-90d4-c1e84503bdd7)|![Screen Shot 2023-05-25 at 12 40 28 PM](https://github.com/facebook/sapling/assets/77301670/488f1d01-94db-46e9-9053-a93ebc9a3561)|
