### PR TITLE
[isl] reduce number of pr fetched in graphql query to avoid timeouts

### DIFF
--- a/addons/isl-server/src/github/githubCodeReviewProvider.ts
+++ b/addons/isl-server/src/github/githubCodeReviewProvider.ts
@@ -64,7 +64,7 @@ export class GitHubCodeReviewProvider implements CodeReviewProvider {
           // This is not very easy with github's graphql API, which doesn't allow more than 5 "OR"s in a search query.
           // But if we used one-query-per-diff we would reach rate limiting too quickly.
           searchQuery: `repo:${this.codeReviewSystem.owner}/${this.codeReviewSystem.repo} is:pr author:@me`,
-          numToFetch: 100,
+          numToFetch: 50,
         });
         if (allSummaries?.search.nodes == null) {
           this.diffSummaries.emit('data', new Map());

--- a/addons/isl/src/stackEdit/ui/SplitStackEditPanel.css
+++ b/addons/isl/src/stackEdit/ui/SplitStackEditPanel.css
@@ -22,7 +22,7 @@
   padding-bottom: 0px;
   border-radius: var(--halfpad);
   min-width: 700px;
-  max-width: 700px;
+  max-width: max(700px, 50vw);
   flex-shrink: 0;
   height: 100%;
 }


### PR DESCRIPTION
When using 100 PRs, I often encounter errors resulting of Github timeouts. Reducing the number of PRs we're fetching solves the issue.
A possibly more elegant future solution would be to specify which PRs' data we're interested in fetching.

---
Stack created with [Sapling](https://sapling-scm.com).
* __->__ #782
* #781