### PR TITLE
reviewstack: show versions for left and right in comparison label

### DIFF
--- a/.github/workflows/sapling-website-deploy.yml
+++ b/.github/workflows/sapling-website-deploy.yml
@@ -2,6 +2,8 @@ name: Publish https://sapling-scm.com
 
 on:
   workflow_dispatch:
+  # only run on prs if not a fork
+  if: ${{ !github.event.pull_request.head.repo.fork }}
   pull_request:
 
 jobs:

--- a/addons/reviewstack/src/PullRequestVersionCommitSelector.tsx
+++ b/addons/reviewstack/src/PullRequestVersionCommitSelector.tsx
@@ -72,8 +72,14 @@ function getIndex(
 }
 
 function commitsLabel(commits: VersionCommit[], beforeIndex: number, afterIndex: number): string {
-  return [commits[beforeIndex]?.commit, commits[afterIndex]?.commit]
+  return [commits[beforeIndex], commits[afterIndex]]
     .filter(notEmpty)
-    .map(shortOid)
+    .map(c => {
+      if (c.version == null) {
+        return shortOid(c.commit);
+      } else {
+        return 'V' + c.version + ' ' + shortOid(c.commit);
+      }
+    })
     .join(' vs. ');
 }

--- a/addons/reviewstack/src/github/types.ts
+++ b/addons/reviewstack/src/github/types.ts
@@ -152,6 +152,11 @@ export interface VersionCommit {
    */
   title: string;
   parents: GitObjectID[];
+
+  /**
+   * Which version of the PR does this commit belong to. Used for labeling
+   */
+  version: number | null;
 }
 
 export interface Version {

--- a/addons/reviewstack/src/recoil.ts
+++ b/addons/reviewstack/src/recoil.ts
@@ -265,6 +265,7 @@ export const gitHubPullRequestVersionBaseAndCommits = selectorFamily<
           committedDate: commit.committer.date,
           title: commit.message.split('\n', 1)[0] ?? '',
           parents: parents.map(({sha}) => sha),
+          version: null,
         })),
       };
     },
@@ -355,6 +356,7 @@ export const gitHubPullRequestVersions = selector<Version[]>({
             committedDate: f.beforeCommittedDate,
             title: 'Version ' + (i + 1),
             parents: f.beforeParents,
+            version: i + 1,
           });
         }
 
@@ -365,6 +367,7 @@ export const gitHubPullRequestVersions = selector<Version[]>({
             committedDate: c.committedDate,
             title: c.messageHeadline,
             parents: c.parents,
+            version: versionCommits.length + 1,
           }),
         );
 


### PR DESCRIPTION
Show version labels for left and right in the comparison label for sapling stacks.  This makes version comparison clearer.

Test Plan:

yarn test --watchAll=false

Local build and run

Before, no versions in Left/Right drop down comparison label, only the short commit ids:
https://reviewstack.dev/benbrittain/buckle/pull/6
![image](https://github.com/facebook/sapling/assets/14246801/f74600cf-7400-4873-8fd3-bea9e881810a) 

vs

After, version prefixes Left/Right drop down comparison label:
![image](https://github.com/facebook/sapling/assets/14246801/d957f93b-64e6-427f-be67-81cbf24fde20)

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/657).
* __->__ #657
* #656
* #658