### PR TITLE
reviewstack: fix github stacked diff display

### DIFF
--- a/addons/reviewstack/src/recoil.ts
+++ b/addons/reviewstack/src/recoil.ts
@@ -852,11 +852,11 @@ export const gitHubPullRequestComparableVersions = atom<ComparableVersions>({
       const [versions, selectedVersionIndex] = get(
         waitForAll([gitHubPullRequestVersions, gitHubPullRequestSelectedVersionIndex]),
       );
-      const latestCommit = versions[selectedVersionIndex].headCommit;
+      const version = versions[selectedVersionIndex];
 
       return {
-        beforeCommitID: null,
-        afterCommitID: latestCommit,
+        beforeCommitID: version.baseParent,
+        afterCommitID:  version.headCommit,
       };
     },
   }),


### PR DESCRIPTION
github diffs were showing the full set of commits in the stack rather than just the commits for the given PR version

gitHubPullRequestComparableVersions was returning null for base commit,  which meant we always fell back on the } else if (afterBaseCommitID != null) { branch of gitHubPullRequestVersionDiff.  That fallback used to work fine, but now its giving us the base of the full stack rather than the base of the PR. I don't know how it worked before (perhaps github api behaviour changed?), but there you go!

Fix is to use the version.baseParent in gitHubPullRequestComparableVersions, which has the right value in it.

Test Plan:

yarn test --watchAll=false

Local build and run:

Before, https://reviewstack.dev/facebookincubator/fizz/pull/96 shows changes for full stack:
![image](https://github.com/facebook/sapling/assets/14246801/932463ed-9132-4efe-8672-92a72ca2bd7c)

After, http://localhost:3000/facebookincubator/fizz/pull/96 shows only relevant changes for PR:
![image](https://github.com/facebook/sapling/assets/14246801/7e8466b6-4a40-4d70-9bb6-7e4182294018)
