### PR TITLE
Avoid linkifying example URL.

### DIFF
--- a/eden/scm/sapling/ext/github/__init__.py
+++ b/eden/scm/sapling/ext/github/__init__.py
@@ -138,9 +138,7 @@ def pull_cmd(ui, repo, *args, **opts):
     """import a pull request into your working copy
 
     The PULL_REQUEST can be specified as either a URL:
-
-        https://github.com/facebook/sapling/pull/321
-
+    `https://github.com/facebook/sapling/pull/321`
     or just the PR number within the GitHub repository identified by
     `sl config paths.default`.
     """


### PR DESCRIPTION
Avoid linkifying example URL.

Without wrapping the URL in backticks, Docusaurus will linkify
the URL to point at the actual pull request, making the docs
not clear at all.
