### PR TITLE
fix eden fs build with GCC 13.2.1

### DIFF
--- a/build/fbcode_builder/manifests/rocksdb
+++ b/build/fbcode_builder/manifests/rocksdb
@@ -2,8 +2,8 @@
 name = rocksdb
 
 [download]
-url = https://github.com/facebook/rocksdb/archive/refs/tags/v7.7.3.tar.gz
-sha256 = b8ac9784a342b2e314c821f6d701148912215666ac5e9bdbccd93cf3767cb611
+url = https://github.com/facebook/rocksdb/archive/refs/tags/v8.7.3.zip
+sha256 = 36c06b61dc167f2455990d60dd88d734b73aa8c4dfc095243efd0243834c6cd3
 
 [dependencies]
 lz4
@@ -11,7 +11,7 @@ snappy
 
 [build]
 builder = cmake
-subdir = rocksdb-7.7.3
+subdir = rocksdb-8.7.3
 
 [cmake.defines]
 WITH_SNAPPY=ON
@@ -22,10 +22,6 @@ WITH_BENCHMARK_TOOLS=OFF
 # and there's no clear way to make it pick the shared gflags
 # so just turn it off.
 WITH_GFLAGS=OFF
-# mac pro machines don't have some of the newer features that
-# rocksdb enables by default; ask it to disable their use even
-# when building on new hardware
-PORTABLE = ON
 # Disable the use of -Werror
 FAIL_ON_WARNINGS = OFF
 

--- a/eden/fs/store/BackingStoreType.h
+++ b/eden/fs/store/BackingStoreType.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <exception>
 #include <string>
 


### PR DESCRIPTION
fix eden fs build with GCC 13.2.1

Fixing two problems that broke builds on Fedora 38, which comes with GCC 13.2.1

   * GCC 13.2.1 can't build the old rocksdb, so update the version
   * there was a missing include in BackingStoreType.h

Test plan:

build locally with:
```
./build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. --project-install-prefix eden:/usr/local eden
```

Before, eden fs build breaks at rocksdb on uint8_t
```
FAILED: CMakeFiles/rocksdb.dir/table/block_based/data_block_hash_index.cc.o
/usr/bin/c++ -DLZ4 -DOS_LINUX -DROCKSDB_FALLOCATE_PRESENT -DROCKSDB_LIB_IO_POSIX -DROCKSDB_MALLOC_USABLE_SIZE -DROCKSDB_NO_DYNAMIC_EXTENSION -DROCKSDB_PLATFORM_POSIX -DROCKSDB_PTHREAD_ADAPTIVE_MUTEX -DROCKSDB_RANGESYNC_PRESENT -DROCKSDB_SCHED_GETCPU_PRESENT -DSNAPPY -I/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/extracted/rocksdb-v7.7.3.tar.gz/rocksdb-7.7.3 -I/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/extracted/rocksdb-v7.7.3.tar.gz/rocksdb-7.7.3/include -isystem /home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/extracted/rocksdb-v7.7.3.tar.gz/rocksdb-7.7.3/third-party/gtest-1.8.1/fused-src -W -Wextra -Wall -pthread -Wsign-compare -Wshadow -Wno-unused-parameter -Wno-unused-variable -Woverloaded-virtual -Wnon-virtual-dtor -Wno-missing-field-initializers -Wno-strict-aliasing -Wno-invalid-offsetof -fno-omit-frame-pointer -momit-leaf-frame-pointer -fno-builtin-memcmp -O2 -g -DNDEBUG -std=gnu++17 -MD -MT CMakeFiles/rocksdb.dir/table/block_based/data_block_hash_index.cc.o -MF CMakeFiles/rocksdb.dir/table/block_based/data_block_hash_index.cc.o.d -o CMakeFiles/rocksdb.dir/table/block_based/data_block_hash_index.cc.o -c /home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/extracted/rocksdb-v7.7.3.tar.gz/rocksdb-7.7.3/table/block_based/data_block_hash_index.cc
In file included from /home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/extracted/rocksdb-v7.7.3.tar.gz/rocksdb-7.7.3/table/block_based/data_block_hash_index.cc:9:
/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/extracted/rocksdb-v7.7.3.tar.gz/rocksdb-7.7.3/table/block_based/data_block_hash_index.h:65:7: error: ‘uint8_t’ does not name a type
   65 | const uint8_t kNoEntry = 255;
      |       ^~~~~~~
/home/alex/local/tmp/fridge/fbc
```

After, works
