### PR TITLE
[pr body update] fix reviewstack option breaking stack list detection

### DIFF
--- a/eden/scm/sapling/ext/github/mock_utils.py
+++ b/eden/scm/sapling/ext/github/mock_utils.py
@@ -297,6 +297,7 @@ class MockGitHubServer:
             ]
             body += (
                 "\n---\n"
+                "[//]: # (BEGIN SAPLING FOOTER)\n"
                 "Stack created with [Sapling](https://sapling-scm.com). Best reviewed"
                 f" with [ReviewStack](https://reviewstack.dev/{owner}/{name}/pull/{pr_number}).\n"
                 + "\n".join(pr_list)

--- a/eden/scm/sapling/ext/github/pull_request_body.py
+++ b/eden/scm/sapling/ext/github/pull_request_body.py
@@ -9,6 +9,7 @@ from typing import List, Tuple
 from .gh_submit import Repository
 
 _HORIZONTAL_RULE = "---"
+_SAPLING_FOOTER_MARKER = "[//]: # (BEGIN SAPLING FOOTER)"
 
 
 def create_pull_request_title_and_body(
@@ -38,6 +39,7 @@ def create_pull_request_title_and_body(
     The original commit message.
     Second line of message.
     ---
+    [//]: # (BEGIN SAPLING FOOTER)
     Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack]({reviewstack_url}).
     * #1
     * #2 (2 commits)
@@ -51,6 +53,7 @@ def create_pull_request_title_and_body(
     The original commit message.
     Second line of message.
     ---
+    [//]: # (BEGIN SAPLING FOOTER)
     * #1
     * #2 (2 commits)
     * __->__ #42
@@ -77,7 +80,7 @@ def create_pull_request_title_and_body(
         )
         extra.append(bulleted_list)
     if extra:
-        body = "\n".join([body, _HORIZONTAL_RULE] + extra)
+        body = "\n".join([body, _HORIZONTAL_RULE, _SAPLING_FOOTER_MARKER] + extra)
     return title, body
 
 
@@ -91,6 +94,23 @@ _StackEntry = Tuple[bool, int]
 
 def parse_stack_information(body: str) -> List[_StackEntry]:
     r"""
+    With sapling stack footer marker:
+    >>> reviewstack_url = "https://reviewstack.dev/facebook/sapling/pull/42"
+    >>> body = (
+    ...     'The original commit message.\n' +
+    ...     'Second line of message.\n' +
+    ...     '---\n' +
+    ...     '[//]: # (BEGIN SAPLING FOOTER)\n' +
+    ...     'Stack created with [Sapling](https://sapling-scm.com). ' +
+    ...     f'Best reviewed with [ReviewStack]({reviewstack_url}).\n' +
+    ...     '* #1\n' +
+    ...     '* #2 (2 commits)\n' +
+    ...     '* __->__ #42\n' +
+    ...     '* #4\n')
+    >>> parse_stack_information(body)
+    [(False, 1), (False, 2), (True, 42), (False, 4)]
+
+    Without sapling stack footer marker (legacy):
     >>> reviewstack_url = "https://reviewstack.dev/facebook/sapling/pull/42"
     >>> body = (
     ...     'The original commit message.\n' +
@@ -105,11 +125,12 @@ def parse_stack_information(body: str) -> List[_StackEntry]:
     >>> parse_stack_information(body)
     [(False, 1), (False, 2), (True, 42), (False, 4)]
     """
-    is_prev_line_hr = False
     in_stack_list = False
     stack_entries = []
     for line in body.splitlines():
-        if in_stack_list:
+        if _line_has_stack_list_marker(line):
+            in_stack_list = True
+        elif in_stack_list:
             match = _STACK_ENTRY.match(line)
             if match:
                 arrow, number = match.groups()
@@ -117,13 +138,14 @@ def parse_stack_information(body: str) -> List[_StackEntry]:
             else:
                 # This must be the end of the list.
                 break
-        elif is_prev_line_hr:
-            if line.startswith("Stack created with [Sapling]"):
-                in_stack_list = True
-            is_prev_line_hr = False
-        elif line.rstrip() == _HORIZONTAL_RULE:
-            is_prev_line_hr = True
     return stack_entries
+
+
+def _line_has_stack_list_marker(line: str) -> bool:
+    # we're still looking at the "Stack created with [Sapling]" text for backward compatibility
+    return line == _SAPLING_FOOTER_MARKER or line.startswith(
+        "Stack created with [Sapling]"
+    )
 
 
 def _format_stack_entry(


### PR DESCRIPTION
In #427 an option was added to remove the ReviewStack link from the PR stack list in the PR body. However, removal of that line entirely breaks [parse_stack_information](https://github.com/facebook/sapling/blob/1e4d8eca58f5096b25dd93fc31bfa4c0667ce343/eden/scm/sapling/ext/github/pull_request_body.py#L93) as it expects to find a line beginning with "Stack created with [Sapling]".

To fix this, I've added a new textual marker (`[//]: # (BEGIN SAPLING FOOTER)`) which markdown doesn't render. From now on, to detect a stack, we'll search for this marker and then this should allow us to split on it. For backward compatibility, I'm leaving in the previous marker detection as well.

Tests: submitted this PR with the proper stack listing :) Also, take a look at downstream PR #780 that also relies on this working.

---
[//]: # (BEGIN SAPLING FOOTER)
* #780
* __->__ #779