### PR TITLE
[RFC] Add blame annotations for highlighted line

### DIFF
--- a/addons/isl-server/src/CodeReviewProvider.ts
+++ b/addons/isl-server/src/CodeReviewProvider.ts
@@ -19,6 +19,8 @@ type DiffSummaries = Map<DiffId, DiffSummary>;
  * API to fetch data from Remote Code Review system, like GitHub and Phabricator.
  */
 export interface CodeReviewProvider {
+  getDiffUrl(diffId: DiffId): string;
+
   triggerDiffSummariesFetch(diffs: Array<DiffId>): unknown;
 
   onChangeDiffSummaries(callback: (result: Result<DiffSummaries>) => unknown): Disposable;

--- a/addons/isl-server/src/github/githubCodeReviewProvider.ts
+++ b/addons/isl-server/src/github/githubCodeReviewProvider.ts
@@ -55,6 +55,10 @@ export class GitHubCodeReviewProvider implements CodeReviewProvider {
     };
   }
 
+  getDiffUrl(diffId: string): string {
+    return `https://${this.codeReviewSystem.hostname}/${this.codeReviewSystem.owner}/${this.codeReviewSystem.repo}/pull/${diffId}`;
+  }
+
   triggerDiffSummariesFetch = debounce(
     async () => {
       try {

--- a/addons/isl/src/types.ts
+++ b/addons/isl/src/types.ts
@@ -457,3 +457,10 @@ export type Disposable = {
 export type ComparisonData = {
   diff: Result<string>;
 };
+
+export type BlameInfo = {
+  user: string;
+  node: string;
+  date: string;
+  line: string;
+}[];

--- a/addons/vscode/extension/BlameAnnotationProvider.ts
+++ b/addons/vscode/extension/BlameAnnotationProvider.ts
@@ -1,0 +1,113 @@
+import type {Logger} from 'isl-server/src/logger';
+import type {TextEditorSelectionChangeEvent} from 'vscode';
+
+import {repositoryCache} from 'isl-server/src/RepositoryCache';
+import {Range, Disposable, MarkdownString, window} from 'vscode';
+
+const annotationDecoration = window.createTextEditorDecorationType({
+  after: {
+    margin: '0px 0px 0px 30px',
+    color: 'rgba(156,156,156,.4)',
+  },
+});
+
+class BlameAnnotationProvider implements Disposable {
+  private disposables: Disposable[] = [];
+  private annotation: Disposable | undefined;
+  constructor(private logger: Logger) {
+    this.disposables.push(
+      Disposable.from(
+        window.onDidChangeTextEditorSelection(this.onTextEditorSelectionChanged, this),
+      ),
+    );
+  }
+  private async onTextEditorSelectionChanged(e: TextEditorSelectionChangeEvent) {
+    try {
+      const editor = e.textEditor;
+      const document = editor.document;
+      const repo = repositoryCache.cachedRepositoryForPath(document.uri.fsPath);
+      if (!repo) {
+        return;
+      }
+
+      this.annotation?.dispose();
+      let isDisposed = false;
+      this.annotation = {dispose: () => (isDisposed = true)};
+
+      if (document.isDirty) {
+        return;
+      }
+      const line = e.selections[0].active.line;
+      const fileBlame = await repo.fetchBlame(document.uri.fsPath);
+
+      const lineBlame = fileBlame?.[line];
+      if (!lineBlame || isDisposed) {
+        return;
+      }
+      const date = formatTimeSince(new Date(lineBlame.date));
+      const commit = await repo.fetchCommit(lineBlame.node);
+      if (isDisposed) {
+        return;
+      }
+      const commitUserName = commit?.author.replace(/ <.*>/, '') ?? 'Unknown author';
+
+      // TODO: Is there a better way to get the diff/PR number from public commits?
+      const diffId = commit?.diffId ?? commit?.title?.match(/#(\d+)/)?.[1];
+      const reviewLink =
+        diffId && repo.codeReviewProvider ? repo.codeReviewProvider.getDiffUrl(diffId) : '';
+
+      const markdown = new MarkdownString(
+        `### ${commitUserName}, ${date}${
+          diffId != null ? ` via PR [#${diffId}](${reviewLink})` : ''
+        }\n#### ${commit?.title}\n\n${commit?.description}\n\n`,
+      );
+      const inlineText = `${commitUserName}, ${date}${
+        diffId != null ? ' via PR #' + diffId : ''
+      } • ${truncate(commit?.title ?? 'Unknown', 50)}`;
+
+      editor.setDecorations(annotationDecoration, [
+        {
+          range: new Range(line, 10000000, line, 10000000), // Necessary so hover message doesn't trigger on the entire line
+          hoverMessage: markdown,
+          renderOptions: {
+            after: {
+              contentText: inlineText,
+            },
+          },
+        },
+      ]);
+      this.annotation = {dispose: () => editor.setDecorations(annotationDecoration, [])};
+    } catch (err) {
+      this.logger.error('Error while handling blame annotation', err);
+    }
+  }
+  dispose() {
+    this.disposables.forEach(d => d.dispose());
+    this.annotation?.dispose();
+  }
+}
+
+export function registerBlameAnnotationProvider(logger: Logger) {
+  return new BlameAnnotationProvider(logger);
+}
+
+const DATE_UNITS = [
+  {unit: 'second', ms: 1000},
+  {unit: 'minute', ms: 60 * 1000},
+  {unit: 'hour', ms: 60 * 60 * 1000},
+  {unit: 'day', ms: 24 * 60 * 60 * 1000},
+  {unit: 'week', ms: 7 * 24 * 60 * 60 * 1000},
+  {unit: 'month', ms: 30 * 24 * 60 * 60 * 1000},
+  {unit: 'year', ms: 365 * 24 * 60 * 60 * 1000},
+];
+
+function formatTimeSince(date: Date) {
+  const timeSince = Date.now() - date.getTime();
+  const unit = DATE_UNITS.findLast(unit => unit.ms <= timeSince) ?? DATE_UNITS[0];
+  const value = Math.round(timeSince / unit.ms);
+  return `${value} ${unit.unit}${value !== 1 ? 's' : ''} ago`;
+}
+
+function truncate(str: string, n: number) {
+  return str.length > n ? str.substring(0, n - 1) + '...' : str;
+}

--- a/addons/vscode/extension/extension.ts
+++ b/addons/vscode/extension/extension.ts
@@ -8,6 +8,7 @@
 import type {Logger} from 'isl-server/src/logger';
 
 import packageJson from '../package.json';
+import {registerBlameAnnotationProvider} from './BlameAnnotationProvider';
 import {registerSaplingDiffContentProvider} from './DiffContentProvider';
 import {watchAndCreateRepositoriesForWorkspaceFolders} from './VSCodeRepo';
 import {registerCommands} from './commands';
@@ -28,6 +29,7 @@ export async function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(outputChannel);
     context.subscriptions.push(watchAndCreateRepositoriesForWorkspaceFolders(logger));
     context.subscriptions.push(registerSaplingDiffContentProvider(logger));
+    context.subscriptions.push(registerBlameAnnotationProvider(logger));
     context.subscriptions.push(...registerCommands(extensionTracker));
     extensionTracker.track('VSCodeExtensionActivated', {duration: Date.now() - start});
   } catch (error) {


### PR DESCRIPTION
[RFC] Add blame annotations for highlighted line


Adds an inline summary of blame for the currently selected line (including author, date, commit title). Hovering that summary also gives a hovercard with more details (including a link to the PR).

This roughly visually matches the blame shown in the GitLens extension.


A few pending things to resolve:
- This doesn't work if a file has uncommitted changes currently, I'm waiting for resolution of `-r 'wdir()'` for blame command. I could update it to just not run if there are uncommitted changes in the active file.
- I'm not sure the best way to abstract PR/diff links, and extracting them from public commits in a repo (for git, looking for #number works)
- Might want to update the caching logic for blame/commit details to use an LRU or something to avoid memory growth
