### PR TITLE
fix(build): fix version number when building with old Sapling

### DIFF
--- a/eden/scm/setup.py
+++ b/eden/scm/setup.py
@@ -308,6 +308,9 @@ def filterhgerr(err):
             and not e.startswith(b"warning: Not importing")
             and not e.startswith(b"obsolete feature not enabled")
             and not e.startswith(b"devel-warn:")
+            # Ignore hints from building hg with an old hg
+            and not e.startswith(b"hint[old-version]")
+            and not e.startswith(b"hint[hint-ack]")
         )
     ]
     return b"\n".join(b"  " + e for e in err)


### PR DESCRIPTION
fix(build): fix version number when building with old Sapling

Summary:
Fix a bug (#711) in Sapling that causes `sl --version` to not work when
building Sapling with an old version of Sapling.

The way `setup.py` gets the version number is by first **finding the path to
the vc exe** (`findhg`) and then running the `sl log ...` (or `git show ...`).  `findhg`
interprets the `hint[old-version]` as an error and aborts.

This commit fixes the bug by simply adding `hint[old-version]` to `filterhgerr`

Test Plan:
It doesn't seem straightforward to write an automated test for this since we
don't have tests for `setup.py`.  The manual steps to test would be:

1. get an old `sl`
```sh
$ sl go "bsearch(date('-50'),main)"
```
    - verify it's old by running any `sl` command and make sure you get
      `hint[old-version]: WARNING! ...`
2. build Sapling (`make oss`)
3. `./sl --version`

Before this commit:

```sh
$ sl --version
Saping 4.4.2
```

This commit:
```sh
$ sl --version
Sapling <date-and-stuff>
```

Closes #711
