### PR TITLE
add oncall annotation for TARGETS files in fbcode based on contbuild information - /data/users/bayarmunkh/target_oncalls_12

### DIFF
--- a/eden/scm/lib/revsets/TARGETS
+++ b/eden/scm/lib/revsets/TARGETS
@@ -1,5 +1,7 @@
 load("@fbcode_macros//build_defs:rust_library.bzl", "rust_library")
 
+oncall("mercurial_release")
+
 rust_library(
     name = "revsets",
     srcs = glob(["src/**/*.rs"]),


### PR DESCRIPTION
Summary:
This diff adds oncall to Buck TARGETS files in fbcode repository based on their contbuild information.

This diff was generated by this command:
    ./fbcode/ownership/coverage/submit_diff_with_file_oncall_mapping.sh /data/users/bayarmunkh/target_oncalls_12

see more context here: https://fb.workplace.com/groups/fbcode/posts/6551897871513663 and https://fb.workplace.com/groups/fbcode.devx/permalink/3149549092006627/

drop_conflicts

Reviewed By: markisaa

Differential Revision: D52121648


