### PR TITLE
github: install gh cli in the dockerfile

### DIFF
--- a/.github/workflows/sapling-cli-ubuntu-20.04.Dockerfile
+++ b/.github/workflows/sapling-cli-ubuntu-20.04.Dockerfile
@@ -9,6 +9,11 @@ ENV TZ=Etc/UTC
 RUN apt-get -y update
 RUN apt-get -y install ca-certificates curl git gnupg
 
+# Install the github cli so that verify-addons-folder.py tests can find it
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg;
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null;
+RUN apt update && apt install -y gh;
+
 # Use a PPA to ensure a specific version of Node (the default Node on
 # Ubuntu 20.04 is v10, which is too old):
 RUN mkdir -p /etc/apt/keyrings

--- a/.github/workflows/sapling-cli-ubuntu-20.04.Dockerfile
+++ b/.github/workflows/sapling-cli-ubuntu-20.04.Dockerfile
@@ -7,13 +7,16 @@ ENV TZ=Etc/UTC
 
 # Update and install some basic packages to register a PPA.
 RUN apt-get -y update
-RUN apt-get -y install curl git
+RUN apt-get -y install ca-certificates curl git gnupg
 
 # Use a PPA to ensure a specific version of Node (the default Node on
 # Ubuntu 20.04 is v10, which is too old):
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
 
 # Now we can install the bulk of the packages:
+RUN apt-get -y update
 RUN apt-get -y install nodejs pkg-config libssl-dev cython3 make g++ dpkg-dev python3.8 python3.8-dev python3.8-distutils
 
 # Unfortunately, we cannot `apt install cargo` because at the time of this

--- a/.github/workflows/sapling-cli-ubuntu-22.04.Dockerfile
+++ b/.github/workflows/sapling-cli-ubuntu-22.04.Dockerfile
@@ -7,13 +7,16 @@ ENV TZ=Etc/UTC
 
 # Update and install some basic packages to register a PPA.
 RUN apt-get -y update
-RUN apt-get -y install curl git
+RUN apt-get -y install ca-certificates curl git gnupg
 
 # Use a PPA to ensure a specific version of Node (the default Node on
 # Ubuntu 20.04 is v10, which is too old):
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
 
 # Now we can install the bulk of the packages:
+RUN apt-get -y update
 RUN apt-get -y install nodejs pkg-config libssl-dev cython3 make g++ dpkg-dev python3.10 python3.10-dev python3.10-distutils
 
 # Unfortunately, we cannot `apt install cargo` because at the time of this

--- a/.github/workflows/sapling-cli-ubuntu-22.04.Dockerfile
+++ b/.github/workflows/sapling-cli-ubuntu-22.04.Dockerfile
@@ -9,6 +9,11 @@ ENV TZ=Etc/UTC
 RUN apt-get -y update
 RUN apt-get -y install ca-certificates curl git gnupg
 
+# Install the github cli so that verify-addons-folder.py tests can find it
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg;
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null;
+RUN apt update && apt install -y gh;
+
 # Use a PPA to ensure a specific version of Node (the default Node on
 # Ubuntu 20.04 is v10, which is too old):
 RUN mkdir -p /etc/apt/keyrings


### PR DESCRIPTION
github: install gh cli in the dockerfile

install the github cli as sapling and review stack need it

Currently the verify-addons-folder.py CI is failing due to missing gh cli with:

```
spawn gh ENOENT
    at Process.ChildProcess._handle.onexit (node:internal/child_process:285:19)
    at onErrorNT (node:internal/child_process:485:16)
    at processTicksAndRejections (node:internal/process/task_queues:83:21)
    at /__w/sapling/sapling/addons/isl-server/src/github/queryGraphQL.ts:50:23
    at processTicksAndRejections (node:internal/process/task_queues:96:5))
    at new NodeError (node:internal/errors:387:5)
    at TypedEventEmitter.emit (node:events:502:17)
    at GitHubCodeReviewProvider.<anonymous> (/__w/sapling/sapling/addons/isl-server/src/github/githubCodeReviewProvider.ts:74:36)
    at Generator.throw (<anonymous>)
    at rejected (/__w/sapling/sapling/addons/isl-server/src/github/githubCodeReviewProvider.ts:12:65)
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  code: 'ERR_UNHANDLED_ERROR',
  context: Error: GhNotInstalledError: Error: Command failed with ENOENT: gh api graphql -f searchQuery=repo:facebook/sapling is:pr author:@me -F numToFetch=100 --hostname github.com -f query=
```

Once the docker images are rebuilt we should start to see something different!

Test Plan:

Before, gh cli missing from the image
```
docker build -t sapling-cli-ubuntu-22.04 -f sapling-cli-ubuntu-22.04.Dockerfile .
docker run -ti sapling-cli-ubuntu-22.04 gh --help
Error: crun: executable file `gh` not found in $PATH: No such file or directory: OCI runtime attempted to invoke a command that was not found

```

After, image contains gh cli
```
docker build -t sapling-cli-ubuntu-22.04 -f sapling-cli-ubuntu-22.04.Dockerfile .
docker run -ti sapling-cli-ubuntu-22.04 gh --help
...
LEARN MORE
  Use 'gh <command> <subcommand> --help' for more information about a command.
  Read the manual at https://cli.github.com/manual

```

Repeated above with the 20.04 image, same results

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/729).
* __->__ #729
* #728