### PR TITLE
Fix backwards diff view of commits

### DIFF
--- a/addons/vscode/extension/commands.ts
+++ b/addons/vscode/extension/commands.ts
@@ -124,14 +124,16 @@ export function registerCommands(tracker: ServerSideTracker): Array<vscode.Dispo
 
 function openDiffView(uri: vscode.Uri, comparison: Comparison): Thenable<unknown> {
   const {fsPath} = uri;
-  const left = encodeSaplingDiffUri(uri, comparison);
-  const right =
-    comparison.type === ComparisonType.Committed
-      ? encodeSaplingDiffUri(uri, {type: ComparisonType.Committed, hash: `${comparison.hash}^`})
-      : uri;
   const title = `${path.basename(fsPath)} (${t(labelForComparison(comparison))})`;
-
-  return executeVSCodeCommand('vscode.diff', left, right, title);
+  const uriForComparison = encodeSaplingDiffUri(uri, comparison);
+  if (comparison.type !== ComparisonType.Committed) {
+    return executeVSCodeCommand('vscode.diff', uriForComparison, uri, title);
+  }
+  const uriForComparisonParent = encodeSaplingDiffUri(uri, {
+    type: ComparisonType.Committed,
+    hash: `${comparison.hash}^`,
+  });
+  return executeVSCodeCommand('vscode.diff', uriForComparisonParent, uriForComparison, title);
 }
 
 /**


### PR DESCRIPTION
Fix backwards diff view of commits

When generating a diff view for committed changes, the previous logic compared left=commit with right=commit^. This is backwards, and led to commits appearing to do the opposite.

For other types of diff view (ex. HEAD/UNCOMMITED_CHANGES), it was correct to have "commit" on the left, because right was something with more changes than commit.

Tried to rename / refactor things a bit to make the behavior more clear too (previously several related variables were being changed with ternary operators, making it hard to understand at a glance the actual result in different scenarios).

This addresses issue https://github.com/facebook/sapling/issues/634


# Test Plan
Checked the diff view of uncommited changes, the diff view of the head commit, and the diff view of non-head commits. Confirmed they all showed the correct direction of changes.