### PR TITLE
Allow collapsing file changes

### DIFF
--- a/addons/reviewstack/src/SplitDiffView.tsx
+++ b/addons/reviewstack/src/SplitDiffView.tsx
@@ -81,6 +81,7 @@ export default function SplitDiffView({
   after,
   isPullRequest,
 }: Props): React.ReactElement {
+  const [open, setOpen] = useState(true);
   const scopeName = getFilepathClassifier().findScopeNameForPath(path);
   const colorMode = useRecoilValue(primerColorMode);
   const loadable = useRecoilValueLoadable(
@@ -111,16 +112,18 @@ export default function SplitDiffView({
       loadable.contents;
     return (
       <Box borderWidth="1px" borderStyle="solid" borderColor="border.default" borderRadius={2}>
-        <FileHeader path={path} />
-        <SplitDiffViewTable
-          path={path}
-          beforeOID={before}
-          tokenization={tokenization}
-          patch={patch}
-          allThreads={allThreads}
-          newCommentInputCallbacks={newCommentInputCallbacks}
-          commitIDs={commitIDs}
-        />
+        <FileHeader path={path} open={open} onChangeOpen={open => setOpen(open)} />
+        {open && (
+          <SplitDiffViewTable
+            path={path}
+            beforeOID={before}
+            tokenization={tokenization}
+            patch={patch}
+            allThreads={allThreads}
+            newCommentInputCallbacks={newCommentInputCallbacks}
+            commitIDs={commitIDs}
+          />
+        )}
       </Box>
     );
   } else {

--- a/addons/shared/SplitDiffView/SplitDiffFileHeader.tsx
+++ b/addons/shared/SplitDiffView/SplitDiffFileHeader.tsx
@@ -9,16 +9,21 @@ import type {DiffType} from '../patch/parse';
 import type {Context} from './types';
 
 import {Icon} from '../Icon';
+import {ChevronDownIcon, ChevronUpIcon} from '@primer/octicons-react';
 import {Box, Text} from '@primer/react';
 
 export function FileHeader<Id>({
   ctx,
   path,
   diffType,
+  open,
+  onChangeOpen,
 }: {
   ctx?: Context<Id>;
   path: string;
   diffType?: DiffType;
+  open?: boolean;
+  onChangeOpen?: (open: boolean) => void;
 }) {
   // Even though the enclosing <SplitDiffView> will have border-radius set, we
   // have to define it again here or things don't look right.
@@ -30,6 +35,8 @@ export function FileHeader<Id>({
   return (
     <Box
       className="split-diff-view-file-header"
+      display="flex"
+      alignItems="center"
       bg="accent.subtle"
       color={color}
       paddingX={2}
@@ -41,6 +48,11 @@ export function FileHeader<Id>({
       borderBottomColor="border.default"
       borderBottomStyle="solid"
       borderBottomWidth="1px">
+      {onChangeOpen && (
+        <Box paddingRight={2} onClick={() => onChangeOpen(!open)} sx={{cursor: 'pointer'}}>
+          {open ? <ChevronUpIcon size={24} /> : <ChevronDownIcon size={24} />}
+        </Box>
+      )}
       {diffType !== undefined && <Icon icon={diffTypeToIcon[diffType]} />}
       <Text fontFamily="mono" fontSize={12}>
         {pathParts.reduce((acc, part, idx) => {


### PR DESCRIPTION
Allow collapsing file changes

Currently there is no way to mark files as viewed, or collapse large ones of no interest (especially generated files). This is pretty painful when you want to go back forth between several files.

This adds a chevron (same as used in the StatusChecks card) that can be clicked to toggle collapsing, matching github's behavior.

![Screen Shot 2023-05-25 at 1 28 20 PM](https://github.com/facebook/sapling/assets/77301670/d52c1af6-3ad3-4e0a-8a0f-a3e10c45e07f)
