### PR TITLE
reviewstack: add version dropdown support for sapling stacks

### DIFF
--- a/.github/workflows/sapling-website-deploy.yml
+++ b/.github/workflows/sapling-website-deploy.yml
@@ -2,6 +2,8 @@ name: Publish https://sapling-scm.com
 
 on:
   workflow_dispatch:
+  # only run on prs if not a fork
+  if: ${{ !github.event.pull_request.head.repo.fork }}
   pull_request:
 
 jobs:


### PR DESCRIPTION
This makes it possible to review the differences between versions of sapling stack PRs in reviewstack.

It populates the the version and left/right drop down selectors for in gitHubPullRequestVersions.  Which in turn meant I could remove the sapling special case in gitHubPullRequestVersionDiff so I could actually see the diffs

fixes #192
fixes #587

Test Plan:

yarn test --watchAll=false

Local build and run

Before, only one version in drop down for Version despite sidebar forcepushes  showing there should be four.
https://reviewstack.dev/benbrittain/buckle/pull/6
![image](https://github-production-user-asset-6210df.s3.amazonaws.com/14246801/248879752-07e93b5d-4d64-415b-a753-01ceeddadf67.png) 

vs

After, versions in drop downs, commit ids match the sidebar force push timeline:
http://localhost:3000/benbrittain/buckle/pull/6
![image](https://github.com/facebook/sapling/assets/14246801/5ffd6935-82a8-4bbf-9bb1-2863ed9d4e1d)

After, diff content matches the version selector, diff shows the change between versions
![image](https://github.com/facebook/sapling/assets/14246801/f74600cf-7400-4873-8fd3-bea9e881810a)

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/656).
* #657
* __->__ #656
* #658