### PR TITLE
Remove extra semi colon from dyno/cpp/server/parsing/util.h

### DIFF
--- a/eden/fs/fuse/FuseChannel.cpp
+++ b/eden/fs/fuse/FuseChannel.cpp
@@ -1175,7 +1175,7 @@ TraceDetailedArgumentsHandle FuseChannel::traceDetailedArguments() const {
       });
   traceDetailedArguments_->fetch_add(1, std::memory_order_acq_rel);
   return handle;
-};
+}
 
 void FuseChannel::requestSessionExit(StopReason reason) {
   requestSessionExit(state_.wlock(), reason);


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: palmje

Differential Revision: D51995090


