### PR TITLE
Add option to suppress creating archive branch in Github

### DIFF
--- a/eden/scm/sapling/ext/github/submit.py
+++ b/eden/scm/sapling/ext/github/submit.py
@@ -231,7 +231,7 @@ async def update_commits_in_stack(
             partitions, index, workflow, pr_numbers_and_num_commits, repository, ui
         )
         for index in range(len(partitions))
-    ] + [
+    ] + ([
         add_commit_to_archives(
             oid_to_archive=tip,
             ui=ui,
@@ -239,7 +239,7 @@ async def update_commits_in_stack(
             repository=repository,
             get_gitdir=get_gitdir,
         )
-    ]
+    ] if not ui.configbool('github', 'no-archive', 'false') else [])
     await asyncio.gather(*rewrite_and_archive_requests)
     return 0
 


### PR DESCRIPTION
Add option to suppress creating archive branch in Github

By default, when submitting PRs to Github, Sapling creates a remote branched named `sapling-pr-archive-UserName` that merges together all of the PR commits ever submitted by the named user.

This adds a lot of noise when using tools such as [Git Graph](https://marketplace.visualstudio.com/items?itemName=mhutchie.git-graph), especially for other contributors to the repository.

This PR adds an option to prevent Sapling from creating or updating this branch:
```
sl config --user github.no-archive=on
```
