### PR TITLE
[pr body update] update stack list without overwriting PR title and body

### DIFF
--- a/eden/scm/sapling/ext/github/__init__.py
+++ b/eden/scm/sapling/ext/github/__init__.py
@@ -47,6 +47,7 @@ configtable = {}
 configitem = registrar.configitem(configtable)
 
 configitem("github", "pull-request-include-reviewstack", default=True)
+configitem("github", "preserve-pull-request-description", default=False)
 
 
 @hint("unlink-closed-pr")
@@ -402,3 +403,4 @@ def _autopullghpr(repo, name, rewritepullrev: bool = False) -> Optional[pullatte
             # HASH".
             friendlyname = "PR%s (%s)" % (prno, hex(n))
             return autopull.pullattempt(headnodes=[n], friendlyname=friendlyname)
+

--- a/eden/scm/sapling/ext/github/consts/query.py
+++ b/eden/scm/sapling/ext/github/consts/query.py
@@ -46,6 +46,7 @@ query ($owner: String!, $name: String!, $number: Int!) {
       headRefOid
       headRefName
       body
+      title
     }
   }
 }

--- a/eden/scm/sapling/ext/github/gh_submit.py
+++ b/eden/scm/sapling/ext/github/gh_submit.py
@@ -116,6 +116,7 @@ class PullRequestDetails:
     #   bodyText: plaintext version of body with Markdown markup removed
     #   bodyHTML: body rendered as "safe" HTML
     body: str
+    title: str
     state: PullRequestState
 
 
@@ -143,6 +144,7 @@ async def get_pull_request_details(
             head_oid=data["headRefOid"],
             head_branch_name=data["headRefName"],
             body=data["body"],
+            title=data["title"],
             state=PullRequestState[data["state"]],
         )
     )

--- a/eden/scm/sapling/ext/github/mock_utils.py
+++ b/eden/scm/sapling/ext/github/mock_utils.py
@@ -501,6 +501,7 @@ class GetPrDetailsRequest(MockRequest):
         base_ref_name: str = "main",
         base_ref_oid: str = "",
         body: str = "",
+        title: str = "",
     ):
         head_ref_name = head_ref_name or f"pr{self._pr_number}"
         head_ref_oid = head_ref_oid or gen_hash_hexdigest(pr_id)
@@ -517,6 +518,7 @@ class GetPrDetailsRequest(MockRequest):
                         "baseRefOid": base_ref_oid,
                         "baseRefName": base_ref_name,
                         "body": body,
+                        "title": title,
                     }
                 }
             }

--- a/eden/scm/sapling/ext/github/mock_utils.py
+++ b/eden/scm/sapling/ext/github/mock_utils.py
@@ -297,6 +297,7 @@ class MockGitHubServer:
             ]
             body += (
                 "\n---\n"
+                "[//]: # (BEGIN SAPLING FOOTER)\n"
                 "Stack created with [Sapling](https://sapling-scm.com). Best reviewed"
                 f" with [ReviewStack](https://reviewstack.dev/{owner}/{name}/pull/{pr_number}).\n"
                 + "\n".join(pr_list)

--- a/eden/scm/sapling/ext/github/pull_request_body.py
+++ b/eden/scm/sapling/ext/github/pull_request_body.py
@@ -9,6 +9,7 @@ from typing import List, Tuple
 from .gh_submit import Repository
 
 _HORIZONTAL_RULE = "---"
+_SAPLING_FOOTER_MARKER = "[//]: # (BEGIN SAPLING FOOTER)"
 
 
 def create_pull_request_title_and_body(
@@ -38,6 +39,7 @@ def create_pull_request_title_and_body(
     The original commit message.
     Second line of message.
     ---
+    [//]: # (BEGIN SAPLING FOOTER)
     Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack]({reviewstack_url}).
     * #1
     * #2 (2 commits)
@@ -51,6 +53,7 @@ def create_pull_request_title_and_body(
     The original commit message.
     Second line of message.
     ---
+    [//]: # (BEGIN SAPLING FOOTER)
     * #1
     * #2 (2 commits)
     * __->__ #42
@@ -77,7 +80,7 @@ def create_pull_request_title_and_body(
         )
         extra.append(bulleted_list)
     if extra:
-        body = "\n".join([body, _HORIZONTAL_RULE] + extra)
+        body = "\n".join([body, _HORIZONTAL_RULE, _SAPLING_FOOTER_MARKER] + extra)
     return title, body
 
 
@@ -91,6 +94,23 @@ _StackEntry = Tuple[bool, int]
 
 def parse_stack_information(body: str) -> List[_StackEntry]:
     r"""
+    With sapling stack footer marker:
+    >>> reviewstack_url = "https://reviewstack.dev/facebook/sapling/pull/42"
+    >>> body = (
+    ...     'The original commit message.\n' +
+    ...     'Second line of message.\n' +
+    ...     '---\n' +
+    ...     '[//]: # (BEGIN SAPLING FOOTER)\n' +
+    ...     'Stack created with [Sapling](https://sapling-scm.com). ' +
+    ...     f'Best reviewed with [ReviewStack]({reviewstack_url}).\n' +
+    ...     '* #1\n' +
+    ...     '* #2 (2 commits)\n' +
+    ...     '* __->__ #42\n' +
+    ...     '* #4\n')
+    >>> parse_stack_information(body)
+    [(False, 1), (False, 2), (True, 42), (False, 4)]
+
+    Without sapling stack footer marker (legacy):
     >>> reviewstack_url = "https://reviewstack.dev/facebook/sapling/pull/42"
     >>> body = (
     ...     'The original commit message.\n' +
@@ -105,11 +125,12 @@ def parse_stack_information(body: str) -> List[_StackEntry]:
     >>> parse_stack_information(body)
     [(False, 1), (False, 2), (True, 42), (False, 4)]
     """
-    is_prev_line_hr = False
     in_stack_list = False
     stack_entries = []
     for line in body.splitlines():
-        if in_stack_list:
+        if _line_has_stack_list_marker(line):
+            in_stack_list = True
+        elif in_stack_list:
             match = _STACK_ENTRY.match(line)
             if match:
                 arrow, number = match.groups()
@@ -117,13 +138,14 @@ def parse_stack_information(body: str) -> List[_StackEntry]:
             else:
                 # This must be the end of the list.
                 break
-        elif is_prev_line_hr:
-            if line.startswith("Stack created with [Sapling]"):
-                in_stack_list = True
-            is_prev_line_hr = False
-        elif line.rstrip() == _HORIZONTAL_RULE:
-            is_prev_line_hr = True
     return stack_entries
+
+
+def _line_has_stack_list_marker(line: str) -> bool:
+    # we're still looking at the "Stack created with [Sapling]" text for backward compatibility
+    return line == _SAPLING_FOOTER_MARKER or line.startswith(
+        "Stack created with [Sapling]"
+    )
 
 
 def _format_stack_entry(

--- a/eden/scm/sapling/ext/github/submit.py
+++ b/eden/scm/sapling/ext/github/submit.py
@@ -261,16 +261,25 @@ async def rewrite_pull_request_body(
         base = none_throws(partitions[index + 1][0].head_branch_name)
 
     head_commit_data = partition[0]
-    commit_msg = head_commit_data.get_msg()
+
+    pr = head_commit_data.pr
+    assert pr
+
+    title = None
+    if ui.configbool("github", "preserve-pull-request-description"):
+        commit_msg = pr.body
+        title = pr.title
+    else:
+        commit_msg = head_commit_data.get_msg()
+
     title, body = create_pull_request_title_and_body(
         commit_msg,
         pr_numbers_and_num_commits,
         index,
         repository,
+        title,
         reviewstack=ui.configbool("github", "pull-request-include-reviewstack"),
     )
-    pr = head_commit_data.pr
-    assert pr
 
     if pr.state != PullRequestState.OPEN:
         ui.status_err(


### PR DESCRIPTION
The current behavior of PR updates is flawed - every time one submits a new version of a PR, it is followed by an update of the title and description body of the PR. Often, the PR author would edit the PR title in Github's web UI after submission, to find their marvelous prose offhandedly deleted by Sapling.

In this diff I'm introducing a new config option (`github.preserve-pull-request-description`) to control this overwrite behavior. With the option turned on, subsequent updates **only overwrite the stack listing** in the PR description to reflect PR stack changes, while the actual PR description and title are left alone.

Here's the new behavior in detail:
- A new PR is submitted using `sl pr submit`
  - The title and description are created out of the commit message.
- The author updates the title and description in the Github web UI
- The author makes changes in their local repo, amends and and runs `sl pr submit` again
  - The PR title is left alone.
  - The PR description is left alone, except for the stack list at the bottom which gets updated

At this point, I've set the option to default to `False` to avoid surprising current users, preserving current (albeit flawed) behavior. However, I believe over time this should default to True. The reasoning being that technically the local commit and remote PR should be 2 separate entities (a PR may contain more than one commit etc).

Test:
- Submit a PR
- Edit the title and description of the PR to make it different than the default commit message content.
- Create another PR stacked on top of the first one
- Submit the new PR
- Observe the old PR now has a stack list
- Amend either of the PRs locally with a new change
- Submit an update to the stack
- Verify the PR titles and descriptions have not changed.

**NOTE**: This PR is dependant on downstream #779 which fixes a bug affecting the parsing and detection of the stack list in the PR description. 

---
[//]: # (BEGIN SAPLING FOOTER)
* __->__ #780
* #779