### PR TITLE
[ReviewStack] Improve TreeQuery performance

### DIFF
--- a/addons/reviewstack/src/queries/TreeFragment.graphql
+++ b/addons/reviewstack/src/queries/TreeFragment.graphql
@@ -3,9 +3,6 @@ fragment TreeFragment on Tree {
   oid
   entries {
     oid
-    object {
-      oid
-    }
     name
     path
     type


### PR DESCRIPTION
[ReviewStack] Improve TreeQuery performance

Seems like "Tree.object.oid" was unused, but the fan-out of Object -> 1k Trees -> 1k Objects (repeats of the original object) added a lot of overhead.

Running queryies in github's graphql explorer, this seems to avoid a timeout.

Probably there are better improvements to be made here, but seems like a free win to include
