### PR TITLE
use system patchelf in eden fs build

### DIFF
--- a/.github/workflows/edenfs_linux.yml
+++ b/.github/workflows/edenfs_linux.yml
@@ -10,11 +10,14 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Show disk space at start
       run: df -h
     - name: Free up disk space

--- a/.github/workflows/edenfs_linux.yml
+++ b/.github/workflows/edenfs_linux.yml
@@ -28,6 +28,8 @@ jobs:
       run: sudo apt-get update
     - name: Install system deps
       run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive eden
+    - name: Install packaging system deps
+      run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive patchelf
     - name: Install Rust Stable
       uses: dtolnay/rust-toolchain@stable
     - name: Fetch ninja

--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -1023,7 +1023,7 @@ jobs:
                 out.write("    - name: Disable autocrlf\n")
                 out.write("      run: git config --system core.autocrlf false\n")
 
-            out.write("    - uses: actions/checkout@v2\n")
+            out.write("    - uses: actions/checkout@v4\n")
 
             if build_opts.free_up_disk:
                 free_up_disk = "--free-up-disk "

--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -497,6 +497,12 @@ class ShowInstDirCmd(ProjectCmdBase):
             manifests = [manifest]
 
         for m in manifests:
+            fetcher = loader.create_fetcher(m)
+            if isinstance(fetcher, SystemPackageFetcher):
+                # We are guaranteed that if the fetcher is set to
+                # SystemPackageFetcher then this item is completely
+                # satisfied by the appropriate system packages
+                continue
             inst_dir = loader.get_project_install_dir_respecting_install_prefix(m)
             print(inst_dir)
 
@@ -1056,6 +1062,11 @@ jobs:
                 out.write(
                     f"      run: {sudo_arg}python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive {manifest.name}\n"
                 )
+                if build_opts.is_linux() or build_opts.is_freebsd():
+                    out.write("    - name: Install packaging system deps\n")
+                    out.write(
+                        f"      run: {sudo_arg}python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive patchelf\n"
+                    )
 
             projects = loader.manifests_in_dependency_order()
 

--- a/build/fbcode_builder/getdeps/dyndeps.py
+++ b/build/fbcode_builder/getdeps/dyndeps.py
@@ -336,16 +336,19 @@ class ElfDeps(DepBase):
         super(ElfDeps, self).__init__(buildopts, install_dirs, strip)
 
         # We need patchelf to rewrite deps, so ensure that it is built...
-        subprocess.check_call([sys.executable, sys.argv[0], "build", "patchelf"])
+        args = [sys.executable, sys.argv[0]]
+        if buildopts.allow_system_packages:
+            args.append("--allow-system-packages")
+        subprocess.check_call(args + ["build", "patchelf"])
+
         # ... and that we know where it lives
-        self.patchelf = os.path.join(
-            os.fsdecode(
-                subprocess.check_output(
-                    [sys.executable, sys.argv[0], "show-inst-dir", "patchelf"]
-                ).strip()
-            ),
-            "bin/patchelf",
-        )
+        patchelf_install = os.fsdecode(subprocess.check_output(args + ["show-inst-dir", "patchelf"]).strip())
+        if not patchelf_install:
+            # its a system package, so we assume it is in the path
+            patchelf_install = "patchelf"
+        else:
+            patchelf_install = os.path.join(patchelf_install, "bin", "patchelf")
+        self.patchelf = patchelf_install
 
     def list_dynamic_deps(self, objfile):
         out = (

--- a/build/fbcode_builder/manifests/rocksdb
+++ b/build/fbcode_builder/manifests/rocksdb
@@ -2,8 +2,8 @@
 name = rocksdb
 
 [download]
-url = https://github.com/facebook/rocksdb/archive/refs/tags/v7.7.3.tar.gz
-sha256 = b8ac9784a342b2e314c821f6d701148912215666ac5e9bdbccd93cf3767cb611
+url = https://github.com/facebook/rocksdb/archive/refs/tags/v8.6.7.zip
+sha256 = 606fb2c92cf3773615c28f2587a41d920bd42fe2893e7262dab5e37a1f0210fe
 
 [dependencies]
 lz4
@@ -11,7 +11,7 @@ snappy
 
 [build]
 builder = cmake
-subdir = rocksdb-7.7.3
+subdir = rocksdb-8.6.7
 
 [cmake.defines]
 WITH_SNAPPY=ON
@@ -22,10 +22,6 @@ WITH_BENCHMARK_TOOLS=OFF
 # and there's no clear way to make it pick the shared gflags
 # so just turn it off.
 WITH_GFLAGS=OFF
-# mac pro machines don't have some of the newer features that
-# rocksdb enables by default; ask it to disable their use even
-# when building on new hardware
-PORTABLE = ON
 # Disable the use of -Werror
 FAIL_ON_WARNINGS = OFF
 

--- a/eden/fs/store/BackingStoreType.h
+++ b/eden/fs/store/BackingStoreType.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <exception>
 #include <string>
 


### PR DESCRIPTION
use system patchelf in eden fs build

Saves us from doing a fetch and build of autoconf, libtool, automake and patchelf during the arfifacts part of CI

Test plan:

run locally with: `/build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --allow-system-packages --strip --src-dir=. eden _artifacts/linux  --project-install-prefix eden:/usr/local --final-install-prefix /usr/local`

Before, builds autoconf, automake, libtool, patchelf from source

After, uses the system installed version

regenerate actions with:`./build/fbcode_builder/getdeps.py --allow-system-packages generate-github-actions --no-tests --free-up-disk --os-type=linux --src-dir=. --output-dir=.github/workflows --job-name "EdenFS " --job-file-prefix=edenfs_ eden`

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/750).
* __->__ #750
* #749
* #748