### PR TITLE
Fix SCM missing data until first poll/update

### DIFF
--- a/addons/isl-server/src/WatchForChanges.ts
+++ b/addons/isl-server/src/WatchForChanges.ts
@@ -44,6 +44,7 @@ export class WatchForChanges {
     this.setupWatchmanSubscriptions();
     this.setupPolling();
     this.pageFocusTracker.onChange(this.poll.bind(this));
+    this.changeCallback('everything');
   }
 
   private timeout: NodeJS.Timeout | undefined;


### PR DESCRIPTION
Fix SCM missing data until first poll/update

Currently the Source Control tab shows no data until the first polling interval is reached, or a change is made (i.e. it will show no changes right when you open VSCode, even if you have some). This seems to be because the Repository tracking logic doesn't fetch anything right away.

Since all repositories get fetched 5 minutes after Repository is constructed for them, it doesn't seem like this will change how much is fetched generally, just does a bit more at startup to ensure the UI can populate correctly.

This PR just adds a trigger of `changeCallback('everything')` at startup. Could also call `this.poll('force')` (perhaps instead of `setupPolling()`), but this seems most direct.
