### PR TITLE
zsh: add "goto" zsh completion

### DIFF
--- a/eden/scm/contrib/zsh_completion
+++ b/eden/scm/contrib/zsh_completion
@@ -617,6 +617,18 @@ _hg_cmd_forget() {
   '*:file:_hg_files'
 }
 
+_hg_cmd_goto() {
+  _arguments -s -w : $_hg_global_opts \
+  '(--clean -C)'{-C,--clean}'[discard uncommitted changes (no backup)]' \
+  '(--check -c)'{-c,--check}'[require clean working copy]' \
+  '(--merge -m)'{-m,--merge}'[merge uncommitted changes]' \
+  '(--rev -r)'{-r+,--rev=}'[revision]:revision:_hg_labels' \
+  '--inactive[update without activating bookmarks]' \
+  '(--bookmark -B)'{-B+,--bookmark=}'[create new bookmark]:text:' \
+  '(--tool -t)'{-t+,--tool=}'[specify merge tool]:text:' \
+  '*:revision:_hg_labels'
+}
+
 _hg_cmd_graft() {
   _arguments -s -w : $_hg_global_opts $_hg_dryrun_opts \
                      $_hg_date_user_opts $_hg_mergetool_opts \


### PR DESCRIPTION
# Summary

Adds ZSH completion for the "goto" command, mimicking the approach for other similar commands.

I use this command all the time. Some ZSH completion is great! Makes it much faster to use.

# Test Plan

Tested locally

![image](https://github.com/facebook/sapling/assets/131916/a8f099b1-e1bb-4ed7-adff-6c5043630bf6)
![image](https://github.com/facebook/sapling/assets/131916/6316445a-62b3-4a57-89f9-71acfe8a8ccf)
