### PR TITLE
Fix github check status logic

### DIFF
--- a/addons/isl-server/src/CodeReviewProvider.ts
+++ b/addons/isl-server/src/CodeReviewProvider.ts
@@ -19,6 +19,8 @@ type DiffSummaries = Map<DiffId, DiffSummary>;
  * API to fetch data from Remote Code Review system, like GitHub and Phabricator.
  */
 export interface CodeReviewProvider {
+  getDiffUrl(diffId: DiffId): string;
+
   triggerDiffSummariesFetch(diffs: Array<DiffId>): unknown;
 
   onChangeDiffSummaries(callback: (result: Result<DiffSummaries>) => unknown): Disposable;

--- a/addons/isl-server/src/Repository.ts
+++ b/addons/isl-server/src/Repository.ts
@@ -32,6 +32,7 @@ import type {
   RepoRelativePath,
   FetchedUncommittedChanges,
   FetchedCommits,
+  BlameInfo,
 } from 'isl/src/types';
 
 import {Internal} from './Internal';
@@ -141,6 +142,8 @@ export class Repository {
 
   private mergeConflicts: MergeConflicts | undefined = undefined;
   private uncommittedChanges: FetchedUncommittedChanges | null = null;
+  private commitCache: Map<string, CommitInfo> = new Map();
+  private blameCache: Map<string, BlameInfo> = new Map();
   private smartlogCommits: FetchedCommits | null = null;
 
   private mergeConflictsEmitter = new TypedEventEmitter<'change', MergeConflicts | undefined>();
@@ -186,6 +189,7 @@ export class Repository {
 
     this.watchForChanges = new WatchForChanges(info, logger, this.pageFocusTracker, kind => {
       if (kind === 'uncommitted changes') {
+        this.blameCache.clear();
         this.fetchUncommittedChanges();
       } else if (kind === 'commits') {
         this.fetchSmartlogCommits();
@@ -519,6 +523,47 @@ export class Repository {
       },
     };
   }
+
+  fetchBlame = async (path: string) => {
+    try {
+      if (this.blameCache.has(path)) {
+        return this.blameCache.get(path);
+      }
+      // Json format doesn't include commit data, so we use the default format and manually parse
+      // TODO: Pass -r 'wdir()' to get the blame for the working copy version of the file
+      const proc = await this.runCommand(['blame', path, '-ucd']);
+      const lines =
+        proc.stdout.trim() === ''
+          ? []
+          : proc.stdout.split('\n').map(line => {
+              const parsed = /^ *([^ ]+) ([^ ]+) (.+?): (.*)/.exec(line);
+              return {
+                user: parsed?.[1] ?? '',
+                node: parsed?.[2] ?? '',
+                date: parsed?.[3] ?? '',
+                line: parsed?.[4] ?? '',
+              };
+            });
+      this.blameCache.set(path, lines);
+      return lines;
+    } catch (err) {
+      this.logger.error('Error fetching blame: ', err);
+    }
+  };
+
+  fetchCommit = async (hash: string) => {
+    try {
+      if (this.commitCache.has(hash)) {
+        return this.commitCache.get(hash);
+      }
+      const proc = await this.runCommand(['log', '--template', FETCH_TEMPLATE, '--rev', hash]);
+      const [commit] = parseCommitInfoOutput(this.logger, proc.stdout.trim());
+      this.commitCache.set(hash, commit);
+      return commit;
+    } catch (err) {
+      this.logger.error('Error fetching commit: ', err);
+    }
+  };
 
   fetchUncommittedChanges = serializeAsyncCall(async () => {
     const fetchStartTimestamp = Date.now();

--- a/addons/isl-server/src/github/generated/graphql.ts
+++ b/addons/isl-server/src/github/generated/graphql.ts
@@ -24257,7 +24257,7 @@ export type YourPullRequestsQueryVariables = Exact<{
 }>;
 
 
-export type YourPullRequestsQueryData = { __typename?: 'Query', search: { __typename?: 'SearchResultItemConnection', nodes?: Array<{ __typename?: 'App' } | { __typename?: 'Discussion' } | { __typename?: 'Issue' } | { __typename?: 'MarketplaceListing' } | { __typename?: 'Organization' } | { __typename: 'PullRequest', number: number, title: string, state: PullRequestState, isDraft: boolean, url: string, comments: { __typename?: 'IssueCommentConnection', totalCount: number }, commits: { __typename?: 'PullRequestCommitConnection', nodes?: Array<{ __typename?: 'PullRequestCommit', commit: { __typename?: 'Commit', checkSuites?: { __typename?: 'CheckSuiteConnection', nodes?: Array<{ __typename?: 'CheckSuite', conclusion?: CheckConclusionState | null, status: CheckStatusState } | null> | null } | null } } | null> | null } } | { __typename?: 'Repository' } | { __typename?: 'User' } | null> | null } };
+export type YourPullRequestsQueryData = { __typename?: 'Query', search: { __typename?: 'SearchResultItemConnection', nodes?: Array<{ __typename?: 'App' } | { __typename?: 'Discussion' } | { __typename?: 'Issue' } | { __typename?: 'MarketplaceListing' } | { __typename?: 'Organization' } | { __typename: 'PullRequest', number: number, title: string, state: PullRequestState, isDraft: boolean, url: string, comments: { __typename?: 'IssueCommentConnection', totalCount: number }, commits: { __typename?: 'PullRequestCommitConnection', nodes?: Array<{ __typename?: 'PullRequestCommit', commit: { __typename?: 'Commit', statusCheckRollup?: { __typename?: 'StatusCheckRollup', state: StatusState } | null } } | null> | null } } | { __typename?: 'Repository' } | { __typename?: 'User' } | null> | null } };
 
 
 export const YourPullRequestsQuery = `
@@ -24277,11 +24277,8 @@ export const YourPullRequestsQuery = `
         commits(last: 1) {
           nodes {
             commit {
-              checkSuites(first: 100) {
-                nodes {
-                  conclusion
-                  status
-                }
+              statusCheckRollup {
+                state
               }
             }
           }

--- a/addons/isl-server/src/github/githubCodeReviewProvider.ts
+++ b/addons/isl-server/src/github/githubCodeReviewProvider.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/consistent-type-imports */
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -8,7 +9,6 @@
 import type {CodeReviewProvider} from '../CodeReviewProvider';
 import type {Logger} from '../logger';
 import type {
-  CheckSuiteConnection,
   YourPullRequestsQueryData,
   YourPullRequestsQueryVariables,
 } from './generated/graphql';
@@ -16,8 +16,7 @@ import type {CodeReviewSystem, DiffSignalSummary, DiffId, Disposable, Result} fr
 
 import {
   PullRequestState,
-  CheckStatusState,
-  CheckConclusionState,
+  StatusState,
   YourPullRequestsQuery,
 } from './generated/graphql';
 import queryGraphQL from './queryGraphQL';
@@ -95,11 +94,8 @@ export class GitHubCodeReviewProvider implements CodeReviewProvider {
               url: summary.url,
               commentCount: summary.comments.totalCount,
               anyUnresolvedComments: false,
-              signalSummary: githubCheckSuitesToCIStatus(
-                summary.commits.nodes?.[0]?.commit.checkSuites as
-                  | CheckSuiteConnection
-                  | null
-                  | undefined,
+              signalSummary: githubStatusRollupStateToCIStatus(
+                summary.commits.nodes?.[0]?.commit.statusCheckRollup?.state,
               ),
             });
           }
@@ -129,40 +125,17 @@ export class GitHubCodeReviewProvider implements CodeReviewProvider {
   }
 }
 
-function githubCheckSuitesToCIStatus(
-  checkSuites: CheckSuiteConnection | undefined | null,
-): DiffSignalSummary {
-  let anyInProgress = false;
-  let anyWarning = false;
-  for (const checkSuite of checkSuites?.nodes ?? []) {
-    switch (checkSuite?.status) {
-      case CheckStatusState.Completed:
-        {
-          switch (checkSuite?.conclusion) {
-            case CheckConclusionState.Success:
-              break;
-            case CheckConclusionState.Neutral:
-            case CheckConclusionState.Stale:
-            case CheckConclusionState.Skipped:
-              anyWarning = true;
-              break;
-            case CheckConclusionState.ActionRequired:
-            case CheckConclusionState.StartupFailure:
-            case CheckConclusionState.Cancelled:
-            case CheckConclusionState.TimedOut:
-            case CheckConclusionState.Failure:
-              return 'failed'; // no need to look at other signals
-          }
-        }
-        break;
-      case CheckStatusState.Waiting:
-      case CheckStatusState.Requested:
-      case CheckStatusState.Queued:
-      case CheckStatusState.Pending:
-      case CheckStatusState.InProgress:
-        anyInProgress = true;
-        break;
-    }
+function githubStatusRollupStateToCIStatus(state: StatusState | undefined): DiffSignalSummary {
+  switch (state) {
+    case undefined:
+    case StatusState.Expected:
+      return 'no-signal';
+    case StatusState.Pending:
+      return 'running';
+    case StatusState.Error:
+    case StatusState.Failure:
+      return 'failed';
+    case StatusState.Success:
+      return 'pass';
   }
-  return anyWarning ? 'warning' : anyInProgress ? 'running' : 'pass';
 }

--- a/addons/isl-server/src/github/githubCodeReviewProvider.ts
+++ b/addons/isl-server/src/github/githubCodeReviewProvider.ts
@@ -55,6 +55,10 @@ export class GitHubCodeReviewProvider implements CodeReviewProvider {
     };
   }
 
+  getDiffUrl(diffId: string): string {
+    return `https://${this.codeReviewSystem.hostname}/${this.codeReviewSystem.owner}/${this.codeReviewSystem.repo}/pull/${diffId}`;
+  }
+
   triggerDiffSummariesFetch = debounce(
     async () => {
       try {

--- a/addons/isl-server/src/github/queries/YourPullRequestsQuery.graphql
+++ b/addons/isl-server/src/github/queries/YourPullRequestsQuery.graphql
@@ -14,11 +14,8 @@ query YourPullRequestsQuery($searchQuery: String!, $numToFetch: Int!) {
         commits(last: 1) {
           nodes {
             commit {
-              checkSuites(first: 100) {
-                nodes {
-                  conclusion
-                  status
-                }
+              statusCheckRollup {
+                state
               }
             }
           }

--- a/addons/isl/src/types.ts
+++ b/addons/isl/src/types.ts
@@ -457,3 +457,10 @@ export type Disposable = {
 export type ComparisonData = {
   diff: Result<string>;
 };
+
+export type BlameInfo = {
+  user: string;
+  node: string;
+  date: string;
+  line: string;
+}[];

--- a/addons/vscode/extension/BlameAnnotationProvider.ts
+++ b/addons/vscode/extension/BlameAnnotationProvider.ts
@@ -1,0 +1,113 @@
+import type {Logger} from 'isl-server/src/logger';
+import type {TextEditorSelectionChangeEvent} from 'vscode';
+
+import {repositoryCache} from 'isl-server/src/RepositoryCache';
+import {Range, Disposable, MarkdownString, window} from 'vscode';
+
+const annotationDecoration = window.createTextEditorDecorationType({
+  after: {
+    margin: '0px 0px 0px 30px',
+    color: 'rgba(156,156,156,.4)',
+  },
+});
+
+class BlameAnnotationProvider implements Disposable {
+  private disposables: Disposable[] = [];
+  private annotation: Disposable | undefined;
+  constructor(private logger: Logger) {
+    this.disposables.push(
+      Disposable.from(
+        window.onDidChangeTextEditorSelection(this.onTextEditorSelectionChanged, this),
+      ),
+    );
+  }
+  private async onTextEditorSelectionChanged(e: TextEditorSelectionChangeEvent) {
+    try {
+      const editor = e.textEditor;
+      const document = editor.document;
+      const repo = repositoryCache.cachedRepositoryForPath(document.uri.fsPath);
+      if (!repo) {
+        return;
+      }
+
+      this.annotation?.dispose();
+      let isDisposed = false;
+      this.annotation = {dispose: () => (isDisposed = true)};
+
+      if (document.isDirty) {
+        return;
+      }
+      const line = e.selections[0].active.line;
+      const fileBlame = await repo.fetchBlame(document.uri.fsPath);
+
+      const lineBlame = fileBlame?.[line];
+      if (!lineBlame || isDisposed) {
+        return;
+      }
+      const date = formatTimeSince(new Date(lineBlame.date));
+      const commit = await repo.fetchCommit(lineBlame.node);
+      if (isDisposed) {
+        return;
+      }
+      const commitUserName = commit?.author.replace(/ <.*>/, '') ?? 'Unknown author';
+
+      // TODO: Is there a better way to get the diff/PR number from public commits?
+      const diffId = commit?.diffId ?? commit?.title?.match(/#(\d+)/)?.[1];
+      const reviewLink =
+        diffId && repo.codeReviewProvider ? repo.codeReviewProvider.getDiffUrl(diffId) : '';
+
+      const markdown = new MarkdownString(
+        `### ${commitUserName}, ${date}${
+          diffId != null ? ` via PR [#${diffId}](${reviewLink})` : ''
+        }\n#### ${commit?.title}\n\n${commit?.description}\n\n`,
+      );
+      const inlineText = `${commitUserName}, ${date}${
+        diffId != null ? ' via PR #' + diffId : ''
+      } • ${truncate(commit?.title ?? 'Unknown', 50)}`;
+
+      editor.setDecorations(annotationDecoration, [
+        {
+          range: new Range(line, 10000000, line, 10000000), // Necessary so hover message doesn't trigger on the entire line
+          hoverMessage: markdown,
+          renderOptions: {
+            after: {
+              contentText: inlineText,
+            },
+          },
+        },
+      ]);
+      this.annotation = {dispose: () => editor.setDecorations(annotationDecoration, [])};
+    } catch (err) {
+      this.logger.error('Error while handling blame annotation', err);
+    }
+  }
+  dispose() {
+    this.disposables.forEach(d => d.dispose());
+    this.annotation?.dispose();
+  }
+}
+
+export function registerBlameAnnotationProvider(logger: Logger) {
+  return new BlameAnnotationProvider(logger);
+}
+
+const DATE_UNITS = [
+  {unit: 'second', ms: 1000},
+  {unit: 'minute', ms: 60 * 1000},
+  {unit: 'hour', ms: 60 * 60 * 1000},
+  {unit: 'day', ms: 24 * 60 * 60 * 1000},
+  {unit: 'week', ms: 7 * 24 * 60 * 60 * 1000},
+  {unit: 'month', ms: 30 * 24 * 60 * 60 * 1000},
+  {unit: 'year', ms: 365 * 24 * 60 * 60 * 1000},
+];
+
+function formatTimeSince(date: Date) {
+  const timeSince = Date.now() - date.getTime();
+  const unit = DATE_UNITS.findLast(unit => unit.ms <= timeSince) ?? DATE_UNITS[0];
+  const value = Math.round(timeSince / unit.ms);
+  return `${value} ${unit.unit}${value !== 1 ? 's' : ''} ago`;
+}
+
+function truncate(str: string, n: number) {
+  return str.length > n ? str.substring(0, n - 1) + '...' : str;
+}

--- a/addons/vscode/extension/extension.ts
+++ b/addons/vscode/extension/extension.ts
@@ -8,6 +8,7 @@
 import type {Logger} from 'isl-server/src/logger';
 
 import packageJson from '../package.json';
+import {registerBlameAnnotationProvider} from './BlameAnnotationProvider';
 import {registerSaplingDiffContentProvider} from './DiffContentProvider';
 import {watchAndCreateRepositoriesForWorkspaceFolders} from './VSCodeRepo';
 import {registerCommands} from './commands';
@@ -28,6 +29,7 @@ export async function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(outputChannel);
     context.subscriptions.push(watchAndCreateRepositoriesForWorkspaceFolders(logger));
     context.subscriptions.push(registerSaplingDiffContentProvider(logger));
+    context.subscriptions.push(registerBlameAnnotationProvider(logger));
     context.subscriptions.push(...registerCommands(extensionTracker));
     extensionTracker.track('VSCodeExtensionActivated', {duration: Date.now() - start});
   } catch (error) {

--- a/addons/vscode/extension/islWebviewPanel.ts
+++ b/addons/vscode/extension/islWebviewPanel.ts
@@ -86,7 +86,11 @@ export function registerISLCommands(
       }
     }),
     registerDeserializer(context, logger),
-    vscode.window.registerWebviewViewProvider(viewType, webviewViewProvider),
+    vscode.window.registerWebviewViewProvider(viewType, webviewViewProvider, {
+      webviewOptions: {
+        retainContextWhenHidden: true,
+      },
+    }),
     vscode.workspace.onDidChangeConfiguration(e => {
       // if we start using ISL as a view, dispose the panel
       if (e.affectsConfiguration('sapling.isl.showInSidebar')) {


### PR DESCRIPTION
Fix github check status logic

# Summary
The current logic for github checks uses "checkSuites" to get all the check suites run for the most recent commit. This doesn't actually match which checks are shown overall for the PR (ex. some may be duplicated and cancelled, and thus not be important, or may not be blocking).

In particular, I noticed for my repo that there is some QUEUED "checkSuites" which don't appear in the github UI, and there are some cancelled checkSuites which were superceded by a later run, and thus are acceptable to fail. This leads to passing PRs showing as "pending", and some PRs showing as "failing" if a run was cancelled and rerun for the latest commit.

This PR updates to use `commit.statusCheckRollup.state` instead of manually trying to aggregate the check suites. If the breakdown is desired, `commit.statusCheckRollup.contexts.checkRunCountsByState` could provide that (but the aggregated "state" seems to handle it well).

# Test Plan
This seems to give accurate results within my repo (tested with some pending, passing, and failing cases)
