### PR TITLE
Fix subcommands list in github extension's `sl pr -h` command

### DIFF
--- a/eden/scm/edenscm/ext/github/__init__.py
+++ b/eden/scm/edenscm/ext/github/__init__.py
@@ -67,7 +67,7 @@ def extsetup(ui):
 @command(
     "pr",
     [],
-    _("<submit|get|link|unlink|...>"),
+    _("<submit|pull|list|link|unlink|...>"),
 )
 def pull_request_command(ui, repo, *args, **opts):
     """exchange local commit data with GitHub pull requests"""


### PR DESCRIPTION
Current behavior:
```
$ sl pr -h
sl pr <submit|get|link|unlink|...>
[...]
```

The issue is there is no `get` command in in Github pr