### PR TITLE
Move sapling_backingstore_get_file_aux_batch to cxx_bridge

### DIFF
--- a/build/fbcode_builder/CMake/RustStaticLibrary.cmake
+++ b/build/fbcode_builder/CMake/RustStaticLibrary.cmake
@@ -363,7 +363,7 @@ endfunction()
 #   `${TARGET}` CMake library target.
 #
 # ```cmake
-# rust_cxx_bridge(<TARGET> <CXX_BRIDGE_FILE> [CRATE <CRATE_NAME>])
+# rust_cxx_bridge(<TARGET> <CXX_BRIDGE_FILE> [CRATE <CRATE_NAME>] [LIBS <LIBNAMES>])
 # ```
 #
 # Parameters:
@@ -374,9 +374,11 @@ endfunction()
 # - CRATE_NAME:
 #   Name of the crate. This parameter is optional. If unspecified, it will
 #   fallback to `${TARGET}`.
+# - LIBS <lib1> [<lib2> ...]:
+#   A list of libraries that this library depends on.
 #
 function(rust_cxx_bridge TARGET CXX_BRIDGE_FILE)
-  fb_cmake_parse_args(ARG "" "CRATE" "" "${ARGN}")
+  fb_cmake_parse_args(ARG "" "CRATE" "LIBS" "${ARGN}")
 
   if(DEFINED ARG_CRATE)
     set(crate_name "${ARG_CRATE}")
@@ -476,6 +478,11 @@ function(rust_cxx_bridge TARGET CXX_BRIDGE_FILE)
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     $<INSTALL_INTERFACE:include>
   )
+  target_link_libraries(
+    ${crate_name}
+    PUBLIC
+    ${ARG_LIBS}
+  )
 
   file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/rust")
   add_custom_command(
@@ -517,10 +524,11 @@ function(rust_cxx_bridge TARGET CXX_BRIDGE_FILE)
     COMMENT "Generating cxx bindings for crate ${crate_name}"
   )
 
-  target_sources(${crate_name}
+  target_sources(
+    ${crate_name}
     PRIVATE
-      "${CMAKE_CURRENT_BINARY_DIR}/${cxx_header}"
-      "${CMAKE_CURRENT_BINARY_DIR}/rust/cxx.h"
-      "${CMAKE_CURRENT_BINARY_DIR}/${cxx_source}"
+    "${CMAKE_CURRENT_BINARY_DIR}/${cxx_header}"
+    "${CMAKE_CURRENT_BINARY_DIR}/rust/cxx.h"
+    "${CMAKE_CURRENT_BINARY_DIR}/${cxx_source}"
   )
 endfunction()

--- a/eden/fs/store/hg/HgDatapackStore.cpp
+++ b/eden/fs/store/hg/HgDatapackStore.cpp
@@ -255,6 +255,23 @@ void HgDatapackStore::getBlobBatch(const ImportRequestsList& importRequests) {
       false,
       // store_.getBlobBatch is blocking, hence we can take these by reference.
       [&](size_t index, folly::Try<std::unique_ptr<folly::IOBuf>> content) {
+        if (content.hasException()) {
+          XLOGF(
+              DBG6,
+              "Failed to import node={} from EdenAPI (batch {}/{}): {}",
+              folly::hexlify(requests[index]),
+              index,
+              requests.size(),
+              content.exception().what().toStdString());
+        } else {
+          XLOGF(
+              DBG6,
+              "Imported node={} from EdenAPI (batch: {}/{})",
+              folly::hexlify(requests[index]),
+              index,
+              requests.size());
+        }
+
         if (config_->getEdenConfig()->hgBlobFetchFallback.getValue() &&
             content.hasException()) {
           if (logger_) {

--- a/eden/fs/store/hg/HgDatapackStore.cpp
+++ b/eden/fs/store/hg/HgDatapackStore.cpp
@@ -136,6 +136,23 @@ void HgDatapackStore::getTreeBatch(const ImportRequestsList& importRequests) {
       [&, filteredPaths](
           size_t index,
           folly::Try<std::shared_ptr<sapling::Tree>> content) mutable {
+        if (content.hasException()) {
+          XLOGF(
+              DBG6,
+              "Failed to import node={} from EdenAPI (batch tree {}/{}): {}",
+              folly::hexlify(requests[index]),
+              index,
+              requests.size(),
+              content.exception().what().toStdString());
+        } else {
+          XLOGF(
+              DBG6,
+              "Imported node={} from EdenAPI (batch tree: {}/{})",
+              folly::hexlify(requests[index]),
+              index,
+              requests.size());
+        }
+
         if (config_->getEdenConfig()->hgTreeFetchFallback.getValue() &&
             content.hasException()) {
           if (logger_) {

--- a/eden/fs/store/hg/HgDatapackStore.cpp
+++ b/eden/fs/store/hg/HgDatapackStore.cpp
@@ -343,6 +343,23 @@ void HgDatapackStore::getBlobMetadataBatch(
       // reference.
       [&](size_t index,
           folly::Try<std::shared_ptr<sapling::FileAuxData>> auxTry) {
+        if (auxTry.hasException()) {
+          XLOGF(
+              DBG6,
+              "Failed to import metadata node={} from EdenAPI (batch {}/{}): {}",
+              folly::hexlify(requests[index]),
+              index,
+              requests.size(),
+              auxTry.exception().what().toStdString());
+        } else {
+          XLOGF(
+              DBG6,
+              "Imported metadata node={} from EdenAPI (batch: {}/{})",
+              folly::hexlify(requests[index]),
+              index,
+              requests.size());
+        }
+
         if (auxTry.hasException() &&
             config_->getEdenConfig()->hgBlobMetaFetchFallback.getValue()) {
           // TODO: log EdenApiMiss for metadata

--- a/eden/scm/lib/backingstore/CMakeLists.txt
+++ b/eden/scm/lib/backingstore/CMakeLists.txt
@@ -19,19 +19,20 @@ install_rust_static_library(
   INSTALL_DIR lib
 )
 
-rust_cxx_bridge(rust_backingstore_bridge "src/ffi.rs")
+rust_cxx_bridge(
+  backingstore
+  "src/ffi.rs"
+  LIBS
+  fmt::fmt
+  Folly::folly
+)
 
 file(GLOB C_API_SRCS "src/*.cpp")
-file(
-  GLOB
-  RUST_BACKINGSTORE_SRCS
-  "${CMAKE_CURRENT_BINARY_DIR}/cxxbridge/backingstore/src/*.cc"
-)
 file(GLOB C_API_HDRS "include/*.h")
-add_library(
+target_sources(
   backingstore
+  PRIVATE
   "${C_API_SRCS}"
-  "${RUST_BACKINGSTORE_SRCS}"
 )
 set_target_properties(
   backingstore
@@ -40,7 +41,9 @@ set_target_properties(
   "${C_API_HDRS}"
 )
 
-target_include_directories(backingstore PUBLIC
+target_include_directories(
+  backingstore
+  PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
@@ -48,9 +51,8 @@ target_link_libraries(
   backingstore
   PUBLIC
   rust_backingstore
-  rust_backingstore_bridge
+  fmt::fmt
   Folly::folly
-  edencommon::edencommon_utils
 )
 
 # curl used in the Rust crate has its own copy of curl compiled and it uses

--- a/eden/scm/lib/backingstore/include/BackingStoreBindings.h
+++ b/eden/scm/lib/backingstore/include/BackingStoreBindings.h
@@ -7,7 +7,7 @@
  * This file is generated with cbindgen. Please run `./tools/cbindgen.sh` to
  * update this file.
  *
- * @generated SignedSource<<3b2996b92f3ae83007b1c8ab31ad87b4>>
+ * @generated SignedSource<<7638284c226833d5b55ae1f9e64ed0da>>
  *
  */
 
@@ -72,12 +72,6 @@ void sapling_file_aux_free(FileAuxData *aux);
 void sapling_cbytes_free(CBytes *vec);
 
 void sapling_cfallible_free_error(char *ptr);
-
-void sapling_backingstore_get_blob_batch(BackingStore *store,
-                                         Slice<Request> requests,
-                                         bool local,
-                                         void *data,
-                                         void (*resolve)(void*, uintptr_t, CFallibleBase));
 
 void sapling_backingstore_get_file_aux_batch(BackingStore *store,
                                              Slice<Request> requests,

--- a/eden/scm/lib/backingstore/include/BackingStoreBindings.h
+++ b/eden/scm/lib/backingstore/include/BackingStoreBindings.h
@@ -7,7 +7,7 @@
  * This file is generated with cbindgen. Please run `./tools/cbindgen.sh` to
  * update this file.
  *
- * @generated SignedSource<<acd2733514d3f5e17ff03431ac01b0a3>>
+ * @generated SignedSource<<3b2996b92f3ae83007b1c8ab31ad87b4>>
  *
  */
 
@@ -28,7 +28,7 @@ struct BackingStore;
 
 struct FileAuxData;
 
-struct Tree;
+struct Request;
 
 template<typename T = void>
 struct Vec;
@@ -44,10 +44,6 @@ struct CBytes {
   operator folly::ByteRange() const {
     return asByteRange();
   }
-};
-
-struct Request {
-  const uint8_t *node;
 };
 
 template<typename T>
@@ -77,12 +73,6 @@ void sapling_cbytes_free(CBytes *vec);
 
 void sapling_cfallible_free_error(char *ptr);
 
-void sapling_backingstore_get_tree_batch(BackingStore *store,
-                                         Slice<Request> requests,
-                                         bool local,
-                                         void *data,
-                                         void (*resolve)(void*, uintptr_t, CFallibleBase));
-
 void sapling_backingstore_get_blob_batch(BackingStore *store,
                                          Slice<Request> requests,
                                          bool local,
@@ -106,8 +96,6 @@ void sapling_test_cfallible_ok_free(uint8_t *val);
 CFallibleBase sapling_test_cfallible_err();
 
 CBytes sapling_test_cbytes();
-
-void sapling_tree_free(Tree *tree);
 
 } // extern "C"
 

--- a/eden/scm/lib/backingstore/include/BackingStoreBindings.h
+++ b/eden/scm/lib/backingstore/include/BackingStoreBindings.h
@@ -7,7 +7,7 @@
  * This file is generated with cbindgen. Please run `./tools/cbindgen.sh` to
  * update this file.
  *
- * @generated SignedSource<<7638284c226833d5b55ae1f9e64ed0da>>
+ * @generated SignedSource<<f399137612eddb864eeafdd5007279c3>>
  *
  */
 
@@ -23,12 +23,6 @@
 #include <folly/Range.h>
 
 namespace sapling {
-
-struct BackingStore;
-
-struct FileAuxData;
-
-struct Request;
 
 template<typename T = void>
 struct Vec;
@@ -46,18 +40,6 @@ struct CBytes {
   }
 };
 
-template<typename T>
-struct Slice {
-  const T *ptr;
-  size_t len;
-  template <typename Q = T>
-  Slice(std::enable_if_t<std::is_same_v<Q, uint8_t>, std::string_view> sv) noexcept
-    : ptr{reinterpret_cast<const uint8_t*>(sv.data())}, len{sv.size()} {}
-
-  Slice(folly::Range<const T*> range) noexcept
-    : ptr{range.data()}, len{range.size()} {}
-};
-
 /// The monomorphized version of `CFallible` used solely because MSVC
 /// does not allow returning template functions from extern "C" functions.
 struct CFallibleBase {
@@ -67,17 +49,9 @@ struct CFallibleBase {
 
 extern "C" {
 
-void sapling_file_aux_free(FileAuxData *aux);
-
 void sapling_cbytes_free(CBytes *vec);
 
 void sapling_cfallible_free_error(char *ptr);
-
-void sapling_backingstore_get_file_aux_batch(BackingStore *store,
-                                             Slice<Request> requests,
-                                             bool local,
-                                             void *data,
-                                             void (*resolve)(void*, uintptr_t, CFallibleBase));
 
 /// Returns a `CFallible` with success return value 1. This function is intended to be called from
 /// C++ tests.

--- a/eden/scm/lib/backingstore/include/SaplingNativeBackingStore.h
+++ b/eden/scm/lib/backingstore/include/SaplingNativeBackingStore.h
@@ -23,11 +23,6 @@ class IOBuf;
 
 namespace sapling {
 
-class SaplingFetchError : public std::runtime_error {
- public:
-  using std::runtime_error::runtime_error;
-};
-
 /**
  * Reference to a 20-byte hg node ID.
  *

--- a/eden/scm/lib/backingstore/include/ffi.h
+++ b/eden/scm/lib/backingstore/include/ffi.h
@@ -11,4 +11,31 @@
 #include <rust/cxx.h>
 #include <memory>
 
-namespace sapling {} // namespace sapling
+namespace sapling {
+
+class SaplingFetchError : public std::runtime_error {
+ public:
+  using std::runtime_error::runtime_error;
+};
+
+struct Tree;
+
+/**
+ * Resolver used in the processing of getTreeBatch requests.
+ */
+struct GetTreeBatchResolver {
+  explicit GetTreeBatchResolver(
+      folly::FunctionRef<void(size_t, folly::Try<std::shared_ptr<Tree>>)>
+          resolve)
+      : resolve{std::move(resolve)} {}
+
+  folly::FunctionRef<void(size_t, folly::Try<std::shared_ptr<Tree>>)> resolve;
+};
+
+void sapling_backingstore_get_tree_batch_handler(
+    std::shared_ptr<GetTreeBatchResolver> resolver,
+    size_t index,
+    rust::String error,
+    std::shared_ptr<Tree> tree);
+
+} // namespace sapling

--- a/eden/scm/lib/backingstore/include/ffi.h
+++ b/eden/scm/lib/backingstore/include/ffi.h
@@ -19,6 +19,7 @@ class SaplingFetchError : public std::runtime_error {
 
 struct Tree;
 struct Blob;
+struct FileAuxData;
 
 /**
  * Resolver used in the processing of getTreeBatch requests.
@@ -45,6 +46,19 @@ struct GetBlobBatchResolver {
       resolve;
 };
 
+/**
+ * Resolver used in the processing of getBlobMetadataBatch requests.
+ */
+struct GetFileAuxBatchResolver {
+  explicit GetFileAuxBatchResolver(
+      folly::FunctionRef<void(size_t, folly::Try<std::shared_ptr<FileAuxData>>)>
+          resolve)
+      : resolve{std::move(resolve)} {}
+
+  folly::FunctionRef<void(size_t, folly::Try<std::shared_ptr<FileAuxData>>)>
+      resolve;
+};
+
 void sapling_backingstore_get_tree_batch_handler(
     std::shared_ptr<GetTreeBatchResolver> resolver,
     size_t index,
@@ -56,5 +70,11 @@ void sapling_backingstore_get_blob_batch_handler(
     size_t index,
     rust::String error,
     rust::Box<Blob> blob);
+
+void sapling_backingstore_get_file_aux_batch_handler(
+    std::shared_ptr<GetFileAuxBatchResolver> resolver,
+    size_t index,
+    rust::String error,
+    std::shared_ptr<FileAuxData> aux);
 
 } // namespace sapling

--- a/eden/scm/lib/backingstore/include/ffi.h
+++ b/eden/scm/lib/backingstore/include/ffi.h
@@ -9,7 +9,6 @@
 
 #include <folly/futures/Future.h>
 #include <rust/cxx.h>
-#include <memory>
 
 namespace sapling {
 
@@ -19,6 +18,7 @@ class SaplingFetchError : public std::runtime_error {
 };
 
 struct Tree;
+struct Blob;
 
 /**
  * Resolver used in the processing of getTreeBatch requests.
@@ -32,10 +32,29 @@ struct GetTreeBatchResolver {
   folly::FunctionRef<void(size_t, folly::Try<std::shared_ptr<Tree>>)> resolve;
 };
 
+/**
+ * Resolver used in the processing of getBlobBatch requests.
+ */
+struct GetBlobBatchResolver {
+  explicit GetBlobBatchResolver(
+      folly::FunctionRef<
+          void(size_t, folly::Try<std::unique_ptr<folly::IOBuf>>)> resolve)
+      : resolve{std::move(resolve)} {}
+
+  folly::FunctionRef<void(size_t, folly::Try<std::unique_ptr<folly::IOBuf>>)>
+      resolve;
+};
+
 void sapling_backingstore_get_tree_batch_handler(
     std::shared_ptr<GetTreeBatchResolver> resolver,
     size_t index,
     rust::String error,
     std::shared_ptr<Tree> tree);
+
+void sapling_backingstore_get_blob_batch_handler(
+    std::shared_ptr<GetBlobBatchResolver> resolver,
+    size_t index,
+    rust::String error,
+    rust::Box<Blob> blob);
 
 } // namespace sapling

--- a/eden/scm/lib/backingstore/src/auxdata.rs
+++ b/eden/scm/lib/backingstore/src/auxdata.rs
@@ -23,10 +23,3 @@ impl From<ScmStoreFileAuxData> for FileAuxData {
         }
     }
 }
-
-#[no_mangle]
-pub extern "C" fn sapling_file_aux_free(aux: *mut FileAuxData) {
-    assert!(!aux.is_null());
-    let aux = unsafe { Box::from_raw(aux) };
-    drop(aux);
-}

--- a/eden/scm/lib/backingstore/src/ffi.cpp
+++ b/eden/scm/lib/backingstore/src/ffi.cpp
@@ -5,7 +5,12 @@
  * GNU General Public License version 2.
  */
 
+#include <folly/Try.h>
+#include <folly/io/IOBuf.h>
+#include <memory>
+
 #include "eden/scm/lib/backingstore/include/ffi.h"
+#include "eden/scm/lib/backingstore/src/ffi.rs.h" // @manual
 
 namespace sapling {
 
@@ -21,6 +26,31 @@ void sapling_backingstore_get_tree_batch_handler(
                         return ResolveResult{tree};
                       } else {
                         return ResolveResult{SaplingFetchError{error.c_str()}};
+                      }
+                    }));
+}
+
+void sapling_backingstore_get_blob_batch_handler(
+    std::shared_ptr<GetBlobBatchResolver> resolver,
+    size_t index,
+    rust::String error,
+    rust::Box<Blob> blob) {
+  using ResolveResult = folly::Try<std::unique_ptr<folly::IOBuf>>;
+
+  resolver->resolve(index, folly::makeTryWith([&] {
+                      auto result = blob.into_raw();
+                      if (result->bytes.empty()) {
+                        auto box = rust::Box<Blob>::from_raw(result);
+                        return ResolveResult{SaplingFetchError{error.c_str()}};
+                      } else {
+                        return ResolveResult{folly::IOBuf::takeOwnership(
+                            reinterpret_cast<void*>(result->bytes.data()),
+                            result->bytes.size(),
+                            [](void* /* buf */, void* blob) mutable {
+                              auto box = rust::Box<Blob>::from_raw(
+                                  reinterpret_cast<Blob*>(blob));
+                            },
+                            reinterpret_cast<void*>(result))};
                       }
                     }));
 }

--- a/eden/scm/lib/backingstore/src/ffi.cpp
+++ b/eden/scm/lib/backingstore/src/ffi.cpp
@@ -7,4 +7,22 @@
 
 #include "eden/scm/lib/backingstore/include/ffi.h"
 
-namespace sapling {} // namespace sapling
+namespace sapling {
+
+void sapling_backingstore_get_tree_batch_handler(
+    std::shared_ptr<GetTreeBatchResolver> resolver,
+    size_t index,
+    rust::String error,
+    std::shared_ptr<Tree> tree) {
+  using ResolveResult = folly::Try<std::shared_ptr<Tree>>;
+
+  resolver->resolve(index, folly::makeTryWith([&] {
+                      if (tree) {
+                        return ResolveResult{tree};
+                      } else {
+                        return ResolveResult{SaplingFetchError{error.c_str()}};
+                      }
+                    }));
+}
+
+} // namespace sapling

--- a/eden/scm/lib/backingstore/src/ffi.cpp
+++ b/eden/scm/lib/backingstore/src/ffi.cpp
@@ -55,4 +55,20 @@ void sapling_backingstore_get_blob_batch_handler(
                     }));
 }
 
+void sapling_backingstore_get_file_aux_batch_handler(
+    std::shared_ptr<GetFileAuxBatchResolver> resolver,
+    size_t index,
+    rust::String error,
+    std::shared_ptr<FileAuxData> aux) {
+  using ResolveResult = folly::Try<std::shared_ptr<FileAuxData>>;
+
+  resolver->resolve(index, folly::makeTryWith([&] {
+                      if (aux) {
+                        return ResolveResult{aux};
+                      } else {
+                        return ResolveResult{SaplingFetchError{error.c_str()}};
+                      }
+                    }));
+}
+
 } // namespace sapling

--- a/eden/scm/lib/backingstore/src/request.rs
+++ b/eden/scm/lib/backingstore/src/request.rs
@@ -11,13 +11,10 @@ use types::Key;
 use types::Node;
 use types::RepoPathBuf;
 
+use crate::ffi::ffi::Request;
+
 // Number of bytes of a node.
 const NODE_LENGTH: usize = 20;
-
-#[repr(C)]
-pub struct Request {
-    node: *const u8,
-}
 
 impl Request {
     pub fn key(&self) -> Key {

--- a/eden/scm/lib/backingstore/src/tree.rs
+++ b/eden/scm/lib/backingstore/src/tree.rs
@@ -97,10 +97,3 @@ impl TryFrom<Box<dyn storemodel::TreeEntry>> for Tree {
         Ok(Tree { entries })
     }
 }
-
-#[no_mangle]
-pub extern "C" fn sapling_tree_free(tree: *mut Tree) {
-    assert!(!tree.is_null());
-    let tree = unsafe { Box::from_raw(tree) };
-    drop(tree);
-}


### PR DESCRIPTION
Summary:
cxx.rs provides a more ergonomic and opinionated interop layer between Rust and C++ that we would like to leverage for future API chages.

This moves  sapling_backingstore_get_file_aux_batch from the existing cbindgen implemenation to the new cxxbridge.

Reviewed By: xavierd

Differential Revision: D51325319


