### PR TITLE
Configurable branch prefix for github PRs

### DIFF
--- a/eden/scm/Makefile
+++ b/eden/scm/Makefile
@@ -16,10 +16,8 @@
 
 export PREFIX=/usr/local
 
-ifeq ($(OS),Windows_NT)
-PYTHON := python
-endif
-PYTHON3 := python3
+PYTHON ?= $(shell python3 contrib/pick_python.py)
+export PYTHON_SYS_EXECUTABLE=$(PYTHON)
 
 ifeq ($(OS),Windows_NT)
   BUCK_DEV_BUILD_MODE := @fbcode//mode/win
@@ -30,7 +28,7 @@ else
   endif
 endif
 
-PYTHON_MINOR_VERSION=$(shell $(shell $(PYTHON3) contrib/pick_python.py $(PYTHON3)) -c "import sys; print(sys.version_info.minor)")
+PYTHON_MINOR_VERSION=$(shell $(PYTHON) -c "import sys; print(sys.version_info.minor)")
 
 ifeq ($(RUST_DEBUG),1)
 RUST_FLAG = --debug
@@ -92,7 +90,7 @@ install-oss: oss
 
 local:
 	SAPLING_OSS_BUILD=$(OSS) HGNAME=$(HGNAME) \
-	  $(shell $(PYTHON3) contrib/pick_python.py $(PYTHON3)) setup.py $(PURE) \
+	  $(PYTHON) setup.py $(PURE) \
 	  build_interactive_smartlog \
 	  build_clib $(COMPILERFLAG) \
 	  build_rust_ext -i -l $(RUST_FLAG) \
@@ -105,7 +103,7 @@ else
 endif
 
 hg:
-	SAPLING_SKIP_OTHER_RUST_BINARIES=true $(shell $(PYTHON3) contrib/pick_python.py $(PYTHON3)) setup.py $(PURE) \
+	SAPLING_SKIP_OTHER_RUST_BINARIES=true $(PYTHON) setup.py $(PURE) \
 	  build_clib $(COMPILERFLAG) \
 	  build_rust_ext -i -l $(RUST_FLAG) \
 	  build_mo
@@ -135,13 +133,12 @@ getdepsbuild:
 	mkdir -p $(GETDEPS_BUILD_DIR)/eden_scm
 	ln -sfn $(GETDEPS_BUILD_DIR)/eden_scm build
 	GETDEPS_BUILD=1 \
-		PYTHON_SYS_EXECUTABLE=$(shell $(PYTHON3) contrib/pick_python.py $(PYTHON3)) \
 		THRIFT="$(GETDEPS_INSTALL_DIR)/fbthrift/bin/thrift1" \
-		$(shell $(PYTHON3) contrib/pick_python.py $(PYTHON3)) setup.py \
+		$(PYTHON) setup.py \
 		$(PURE) build $(COMPILERFLAG)
 
 cleanbutpackages:
-	-$(PYTHON3) setup.py clean --all # ignore errors from this command
+	-$(PYTHON) setup.py clean --all # ignore errors from this command
 	find contrib doc i18n sapling tests \
 		\( -name '*.py[cdo]' -o -name '*.so' \) -exec rm -f '{}' ';'
 	rm -f MANIFEST MANIFEST.in sapling/ext/__index__.py tests/*.err
@@ -166,16 +163,15 @@ install-home: build
 	$(PYTHON) setup.py $(PURE) install --home="$(HOME)" --prefix="" --force
 
 install-getdeps: getdepsbuild
-	PYTHON_SYS_EXECUTABLE=$(shell $(PYTHON3) contrib/pick_python.py $(PYTHON3)) \
-	    GETDEPS_BUILD=1 $(shell $(PYTHON3) contrib/pick_python.py $(PYTHON3)) \
+	    GETDEPS_BUILD=1 $(PYTHON) \
 		setup.py $(PURE) install --root="$(DESTDIR)/" --prefix="$(PREFIX)" --install-lib="$(PREFIX)/bin" --force
 
 check: tests
 
 .PHONY: tests
 tests:
-	cd tests && PYTHON_SYS_EXECUTABLE=$(shell $(PYTHON3) contrib/pick_python.py $(PYTHON3)) \
-	    $(shell $(PYTHON3) contrib/pick_python.py $(PYTHON3)) run-tests.py
+	cd tests && \
+	    $(PYTHON) run-tests.py
 
 update-pot: i18n/hg.pot
 

--- a/eden/scm/sapling/ext/github/mock_utils.py
+++ b/eden/scm/sapling/ext/github/mock_utils.py
@@ -172,6 +172,7 @@ class MockGitHubServer:
 
     def expect_create_pr_using_placeholder_request(
         self,
+        ui,
         body: str,
         issue: int,
         head: str = "",
@@ -180,9 +181,10 @@ class MockGitHubServer:
         owner: str = OWNER,
         name: str = REPO_NAME,
     ) -> "CreatePrUsingPlaceholderRequest":
+        pr_branch_prefix = ui.config("github", "pr_branch_prefix", "")
         params: ParamsType = {
             "base": base,
-            "head": head or f"pr{issue}",
+            "head": head or f"{pr_branch_prefix}pr{issue}",
             "body": body,
             "issue": issue,
             "draft": is_draft,

--- a/eden/scm/sapling/ext/github/pull_request_body.py
+++ b/eden/scm/sapling/ext/github/pull_request_body.py
@@ -41,7 +41,7 @@ def create_pull_request_title_and_body(
     Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack]({reviewstack_url}).
     * #1
     * #2 (2 commits)
-    * __->__ #42
+    * #42 \u21E6
     * #4
 
     Disable reviewstack message:
@@ -53,7 +53,7 @@ def create_pull_request_title_and_body(
     ---
     * #1
     * #2 (2 commits)
-    * __->__ #42
+    * #42 \u21E6
     * #4
 
     Single commit stack:
@@ -81,7 +81,7 @@ def create_pull_request_title_and_body(
     return title, body
 
 
-_STACK_ENTRY = re.compile(r"^\* (__->__ )?#([1-9]\d*).*$")
+_STACK_ENTRY = re.compile(r"^\* (__->__ )?#([1-9]\d*)( \u21E6)?.*$")
 
 # Pair where the first value is True if this entry was noted as the "current"
 # one with the "__->__" marker; otherwise, False.
@@ -101,6 +101,17 @@ def parse_stack_information(body: str) -> List[_StackEntry]:
     ...     '* #1\n' +
     ...     '* #2 (2 commits)\n' +
     ...     '* __->__ #42\n' +
+    ...     '* #4\n')
+    >>> parse_stack_information(body)
+    [(False, 1), (False, 2), (True, 42), (False, 4)]
+    >>> body = (
+    ...     'The original commit message.\n' +
+    ...     'Second line of message.\n' +
+    ...     '---\n' +
+    ...     'Stack created with [Sapling](https://sapling-scm.com). ' +
+    ...     '* #1\n' +
+    ...     '* #2 (2 commits)\n' +
+    ...     '* #42 \u21E6\n' +
     ...     '* #4\n')
     >>> parse_stack_information(body)
     [(False, 1), (False, 2), (True, 42), (False, 4)]
@@ -135,7 +146,7 @@ def _format_stack_entry(
     line = (
         f"* #{pr_number}"
         if current_pr_index != pr_number_index
-        else f"* __->__ #{pr_number}"
+        else f"* #{pr_number} \u21E6"
     )
     if num_commits > 1:
         line += f" ({num_commits} commits)"

--- a/eden/scm/sapling/ext/github/submit.py
+++ b/eden/scm/sapling/ext/github/submit.py
@@ -301,6 +301,11 @@ class SerialStrategyParams:
     repository: Optional[Repository]
 
 
+def branch_name_for_pr(ui, pull_request_number) -> str:
+    # Consider including username in branch_name?
+    branch_prefix = ui.config("github", "pr_branch_prefix", "")
+    return f"{branch_prefix}pr{pull_request_number}"
+
 async def create_serial_strategy_params(
     ui,
     partitions: List[List[CommitData]],
@@ -351,8 +356,8 @@ async def create_serial_strategy_params(
                     next_pull_request_number = result.unwrap()
             else:
                 next_pull_request_number += 1
-            # Consider including username in branch_name?
-            branch_name = f"pr{next_pull_request_number}"
+            branch_name = branch_name_for_pr(ui, next_pull_request_number)
+
             refs_to_update.append(f"{hex(top.node)}:refs/heads/{branch_name}")
             top.head_branch_name = branch_name
             pull_requests_to_create.append((top, branch_name))
@@ -486,8 +491,7 @@ async def create_placeholder_strategy_params(
         for commit_needs_pr, number in zip(
             commits_that_need_pull_requests, issue_numbers
         ):
-            # Consider including username in branch_name?
-            branch_name = f"pr{number}"
+            branch_name = branch_name_for_pr(ui, number)
             commit = commit_needs_pr.commit
             commit.head_branch_name = branch_name
             refs_to_update.append(f"{hex(commit.node)}:refs/heads/{branch_name}")

--- a/eden/scm/setup.py
+++ b/eden/scm/setup.py
@@ -417,8 +417,7 @@ def pickversion():
     # Some tools parse this number to figure out if they support this version of
     # Mercurial, so prepend with 4.4.2.
     # ex. 4.4.2_20180105_214829_58fda95a0202
-    return "_".join(["4.4.2"] + out.split())
-
+    return "4.4.2+" + "_".join(out.split())
 
 if not os.path.isdir(builddir):
     # Create the "build" directory

--- a/eden/scm/tests/github/mock_create_one_pr_placeholder_issue.py
+++ b/eden/scm/tests/github/mock_create_one_pr_placeholder_issue.py
@@ -13,7 +13,7 @@ from sapling.ext.github.mock_utils import mock_run_git_command, MockGitHubServer
 # function for how wrapper functions are registered.
 
 
-def setup_mock_github_server() -> MockGitHubServer:
+def setup_mock_github_server(ui) -> MockGitHubServer:
     """Setup mock GitHub Server for testing happy case of `sl pr submit` command."""
     github_server = MockGitHubServer()
 
@@ -26,7 +26,7 @@ def setup_mock_github_server() -> MockGitHubServer:
 
     body = "addfile\n"
     github_server.expect_create_pr_using_placeholder_request(
-        body=body, issue=pr_number
+        ui, body=body, issue=pr_number
     ).and_respond()
 
     pr_id = f"PR_id_{pr_number}"
@@ -42,7 +42,7 @@ def setup_mock_github_server() -> MockGitHubServer:
 
 
 def uisetup(ui):
-    mock_github_server = setup_mock_github_server()
+    mock_github_server = setup_mock_github_server(ui)
     extensions.wrapfunction(
         github_gh_cli, "_make_request", mock_github_server.make_request
     )

--- a/eden/scm/tests/github/mock_create_prs.py
+++ b/eden/scm/tests/github/mock_create_prs.py
@@ -28,10 +28,11 @@ def setup_mock_github_server(ui) -> MockGitHubServer:
     ]
 
     single = ui.config("github", "pr-workflow") == "single"
+    pr_branch_prefix = ui.config("github", "pr_branch_prefix", "")
 
     for idx, (num, body) in enumerate(prs):
         title = firstline(body)
-        head = f"pr{num}"
+        head = f"{pr_branch_prefix}pr{num}"
 
         base = "main"
         if single and idx > 0:


### PR DESCRIPTION

This PR adds a config option to set a prefix on the branch name for
PRs submitted to github.  This enables a github action to block merge
of PRs before their parent in the stack is merged, enabling stacked
review directly on Github.

Other commits in this PR:
 - Make version in setup.py pip-440 compliant
 - Allow overriding python during build
 - Use a more pleasing arrow for current PR in stack

