### PR TITLE
[isl] increase width of diff window in split stack edit panel

### DIFF
--- a/addons/isl/src/stackEdit/ui/SplitStackEditPanel.css
+++ b/addons/isl/src/stackEdit/ui/SplitStackEditPanel.css
@@ -22,7 +22,7 @@
   padding-bottom: 0px;
   border-radius: var(--halfpad);
   min-width: 700px;
-  max-width: 700px;
+  max-width: max(700px, 50vw);
   flex-shrink: 0;
   height: 100%;
 }


### PR DESCRIPTION
The width of the a diff window in the stack splitting dialog in ISL is too narrow and isn't adaptive to screen sizes. It makes it unnecessarily hard to split code formatted with longer lines when working on larger screens and resolutions.

Tested with a longer line length on a small and large screen.


---
Stack created with [Sapling](https://sapling-scm.com).
* #782
* __->__ #781