### PR TITLE
github: migrate docker from deprecated nodesource script, fixes 60 second delay

### DIFF
--- a/.github/workflows/sapling-cli-ubuntu-20.04.Dockerfile
+++ b/.github/workflows/sapling-cli-ubuntu-20.04.Dockerfile
@@ -7,13 +7,16 @@ ENV TZ=Etc/UTC
 
 # Update and install some basic packages to register a PPA.
 RUN apt-get -y update
-RUN apt-get -y install curl git
+RUN apt-get -y install ca-certificates curl git gnupg
 
 # Use a PPA to ensure a specific version of Node (the default Node on
 # Ubuntu 20.04 is v10, which is too old):
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
 
 # Now we can install the bulk of the packages:
+RUN apt-get -y update
 RUN apt-get -y install nodejs pkg-config libssl-dev cython3 make g++ dpkg-dev python3.8 python3.8-dev python3.8-distutils
 
 # Unfortunately, we cannot `apt install cargo` because at the time of this

--- a/.github/workflows/sapling-cli-ubuntu-22.04.Dockerfile
+++ b/.github/workflows/sapling-cli-ubuntu-22.04.Dockerfile
@@ -7,13 +7,16 @@ ENV TZ=Etc/UTC
 
 # Update and install some basic packages to register a PPA.
 RUN apt-get -y update
-RUN apt-get -y install curl git
+RUN apt-get -y install ca-certificates curl git gnupg
 
 # Use a PPA to ensure a specific version of Node (the default Node on
 # Ubuntu 20.04 is v10, which is too old):
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
 
 # Now we can install the bulk of the packages:
+RUN apt-get -y update
 RUN apt-get -y install nodejs pkg-config libssl-dev cython3 make g++ dpkg-dev python3.10 python3.10-dev python3.10-distutils
 
 # Unfortunately, we cannot `apt install cargo` because at the time of this


### PR DESCRIPTION
github: migrate docker from deprecated nodesource script, fixes 60 second delay

nodesource have added a 60 second delay in their setup_XX scripts to encourage people to move to reference their apt repo directly.

update the docker file, as I found the 60 second delay annoying when adding the gh cli to the image in the next change

Test plan:

Run a build
```
docker build -t sapling-cli-ubuntu-22.04 -f .github/workflows/sapling-cli-ubuntu-22.04.Dockerfile .
```

Before,  get the 60 second wait message from the nodesource script
```
--> 657ed25e358a
STEP 6/17: RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -

================================================================================
▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
================================================================================

                           SCRIPT DEPRECATION WARNING


  This script, located at https://deb.nodesource.com/setup_X, used to
  install Node.js is deprecated now and will eventually be made inactive.

  Please visit the NodeSource distributions Github and follow the
  instructions to migrate your repo.
  https://github.com/nodesource/distributions

  The NodeSource Node.js Linux distributions GitHub repository contains
  information about which versions of Node.js and which Linux distributions
  are supported and how to install it.
  https://github.com/nodesource/distributions


                          SCRIPT DEPRECATION WARNING

================================================================================
▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
================================================================================

TO AVOID THIS WAIT MIGRATE THE SCRIPT
Continuing in 60 seconds (press Ctrl-C to abort) ...
```

After, the 60 second wait has gone

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/728).
* #729
* __->__ #728