### PR TITLE
doc: fix GitHub PR link in `getting-started.md`

### DIFF
--- a/website/docs/introduction/getting-started.md
+++ b/website/docs/introduction/getting-started.md
@@ -170,7 +170,7 @@ In addition to reviewing pull requests on github.com, you may also want to try [
 
 To view a GitHub pull request on ReviewStack, take the original URL:
 
-> https://github.com/facebook/react/pull/25506
+> [https://github.com/facebook/react/pull/25506](https://github.com/facebook/react/pull/25506)
 
 and replace the `github.com` domain with `reviewstack.dev`:
 


### PR DESCRIPTION
The 'Getting Started' documentation page has a section about replacing the GitHub PR URL with reviewstack, but the link in Markdown is parsed as GitHub flavored Markdown and shows just `facebook/react#25506` instead of `https://github.com/facebook/react/pull/25506` which is slightly confusing. This change fixes that to the full intended URL is displayed.

See: https://sapling-scm.com/docs/introduction/getting-started#browsing-pull-requests
![image](https://github.com/facebook/sapling/assets/132238190/89880bb4-b13f-4980-9e9c-c1a446dfbc4d)
