### PR TITLE
Fix retainContextWhenHidden setting when using sidebar

### DIFF
--- a/addons/vscode/extension/islWebviewPanel.ts
+++ b/addons/vscode/extension/islWebviewPanel.ts
@@ -86,7 +86,11 @@ export function registerISLCommands(
       }
     }),
     registerDeserializer(context, logger),
-    vscode.window.registerWebviewViewProvider(viewType, webviewViewProvider),
+    vscode.window.registerWebviewViewProvider(viewType, webviewViewProvider, {
+      webviewOptions: {
+        retainContextWhenHidden: true,
+      },
+    }),
     vscode.workspace.onDidChangeConfiguration(e => {
       // if we start using ISL as a view, dispose the panel
       if (e.affectsConfiguration('sapling.isl.showInSidebar')) {


### PR DESCRIPTION
Fix retainContextWhenHidden setting when using sidebar


# Summary
Currently retainContextWhenHidden is set to true within the webview options. This means when you open the ISL view, it preserves its webview state rather than reloading if you switch to another file, then back. This has a bunch of advantages (preserves pending commit message, selected commit, commitinfo collapse state, faster load time, etc.).

However, when using ISL within the sidebar, that setting did not take effect because of where it was set. This PR adds the same setting within `registerWebviewViewProvider` (instead of just `createWebviewPanel`).

# Test Plan
Confirmed that now when using ISL in the sidebar, I can switch between ISL and Files Explorer, or close the sidebar, and reopen with the same state.
