### PR TITLE
fix eden build with python 3.12

### DIFF
--- a/build/fbcode_builder/CMake/fb_py_test_main.py
+++ b/build/fbcode_builder/CMake/fb_py_test_main.py
@@ -194,7 +194,7 @@ class CallbackStream(object):
         return self._fileno
 
 
-class BuckTestResult(unittest._TextTestResult):
+class BuckTestResult(unittest.TextTestResult):
     """
     Our own TestResult class that outputs data in a format that can be easily
     parsed by buck's test runner.

--- a/eden/scm/tests/run-tests.py
+++ b/eden/scm/tests/run-tests.py
@@ -2402,7 +2402,7 @@ class IOLockWithProgress:
 iolock = showprogress and IOLockWithProgress() or _iolock
 
 
-class TestResult(unittest._TextTestResult):
+class TestResult(unittest.TextTestResult):
     """Holds results when executing via unittest."""
 
     # Don't worry too much about accessing the non-public _TextTestResult.
@@ -2459,7 +2459,7 @@ class TestResult(unittest._TextTestResult):
 
     def addSuccess(self, test):
         if showprogress and not self.showAll:
-            super(unittest._TextTestResult, self).addSuccess(test)
+            super(unittest.TextTestResult, self).addSuccess(test)
         else:
             with iolock:
                 super(TestResult, self).addSuccess(test)
@@ -2467,7 +2467,7 @@ class TestResult(unittest._TextTestResult):
 
     def addError(self, test, err):
         if showprogress and not self.showAll:
-            super(unittest._TextTestResult, self).addError(test, err)
+            super(unittest.TextTestResult, self).addError(test, err)
         else:
             with iolock:
                 super(TestResult, self).addError(test, err)


### PR DESCRIPTION
fix eden build with python 3.12

python 3.12 removes many long deprecated unittest features including  _TextTestResult (deprecated in Python 3.2)

notices as fedora 39 ships with python 3.12

Test plan:

Local build with `./build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. eden`

Before:
```
FAILED: eden/integration/CMakeFiles/integration_tests.GEN_PY_EXE.util eden/integration/integration_tests_tests.cmake /home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/build/eden/eden/integration/integration_tests_tests.cmake
cd /home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/build/eden/eden/integration && /usr/bin/cmake -D TEST_TARGET=integration_tests -D TEST_INTERPRETER=/usr/bin/python3.12 -D TEST_ENV=CMAKE_SOURCE_DIR=/home/alex/local/sapling -D TEST_EXECUTABLE=/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/build/eden/eden/integration/integration_tests -D TEST_WORKING_DIR=/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/build/eden -D TEST_LIST=integration_tests_TESTS -D TEST_PREFIX=integration_tests:: -D TEST_PROPERTIES= -D CTEST_FILE=/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/build/eden/eden/integration/integration_tests_tests.cmake -P /home/alex/local/sapling/build/fbcode_builder/CMake/FBPythonTestAddTests.cmake
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/build/eden/eden/integration/integration_tests/__main__.py", line 197, in <module>
  File "/usr/lib64/python3.12/unittest/__init__.py", line 85, in __getattr__
    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
AttributeError: module 'unittest' has no attribute '_TextTestResult'. Did you mean: 'TextTestResult'?
```

After, works

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/778).
* #748
* __->__ #778