### PR TITLE
fix CI warning about node12 by updating actions/checkout version

### DIFF
--- a/.github/workflows/edenfs_linux.yml
+++ b/.github/workflows/edenfs_linux.yml
@@ -10,11 +10,14 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Show disk space at start
       run: df -h
     - name: Free up disk space

--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -1023,7 +1023,7 @@ jobs:
                 out.write("    - name: Disable autocrlf\n")
                 out.write("      run: git config --system core.autocrlf false\n")
 
-            out.write("    - uses: actions/checkout@v2\n")
+            out.write("    - uses: actions/checkout@v4\n")
 
             if build_opts.free_up_disk:
                 free_up_disk = "--free-up-disk "

--- a/build/fbcode_builder/manifests/rocksdb
+++ b/build/fbcode_builder/manifests/rocksdb
@@ -2,8 +2,8 @@
 name = rocksdb
 
 [download]
-url = https://github.com/facebook/rocksdb/archive/refs/tags/v7.7.3.tar.gz
-sha256 = b8ac9784a342b2e314c821f6d701148912215666ac5e9bdbccd93cf3767cb611
+url = https://github.com/facebook/rocksdb/archive/refs/tags/v8.6.7.zip
+sha256 = 606fb2c92cf3773615c28f2587a41d920bd42fe2893e7262dab5e37a1f0210fe
 
 [dependencies]
 lz4
@@ -11,7 +11,7 @@ snappy
 
 [build]
 builder = cmake
-subdir = rocksdb-7.7.3
+subdir = rocksdb-8.6.7
 
 [cmake.defines]
 WITH_SNAPPY=ON
@@ -22,10 +22,6 @@ WITH_BENCHMARK_TOOLS=OFF
 # and there's no clear way to make it pick the shared gflags
 # so just turn it off.
 WITH_GFLAGS=OFF
-# mac pro machines don't have some of the newer features that
-# rocksdb enables by default; ask it to disable their use even
-# when building on new hardware
-PORTABLE = ON
 # Disable the use of -Werror
 FAIL_ON_WARNINGS = OFF
 

--- a/eden/fs/store/BackingStoreType.h
+++ b/eden/fs/store/BackingStoreType.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <exception>
 #include <string>
 


### PR DESCRIPTION
fix CI warning about node12 by updating actions/checkout version

Update the actions/checkout version to fix build warning

Test plan:

regenerate actions with:
```
./build/fbcode_builder/getdeps.py --allow-system-packages generate-github-actions --no-tests --free-up-disk --os-type=linux --src-dir=. --output-dir=.github/workflows --job-name "EdenFS " --job-file-prefix=edenfs_ eden
```

Before, CI has warning:
```The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2```

After, warning is gone

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/749).
* #750
* __->__ #749
* #748