### PR TITLE
fix mononoke build

### DIFF
--- a/.github/workflows/mononoke_linux.yml
+++ b/.github/workflows/mononoke_linux.yml
@@ -10,11 +10,14 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Show disk space at start
       run: df -h
     - name: Free up disk space
@@ -25,10 +28,10 @@ jobs:
       run: sudo apt-get update
     - name: Install system deps
       run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive mononoke
+    - name: Install packaging system deps
+      run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive patchelf
     - name: Install Rust Stable
       uses: dtolnay/rust-toolchain@stable
-    - name: Fetch lld
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests lld
     - name: Fetch ninja
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests ninja
     - name: Fetch cmake
@@ -89,8 +92,6 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fb303
     - name: Fetch rust-shed
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests rust-shed
-    - name: Build lld
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests lld
     - name: Build ninja
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests ninja
     - name: Build cmake

--- a/.github/workflows/mononoke_mac.yml
+++ b/.github/workflows/mononoke_mac.yml
@@ -10,11 +10,14 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
   build:
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Show disk space at start
       run: df -h
     - name: Free up disk space

--- a/eden/mononoke/commit_rewriting/mononoke_x_repo_sync_job/src/sync.rs
+++ b/eden/mononoke/commit_rewriting/mononoke_x_repo_sync_job/src/sync.rs
@@ -523,7 +523,7 @@ async fn check_if_independent_branch_and_return(
         .commit_graph()
         .ancestors_difference_stream(ctx, branch_tips.clone(), other_branches)
         .await?
-        .map_ok({ move |cs| async move { Ok(cs.load(ctx, blobstore).await?) } })
+        .map_ok(move |cs| async move { Ok(cs.load(ctx, blobstore).await?) })
         .try_buffered(100)
         .try_collect::<Vec<_>>()
         .await?;

--- a/eden/mononoke/git/git_types/src/lib.rs
+++ b/eden/mononoke/git/git_types/src/lib.rs
@@ -7,7 +7,7 @@
 
 #![feature(error_generic_member_access)]
 #![feature(iterator_try_reduce)]
-#![feature(provide_any)]
+#![cfg_attr(fbcode_build, feature(provide_any))]
 
 pub mod mode;
 

--- a/eden/mononoke/mononoke_api/src/errors.rs
+++ b/eden/mononoke/mononoke_api/src/errors.rs
@@ -5,7 +5,6 @@
  * GNU General Public License version 2.
  */
 
-use std::any::Demand;
 use std::backtrace::Backtrace;
 use std::convert::Infallible;
 use std::error::Error as StdError;
@@ -30,9 +29,19 @@ use crate::path::MononokePath;
 #[derive(Clone, Debug)]
 pub struct InternalError(Arc<Error>);
 
+// The cargo build of anyhow disables its backtrace features when using RUSTC_BOOTSTRAP=1
+#[cfg(not(fbcode_build))]
+static DISABLED: Backtrace = Backtrace::disabled();
+
 impl InternalError {
+    #[cfg(fbcode_build)]
     pub fn backtrace(&self) -> &Backtrace {
         self.0.backtrace()
+    }
+
+    #[cfg(not(fbcode_build))]
+    pub fn backtrace(&self) -> &Backtrace {
+        &DISABLED
     }
 }
 
@@ -53,7 +62,8 @@ impl StdError for InternalError {
         Some(&**self.0)
     }
 
-    fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
+    #[cfg(fbcode_build)]
+    fn provide<'a>(&'a self, demand: &mut ::std::any::Demand<'a>) {
         demand.provide_ref::<Backtrace>(self.backtrace());
     }
 }

--- a/eden/mononoke/mononoke_api/src/lib.rs
+++ b/eden/mononoke/mononoke_api/src/lib.rs
@@ -6,7 +6,7 @@
  */
 
 #![feature(error_generic_member_access)]
-#![feature(provide_any)]
+#![cfg_attr(fbcode_build, feature(provide_any))]
 #![feature(trait_alias)]
 
 use std::sync::Arc;


### PR DESCRIPTION
fix mononoke build

Makes usage of anyhow::Error::backtrace() conditional on fbcode_build. This is necessary because the cargo build of anyhow disables its backtrace features when using RUSTC_BOOTSTRAP=1

For oss cargo build to work on current rustc stable 1.73+ I hid the #![feature(provide_any)] usage by making it condition on fbcode_build.

Test plan:

local build with `./build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. mononoke`

github CI, done by regenerating the mononoke github actions with: `./build/fbcode_builder/getdeps.py --allow-system-packages generate-github-actions --free-up-disk --src-dir=. --output-dir=.github/workflows --job-name="Mononoke " --job-file-prefix=mononoke_ mononoke`

Before, broken

After, works
