### PR TITLE
[isl] Add badge for GitHub PR review decision

### DIFF
--- a/addons/isl-server/src/github/generated/graphql.ts
+++ b/addons/isl-server/src/github/generated/graphql.ts
@@ -24257,7 +24257,7 @@ export type YourPullRequestsQueryVariables = Exact<{
 }>;
 
 
-export type YourPullRequestsQueryData = { __typename?: 'Query', search: { __typename?: 'SearchResultItemConnection', nodes?: Array<{ __typename?: 'App' } | { __typename?: 'Discussion' } | { __typename?: 'Issue' } | { __typename?: 'MarketplaceListing' } | { __typename?: 'Organization' } | { __typename: 'PullRequest', number: number, title: string, body: string, state: PullRequestState, isDraft: boolean, url: string, comments: { __typename?: 'IssueCommentConnection', totalCount: number }, commits: { __typename?: 'PullRequestCommitConnection', nodes?: Array<{ __typename?: 'PullRequestCommit', commit: { __typename?: 'Commit', statusCheckRollup?: { __typename?: 'StatusCheckRollup', state: StatusState } | null } } | null> | null } } | { __typename?: 'Repository' } | { __typename?: 'User' } | null> | null } };
+export type YourPullRequestsQueryData = { __typename?: 'Query', search: { __typename?: 'SearchResultItemConnection', nodes?: Array<{ __typename?: 'App' } | { __typename?: 'Discussion' } | { __typename?: 'Issue' } | { __typename?: 'MarketplaceListing' } | { __typename?: 'Organization' } | { __typename: 'PullRequest', number: number, title: string, body: string, state: PullRequestState, isDraft: boolean, url: string, reviewDecision?: PullRequestReviewDecision | null, comments: { __typename?: 'IssueCommentConnection', totalCount: number }, commits: { __typename?: 'PullRequestCommitConnection', nodes?: Array<{ __typename?: 'PullRequestCommit', commit: { __typename?: 'Commit', statusCheckRollup?: { __typename?: 'StatusCheckRollup', state: StatusState } | null } } | null> | null } } | { __typename?: 'Repository' } | { __typename?: 'User' } | null> | null } };
 
 
 export const YourPullRequestsQuery = `
@@ -24272,6 +24272,7 @@ export const YourPullRequestsQuery = `
         state
         isDraft
         url
+        reviewDecision
         comments {
           totalCount
         }

--- a/addons/isl-server/src/github/githubCodeReviewProvider.ts
+++ b/addons/isl-server/src/github/githubCodeReviewProvider.ts
@@ -7,7 +7,11 @@
 
 import type {CodeReviewProvider} from '../CodeReviewProvider';
 import type {Logger} from '../logger';
-import type {YourPullRequestsQueryData, YourPullRequestsQueryVariables} from './generated/graphql';
+import type {
+  PullRequestReviewDecision,
+  YourPullRequestsQueryData,
+  YourPullRequestsQueryVariables,
+} from './generated/graphql';
 import type {CodeReviewSystem, DiffSignalSummary, DiffId, Disposable, Result} from 'isl/src/types';
 
 import {PullRequestState, StatusState, YourPullRequestsQuery} from './generated/graphql';
@@ -25,6 +29,7 @@ export type GitHubDiffSummary = {
   commentCount: number;
   anyUnresolvedComments: false;
   signalSummary?: DiffSignalSummary;
+  reviewDecision?: PullRequestReviewDecision;
 };
 
 type GitHubCodeReviewSystem = CodeReviewSystem & {type: 'github'};
@@ -88,6 +93,7 @@ export class GitHubCodeReviewProvider implements CodeReviewProvider {
               signalSummary: githubStatusRollupStateToCIStatus(
                 summary.commits.nodes?.[0]?.commit.statusCheckRollup?.state,
               ),
+              reviewDecision: summary.reviewDecision ?? undefined,
             });
           }
         }

--- a/addons/isl-server/src/github/queries/YourPullRequestsQuery.graphql
+++ b/addons/isl-server/src/github/queries/YourPullRequestsQuery.graphql
@@ -9,6 +9,7 @@ query YourPullRequestsQuery($searchQuery: String!, $numToFetch: Int!) {
         state
         isDraft
         url
+        reviewDecision
         comments {
           totalCount
         }

--- a/addons/isl/src/codeReview/github/GitHubPRBadge.css
+++ b/addons/isl/src/codeReview/github/GitHubPRBadge.css
@@ -24,11 +24,19 @@
   background-color: var(--github-neutral-bg);
 }
 
+.github-diff-info {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--halfpad);
+}
+
 .github-diff-status {
   font-weight: bold;
   border-radius: 10px;
   padding: 3px 8px;
   font-size: 70%;
+  white-space: nowrap;
 }
 .github-diff-badge .codicon {
   font-size: 90%;
@@ -39,4 +47,21 @@
 
 .github-diff-status .tooltip-creator {
   align-items: center;
+}
+
+.github-review-decision {
+  border-radius: 10px;
+  padding: 3px 8px;
+  font-size: 70%;
+  white-space: nowrap;
+}
+
+.github-review-decision-APPROVED {
+  background-color: var(--github-open-bg);
+}
+.github-review-decision-CHANGES_REQUESTED {
+  background-color: var(--github-closed-bg);
+}
+.github-review-decision-REVIEW_REQUIRED {
+  background-color: var(--github-neutral-bg);
 }

--- a/addons/isl/src/codeReview/github/github.tsx
+++ b/addons/isl/src/codeReview/github/github.tsx
@@ -14,7 +14,7 @@ import {Tooltip} from '../../Tooltip';
 import {t, T} from '../../i18n';
 import {GhStackSubmitOperation} from '../../operations/GhStackSubmitOperation';
 import {PrSubmitOperation} from '../../operations/PrSubmitOperation';
-import {PullRequestState} from 'isl-server/src/github/generated/graphql';
+import {PullRequestReviewDecision, PullRequestState} from 'isl-server/src/github/generated/graphql';
 import {Icon} from 'shared/Icon';
 
 import './GitHubPRBadge.css';
@@ -39,13 +39,18 @@ export class GithubUICodeReviewProvider implements UICodeReviewProvider {
       return null;
     }
     return (
-      <div
-        className={'github-diff-status' + (diff?.state ? ` github-diff-status-${diff.state}` : '')}>
-        <Tooltip title={t('Click to open Pull Request in GitHub')} delayMs={500}>
-          {diff && <Icon icon={iconForPRState(diff.state)} />}
-          {diff?.state && <PRStateLabel state={diff.state} />}
-          {children}
-        </Tooltip>
+      <div className="github-diff-info">
+        <div
+          className={
+            'github-diff-status' + (diff?.state ? ` github-diff-status-${diff.state}` : '')
+          }>
+          <Tooltip title={t('Click to open Pull Request in GitHub')} delayMs={500}>
+            {diff && <Icon icon={iconForPRState(diff.state)} />}
+            {diff?.state && <PRStateLabel state={diff.state} />}
+            {children}
+          </Tooltip>
+        </div>
+        {diff?.reviewDecision && <ReviewDecision decision={diff.reviewDecision} />}
       </div>
     );
   }
@@ -123,4 +128,25 @@ function PRStateLabel({state}: {state: BadgeState}) {
     default:
       return <T>{state}</T>;
   }
+}
+
+function reviewDecisionLabel(decision: PullRequestReviewDecision) {
+  switch (decision) {
+    case PullRequestReviewDecision.Approved:
+      return <T>Approved</T>;
+    case PullRequestReviewDecision.ChangesRequested:
+      return <T>Changes Requested</T>;
+    case PullRequestReviewDecision.ReviewRequired:
+      return <T>Review Required</T>;
+    default:
+      return <T>{decision}</T>;
+  }
+}
+
+function ReviewDecision({decision}: {decision: PullRequestReviewDecision}) {
+  return (
+    <div className={`github-review-decision github-review-decision-${decision}`}>
+      {reviewDecisionLabel(decision)}
+    </div>
+  );
 }


### PR DESCRIPTION
[isl] Add badge for GitHub PR review decision

## Summary:

This diff relates to [Issue #652](https://github.com/facebook/sapling/issues/652).

It's useful to know the review state of a PR. We do this for diffs internally, and in fact that's the main "status" we show. GitHub differentiates between "Open/Closed/Merged" but separately differentiates independent review states "Approved/Changes Requested/Review Required".

We should show this review state as well as status.

I considered merging the two, so it's more like we have internally. But I think it makes more sense to keep this separate, to be true to GitHub's data model.

## Test Plan: 

<img width="304" alt="Screenshot 2023-08-01 at 11 33 44 AM" src="https://github.com/facebook/sapling/assets/1762690/2960f898-42f0-43eb-8790-6d0594f54034">
<img width="372" alt="Screenshot 2023-08-01 at 11 33 55 AM" src="https://github.com/facebook/sapling/assets/1762690/5b3d7fc3-669d-463c-85f6-6ba964be6578">

I tried a couple of other UI variants, including one where the review states are not badge but just text. This would have matched GitHub's design more closely. But I couldn't make it fit quite right. I felt like the badges are easier to read at a glance. Happy to get feedback about this though.
