### PR TITLE
getdeps: add --build-type option to build in Debug or RelWithDebInfo mode

### DIFF
--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -814,6 +814,13 @@ class BuildCmd(ProjectCmdBase):
             action="store_true",
             default=False,
         )
+        parser.add_argument(
+            "--build-type",
+            help="Set the build type explicitly.  Cmake and cargo builders act on them. Only Debug and RelWithDebInfo widely supported.",
+            choices=["Debug", "Release", "RelWithDebInfo", "MinSizeRel"],
+            action="store",
+            default=None,
+        )
 
 
 @cmd("fixup-dyn-deps", "Adjusts dynamic dependencies for packaging purposes")
@@ -1038,6 +1045,10 @@ jobs:
 
             out.write("    - uses: actions/checkout@v4\n")
 
+            build_type_arg=""
+            if args.build_type:
+                build_type_arg = f"--build-type {args.build_type} "
+
             if build_opts.free_up_disk:
                 free_up_disk = "--free-up-disk "
                 if not build_opts.is_windows():
@@ -1118,7 +1129,7 @@ jobs:
                             has_same_repo_dep = True
                         out.write("    - name: Build %s\n" % m.name)
                         out.write(
-                            f"      run: {getdepscmd}{allow_sys_arg} build {src_dir_arg}{free_up_disk}--no-tests {m.name}\n"
+                            f"      run: {getdepscmd}{allow_sys_arg} build {build_type_arg}{src_dir_arg}{free_up_disk}--no-tests {m.name}\n"
                         )
 
             out.write("    - name: Build %s\n" % manifest.name)
@@ -1139,7 +1150,7 @@ jobs:
                 no_tests_arg = "--no-tests "
 
             out.write(
-                f"      run: {getdepscmd}{allow_sys_arg} build {no_tests_arg}{no_deps_arg}--src-dir=. {manifest.name} {project_prefix}\n"
+                f"      run: {getdepscmd}{allow_sys_arg} build {build_type_arg}{no_tests_arg}{no_deps_arg}--src-dir=. {manifest.name} {project_prefix}\n"
             )
 
             out.write("    - name: Copy artifacts\n")
@@ -1224,6 +1235,13 @@ jobs:
             help="Remove unused tools and clean up intermediate files if possible to maximise space for the build",
             action="store_true",
             default=False,
+        )
+        parser.add_argument(
+            "--build-type",
+            help="Set the build type explicitly.  Cmake and cargo builders act on them. Only Debug and RelWithDebInfo widely supported.",
+            choices=["Debug", "Release", "RelWithDebInfo", "MinSizeRel"],
+            action="store",
+            default=None,
         )
 
 

--- a/build/fbcode_builder/getdeps/builder.py
+++ b/build/fbcode_builder/getdeps/builder.py
@@ -488,7 +488,7 @@ def main():
                 "--target",
                 target,
                 "--config",
-                "Release",
+                {build_type},
                 get_jobs_argument(args.num_jobs),
         ] + args.cmake_args
     elif args.mode == "test":
@@ -610,8 +610,9 @@ if __name__ == "__main__":
             # unspecified.  Some of the deps fail to compile in release mode
             # due to warning->error promotion.  RelWithDebInfo is the happy
             # medium.
-            "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+            "CMAKE_BUILD_TYPE": self.build_opts.build_type
         }
+
         if "SANDCASTLE" not in os.environ:
             # We sometimes see intermittent ccache related breakages on some
             # of the FB internal CI hosts, so we prefer to disable ccache
@@ -708,6 +709,7 @@ if __name__ == "__main__":
                 build_dir=self.build_dir,
                 install_dir=self.inst_dir,
                 sys=sys,
+                build_type=self.build_opts.build_type,
             )
 
             self._invalidate_cache()
@@ -721,7 +723,7 @@ if __name__ == "__main__":
                 "--target",
                 self.cmake_target,
                 "--config",
-                "Release",
+                self.build_opts.build_type,
                 "-j",
                 str(self.num_jobs),
             ],
@@ -1194,7 +1196,7 @@ install(FILES sqlite3.h sqlite3ext.h DESTINATION include)
                 "--target",
                 "install",
                 "--config",
-                "Release",
+                self.build_opts.build_type,
                 "-j",
                 str(self.num_jobs),
             ],

--- a/build/fbcode_builder/getdeps/buildopts.py
+++ b/build/fbcode_builder/getdeps/buildopts.py
@@ -52,6 +52,7 @@ class BuildOptions(object):
         shared_libs: bool = False,
         facebook_internal=None,
         free_up_disk: bool = False,
+        build_type: str = None,
     ) -> None:
         """fbcode_builder_dir - the path to either the in-fbsource fbcode_builder dir,
                              or for shipit-transformed repos, the build dir that
@@ -67,6 +68,7 @@ class BuildOptions(object):
         vcvars_path - Path to external VS toolchain's vsvarsall.bat
         shared_libs - whether to build shared libraries
         free_up_disk - take extra actions to save runner disk space
+        build_type - CMAKE_BUILD_TYPE, used by cmake and cargo builders
         """
 
         if not install_dir:
@@ -106,6 +108,11 @@ class BuildOptions(object):
         self.lfs_path = lfs_path
         self.shared_libs = shared_libs
         self.free_up_disk = free_up_disk
+
+        if build_type is None:
+            build_type = "RelWithDebInfo"
+
+        self.build_type = build_type
 
         lib_path = None
         if self.is_darwin():
@@ -606,6 +613,7 @@ def setup_build_options(args, host_type=None) -> BuildOptions:
             "lfs_path",
             "shared_libs",
             "free_up_disk",
+            "build_type",
         }
     }
 

--- a/build/fbcode_builder/getdeps/cargo.py
+++ b/build/fbcode_builder/getdeps/cargo.py
@@ -148,21 +148,29 @@ incremental = false
     def _build(self, install_dirs, reconfigure) -> None:
         # _prepare has been run already. Actually do the build
         build_source_dir = self.build_source_dir()
+
+        build_args = [
+            "--out-dir",
+            os.path.join(self.inst_dir, "bin"),
+            "-Zunstable-options",
+        ]
+
+        if self.build_opts.build_type != "Debug":
+            build_args.append("--release")
+
         if self.manifests_to_build is None:
             self.run_cargo(
                 install_dirs,
                 "build",
-                ["--out-dir", os.path.join(self.inst_dir, "bin"), "-Zunstable-options"],
+                build_args,
             )
         else:
             for manifest in self.manifests_to_build:
                 self.run_cargo(
                     install_dirs,
                     "build",
-                    [
-                        "--out-dir",
-                        os.path.join(self.inst_dir, "bin"),
-                        "-Zunstable-options",
+                    build_args
+                    + [
                         "--manifest-path",
                         self.manifest_dir(manifest),
                     ],


### PR DESCRIPTION
getdeps: add --build-type option to build in Debug or RelWithDebInfo mode

Adds a --build-type option so one can force RelWithDebInfo or Debug explicity

Default remains RelWithDebInfo for cmake.

cargo default is updated to --release to match cmake more closely, if you don't want release use --build-type Debug.

If you want to run github CI in Debug mode (faster build, but tests will run slower), then can pass --build-type Debug to getdeps.py generate-github-actions

Test plan:

test cmake locally with:
```
rm -rf "$(./build/fbcode_builder/getdeps.py show-scratch-dir)/build/eden"
\time ./build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. --project-install-prefix eden:/usr/local eden`
```

Before, no build type override, so using the RelWithDebInfo default:
```
5248.08user 430.84system 4:56.08elapsed 1918%CPU (0avgtext+0avgdata 5114200maxresident)k
37040inputs+44610808outputs (3471major+99433066minor)pagefaults 0swaps
```

After, using new --build-type=Debug
```
3241.20user 407.41system 3:18.61elapsed 1837%CPU (0avgtext+0avgdata 5073736maxresident)k
3800920inputs+54157640outputs (4255major+93446653minor)pagefaults 0swaps
```

test cargo locally with:
```
rm -rf "$(./build/fbcode_builder/getdeps.py show-scratch-dir)/build/mononoke"
\time ./build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. mononoke
```

Before, debug by default:
```
1394.39user 452.40system 2:33.99elapsed 1199%CPU (0avgtext+0avgdata 2062784maxresident)k
28548344inputs+50334480outputs (2216major+55720388minor)pagefaults 0swaps
```

After, release by default:
```
5803.35user 332.76system 4:31.89elapsed 2256%CPU (0avgtext+0avgdata 2424304maxresident)k
11618048inputs+44717584outputs (1377major+62062485minor)pagefaults 0swaps
```

CI
