### PR TITLE
regenerate eden getdeps with rust-shed dependency

### DIFF
--- a/.github/workflows/edenfs_linux.yml
+++ b/.github/workflows/edenfs_linux.yml
@@ -25,14 +25,16 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests ninja
     - name: Fetch cmake
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests cmake
+    - name: Fetch blake3
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests blake3
     - name: Fetch cpptoml
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests cpptoml
+    - name: Fetch fmt
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fmt
     - name: Fetch gflags
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests gflags
     - name: Fetch glog
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests glog
-    - name: Fetch fmt
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fmt
     - name: Fetch googletest
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests googletest
     - name: Fetch python-six
@@ -93,6 +95,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests folly
     - name: Fetch fizz
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fizz
+    - name: Fetch mvfst
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests mvfst
     - name: Fetch wangle
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests wangle
     - name: Fetch fbthrift
@@ -101,94 +105,94 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fb303
     - name: Fetch rust-shed
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests rust-shed
-    - name: Fetch sapling
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests sapling
     - name: Fetch edencommon
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests edencommon
     - name: Build ninja
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests ninja
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests ninja
     - name: Build cmake
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests cmake
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests cmake
+    - name: Build blake3
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests blake3
     - name: Build cpptoml
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests cpptoml
-    - name: Build gflags
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests gflags
-    - name: Build glog
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests glog
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests cpptoml
     - name: Build fmt
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fmt
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests fmt
+    - name: Build gflags
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests gflags
+    - name: Build glog
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests glog
     - name: Build googletest
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests googletest
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests googletest
     - name: Build python-six
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests python-six
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests python-six
     - name: Build zstd
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests zstd
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests zstd
     - name: Build boost
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests boost
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests boost
     - name: Build double-conversion
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests double-conversion
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests double-conversion
     - name: Build libevent
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libevent
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests libevent
     - name: Build lz4
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests lz4
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests lz4
     - name: Build snappy
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests snappy
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests snappy
     - name: Build libgit2
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libgit2
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests libgit2
     - name: Build python-ptyprocess
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests python-ptyprocess
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests python-ptyprocess
     - name: Build pexpect
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests pexpect
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests pexpect
     - name: Build bz2
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests bz2
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests bz2
     - name: Build python-filelock
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests python-filelock
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests python-filelock
     - name: Build python-toml
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests python-toml
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests python-toml
     - name: Build re2
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests re2
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests re2
     - name: Build rocksdb
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests rocksdb
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests rocksdb
     - name: Build sqlite3
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests sqlite3
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests sqlite3
     - name: Build zlib
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests zlib
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests zlib
     - name: Build autoconf
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests autoconf
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests autoconf
     - name: Build automake
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests automake
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests automake
     - name: Build libtool
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libtool
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests libtool
     - name: Build nghttp2
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests nghttp2
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests nghttp2
     - name: Build libcurl
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libcurl
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests libcurl
     - name: Build libffi
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libffi
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests libffi
     - name: Build ncurses
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests ncurses
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests ncurses
     - name: Build python
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests python
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests python
     - name: Build libsodium
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libsodium
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests libsodium
     - name: Build xz
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests xz
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests xz
     - name: Build folly
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests folly
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests folly
     - name: Build fizz
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fizz
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests fizz
+    - name: Build mvfst
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests mvfst
     - name: Build wangle
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests wangle
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests wangle
     - name: Build fbthrift
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fbthrift
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests fbthrift
     - name: Build fb303
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fb303
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests fb303
     - name: Build rust-shed
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests rust-shed
-    - name: Build sapling
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests sapling
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests rust-shed
     - name: Build edencommon
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests edencommon
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --clean-intermediate --no-tests edencommon
     - name: Build eden
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. eden  --project-install-prefix eden:/usr/local
     - name: Copy artifacts

--- a/.github/workflows/mononoke_linux.yml
+++ b/.github/workflows/mononoke_linux.yml
@@ -59,18 +59,20 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libtool
     - name: Fetch libsodium
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libsodium
-    - name: Fetch libffi
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libffi
-    - name: Fetch ncurses
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests ncurses
-    - name: Fetch python
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests python
     - name: Fetch xz
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests xz
     - name: Fetch folly
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests folly
     - name: Fetch fizz
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fizz
+    - name: Fetch mvfst
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests mvfst
+    - name: Fetch libffi
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libffi
+    - name: Fetch ncurses
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests ncurses
+    - name: Fetch python
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests python
     - name: Fetch wangle
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests wangle
     - name: Fetch fbthrift
@@ -117,18 +119,20 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libtool
     - name: Build libsodium
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libsodium
-    - name: Build libffi
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libffi
-    - name: Build ncurses
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests ncurses
-    - name: Build python
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests python
     - name: Build xz
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests xz
     - name: Build folly
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests folly
     - name: Build fizz
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fizz
+    - name: Build mvfst
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests mvfst
+    - name: Build libffi
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libffi
+    - name: Build ncurses
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests ncurses
+    - name: Build python
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests python
     - name: Build wangle
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests wangle
     - name: Build fbthrift

--- a/.github/workflows/mononoke_mac.yml
+++ b/.github/workflows/mononoke_mac.yml
@@ -63,6 +63,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests folly
     - name: Fetch fizz
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fizz
+    - name: Fetch mvfst
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests mvfst
     - name: Fetch wangle
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests wangle
     - name: Fetch fbthrift
@@ -115,6 +117,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests folly
     - name: Build fizz
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fizz
+    - name: Build mvfst
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests mvfst
     - name: Build wangle
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests wangle
     - name: Build fbthrift

--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -933,7 +933,8 @@ class GenerateGitHubActionsCmd(ProjectCmdBase):
         # We do this by looking at the builder type in the manifest file
         # rather than creating a builder and checking its type because we
         # don't know enough to create the full builder instance here.
-        if manifest.get("build", "builder", ctx=manifest_ctx) == "nop":
+        builder_name = manifest.get("build", "builder", ctx=manifest_ctx)
+        if builder_name == "nop":
             return None
 
         # We want to be sure that we're running things with python 3
@@ -1039,18 +1040,24 @@ jobs:
             main_repo_url = manifest.get_repo_url(manifest_ctx)
             has_same_repo_dep = False
 
+            # Add the rust dep which doesn't have a manifest
             for m in projects:
-                if m != manifest:
-                    if m.name == "rust":
-                        out.write("    - name: Install Rust Stable\n")
-                        out.write("      uses: dtolnay/rust-toolchain@stable\n")
-                    else:
-                        ctx = loader.ctx_gen.get_context(m.name)
-                        if m.get_repo_url(ctx) != main_repo_url:
-                            out.write("    - name: Fetch %s\n" % m.name)
-                            out.write(
-                                f"      run: {getdepscmd}{allow_sys_arg} fetch --no-tests {m.name}\n"
-                            )
+                if m == manifest:
+                    continue
+                mbuilder_name = m.get("build", "builder", ctx=manifest_ctx)
+                if ( m.name == "rust" or builder_name == "cargo" or mbuilder_name == "cargo"):
+                    out.write("    - name: Install Rust Stable\n")
+                    out.write("      uses: dtolnay/rust-toolchain@stable\n")
+                    break
+
+            # Normal deps that have manifests
+            for m in projects:
+                if m == manifest or m.name == "rust":
+                    continue
+                ctx = loader.ctx_gen.get_context(m.name)
+                if m.get_repo_url(ctx) != main_repo_url:
+                    out.write("    - name: Fetch %s\n" % m.name)
+                    out.write(f"      run: {getdepscmd}{allow_sys_arg} fetch --no-tests {m.name}\n")
 
             for m in projects:
                 if m != manifest:
@@ -1081,8 +1088,12 @@ jobs:
             if has_same_repo_dep:
                 no_deps_arg = "--no-deps "
 
+            no_tests_arg = ""
+            if not args.enable_tests:
+                no_tests_arg = "--no-tests "
+
             out.write(
-                f"      run: {getdepscmd}{allow_sys_arg} build {no_deps_arg}--src-dir=. {manifest.name} {project_prefix}\n"
+                f"      run: {getdepscmd}{allow_sys_arg} build {no_tests_arg}{no_deps_arg}--src-dir=. {manifest.name} {project_prefix}\n"
             )
 
             out.write("    - name: Copy artifacts\n")
@@ -1106,7 +1117,7 @@ jobs:
             out.write("        name: %s\n" % manifest.name)
             out.write("        path: _artifacts\n")
 
-            if manifest.get("github.actions", "run_tests", ctx=manifest_ctx) != "off":
+            if args.enable_tests and manifest.get("github.actions", "run_tests", ctx=manifest_ctx) != "off":
                 out.write("    - name: Test %s\n" % manifest.name)
                 out.write(
                     f"      run: {getdepscmd}{allow_sys_arg} test --src-dir=. {manifest.name} {project_prefix}\n"

--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -795,6 +795,12 @@ class BuildCmd(ProjectCmdBase):
             action="store_true",
             default=False,
         )
+        parser.add_argument(
+            "--clean-intermediate",
+            help="Clean up intermediate files if possible to reduce disk usage",
+            action="store_true",
+            default=False,
+        )
 
 
 @cmd("fixup-dyn-deps", "Adjusts dynamic dependencies for packaging purposes")
@@ -1059,6 +1065,11 @@ jobs:
                     out.write("    - name: Fetch %s\n" % m.name)
                     out.write(f"      run: {getdepscmd}{allow_sys_arg} fetch --no-tests {m.name}\n")
 
+            if build_opts.clean_intermediate:
+                clean_intermediate = "--clean-intermediate "
+            else:
+                clean_intermediate = ""
+
             for m in projects:
                 if m != manifest:
                     if m.name == "rust":
@@ -1072,7 +1083,7 @@ jobs:
                             has_same_repo_dep = True
                         out.write("    - name: Build %s\n" % m.name)
                         out.write(
-                            f"      run: {getdepscmd}{allow_sys_arg} build {src_dir_arg}--no-tests {m.name}\n"
+                            f"      run: {getdepscmd}{allow_sys_arg} build {src_dir_arg}{clean_intermediate}--no-tests {m.name}\n"
                         )
 
             out.write("    - name: Build %s\n" % manifest.name)
@@ -1165,6 +1176,12 @@ jobs:
             type=str,
             help="add a prefix to all job names",
             default=None,
+        )
+        parser.add_argument(
+            "--clean-intermediate",
+            help="Clean up intermediate files if possible to reduce disk usage",
+            action="store_true",
+            default=False,
         )
 
 

--- a/build/fbcode_builder/getdeps/builder.py
+++ b/build/fbcode_builder/getdeps/builder.py
@@ -136,6 +136,11 @@ class BuilderBase(object):
         self._prepare(install_dirs=install_dirs, reconfigure=reconfigure)
         self._build(install_dirs=install_dirs, reconfigure=reconfigure)
 
+        if self.build_opts.clean_intermediate:
+            # don't clean --src-dir=. case as user may want to build again or run tests on the build
+            if self.src_dir.startswith(self.build_opts.scratch_dir) and os.path.isdir(self.build_dir):
+                shutil.rmtree(self.build_dir)
+
         # On Windows, emit a wrapper script that can be used to run build artifacts
         # directly from the build directory, without installing them.  On Windows $PATH
         # needs to be updated to include all of the directories containing the runtime

--- a/build/fbcode_builder/getdeps/buildopts.py
+++ b/build/fbcode_builder/getdeps/buildopts.py
@@ -51,6 +51,7 @@ class BuildOptions(object):
         lfs_path=None,
         shared_libs: bool = False,
         facebook_internal=None,
+        clean_intermediate: bool = False,
     ) -> None:
         """fbcode_builder_dir - the path to either the in-fbsource fbcode_builder dir,
                              or for shipit-transformed repos, the build dir that
@@ -65,6 +66,7 @@ class BuildOptions(object):
         use_shipit - use real shipit instead of the simple shipit transformer
         vcvars_path - Path to external VS toolchain's vsvarsall.bat
         shared_libs - whether to build shared libraries
+        clean_intermediate - whether to clean up intermediate build files to save runner disk space
         """
 
         if not install_dir:
@@ -103,6 +105,7 @@ class BuildOptions(object):
         self.allow_system_packages = allow_system_packages
         self.lfs_path = lfs_path
         self.shared_libs = shared_libs
+        self.clean_intermediate = clean_intermediate
 
         lib_path = None
         if self.is_darwin():
@@ -602,6 +605,7 @@ def setup_build_options(args, host_type=None) -> BuildOptions:
             "allow_system_packages",
             "lfs_path",
             "shared_libs",
+            "clean_intermediate"
         }
     }
 

--- a/build/fbcode_builder/manifests/eden
+++ b/build/fbcode_builder/manifests/eden
@@ -5,7 +5,7 @@ shipit_project = eden
 shipit_fbcode_builder = true
 
 [git]
-repo_url = https://github.com/facebookexperimental/eden.git
+repo_url = https://github.com/facebook/sapling.git
 
 [github.actions]
 run_tests = off
@@ -30,6 +30,7 @@ pexpect
 python-toml
 python-filelock
 edencommon
+rust-shed
 
 [dependencies.fbsource=on]
 rust

--- a/build/fbcode_builder/manifests/mononoke
+++ b/build/fbcode_builder/manifests/mononoke
@@ -5,7 +5,7 @@ shipit_project = eden
 shipit_fbcode_builder = true
 
 [git]
-repo_url = https://github.com/facebookexperimental/eden.git
+repo_url = https://github.com/facebook/sapling.git
 
 [build.not(os=windows)]
 builder = cargo


### PR DESCRIPTION
regenerate eden getdeps with rust-shed dependency

Eden manifest is missing the rust-shed dependency and still has old repo name

Fix and regenerate

Test Plan:

`./build/fbcode_builder/getdeps.py --allow-system-packages generate-github-actions --os-type=linux --src-dir=. --output-dir=.github/workflows --job-name "EdenFS " --job-file-prefix=edenfs_ eden`

Tested by the later PRs in this stack that fix eden build issues

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/690).
* #695
* #694
* #693
* #692
* #696
* #691
* __->__ #690
* #689
* #682