### PR TITLE
Add "open in code review" context menu action

### DIFF
--- a/addons/isl-server/src/CodeReviewProvider.ts
+++ b/addons/isl-server/src/CodeReviewProvider.ts
@@ -45,6 +45,13 @@ export interface CodeReviewProvider {
   getDiffUrlMarkdown(diffId: DiffId): string;
   getCommitHashUrlMarkdown(hash: string): string;
 
+  getRemoteFileURL?(
+    path: string,
+    publicCommitHash: string | null,
+    selectionStart?: {line: number; char: number},
+    selectionEnd?: {line: number; char: number},
+  ): string;
+
   updateDiffMessage?(diffId: DiffId, newTitle: string, newDescription: string): Promise<void>;
 
   getSuggestedReviewers?(context: {paths: Array<string>}): Promise<Array<string>>;

--- a/addons/isl-server/src/Repository.ts
+++ b/addons/isl-server/src/Repository.ts
@@ -677,9 +677,14 @@ export class Repository {
     }
   });
 
+  /** Get the current head commit if loaded */
+  getHeadCommit(): CommitInfo | undefined {
+    return this.smartlogCommits?.commits.value?.find(commit => commit.isHead);
+  }
+
   /** Watch for changes to the head commit, e.g. from checking out a new commit */
   subscribeToHeadCommit(callback: (head: CommitInfo) => unknown) {
-    let headCommit = this.smartlogCommits?.commits.value?.find(commit => commit.isHead);
+    let headCommit = this.getHeadCommit();
     if (headCommit != null) {
       callback(headCommit);
     }

--- a/addons/isl-server/src/github/githubCodeReviewProvider.ts
+++ b/addons/isl-server/src/github/githubCodeReviewProvider.ts
@@ -133,6 +133,26 @@ export class GitHubCodeReviewProvider implements CodeReviewProvider {
       this.codeReviewSystem.owner
     }/${this.codeReviewSystem.repo}/commit/${hash})`;
   }
+
+  getRemoteFileURL(
+    path: string,
+    publicCommitHash: string | null,
+    selectionStart?: {line: number; char: number},
+    selectionEnd?: {line: number; char: number},
+  ): string {
+    const {hostname, owner, repo} = this.codeReviewSystem;
+    let url = `https://${hostname}/${owner}/${repo}/blob/${publicCommitHash ?? 'HEAD'}/${path}`;
+    if (selectionStart != null) {
+      url += `#L${selectionStart.line + 1}`;
+      if (
+        selectionEnd &&
+        (selectionEnd.line !== selectionStart.line || selectionEnd.char !== selectionStart.char)
+      ) {
+        url += `C${selectionStart.char + 1}-L${selectionEnd.line + 1}C${selectionEnd.char + 1}`;
+      }
+    }
+    return url;
+  }
 }
 
 function githubStatusRollupStateToCIStatus(state: StatusState | undefined): DiffSignalSummary {

--- a/addons/vscode/extension/VSCodeRepo.ts
+++ b/addons/vscode/extension/VSCodeRepo.ts
@@ -15,6 +15,7 @@ import type {Writable} from 'shared/typeUtils';
 
 import {encodeSaplingDiffUri} from './DiffContentProvider';
 import SaplingFileDecorationProvider from './SaplingFileDecorationProvider';
+import {executeVSCodeCommand} from './commands';
 import {getCLICommand} from './config';
 import {t} from './i18n';
 import {Repository} from 'isl-server/src/Repository';
@@ -84,6 +85,15 @@ export class VSCodeReposList {
       repo?.unref();
       this.knownRepos.delete(fsPath);
     }
+
+    executeVSCodeCommand('setContext', 'sapling:hasRepo', this.knownRepos.size > 0);
+
+    Promise.all(Array.from(this.knownRepos.values()).map(repo => repo.promise)).then(repos => {
+      const hasRemoteLinkRepo = repos.some(
+        repo => repo instanceof Repository && repo.codeReviewProvider?.getRemoteFileURL,
+      );
+      executeVSCodeCommand('setContext', 'sapling:hasRemoteLinkRepo', hasRemoteLinkRepo);
+    });
   }
 
   /** return the VSCodeRepo that contains the given path */

--- a/addons/vscode/extension/commands.ts
+++ b/addons/vscode/extension/commands.ts
@@ -17,6 +17,7 @@ import {t} from './i18n';
 import fs from 'fs';
 import {repoRelativePathForAbsolutePath} from 'isl-server/src/Repository';
 import {repositoryCache} from 'isl-server/src/RepositoryCache';
+import {findPublicAncestor} from 'isl-server/src/utils';
 import {RevertOperation} from 'isl/src/operations/RevertOperation';
 import path from 'path';
 import {ComparisonType, labelForComparison} from 'shared/Comparison';
@@ -37,6 +38,13 @@ export const vscodeCommands = {
   ),
   ['sapling.open-file-diff']: (uri: vscode.Uri, comparison: Comparison) =>
     openDiffView(uri, comparison),
+
+  ['sapling.open-remote-file-link']: commandWithUriOrResourceState(
+    (repo: Repository, uri, path: RepoRelativePath) => openRemoteFileLink(repo, uri, path),
+  ),
+  ['sapling.copy-remote-file-link']: commandWithUriOrResourceState(
+    (repo: Repository, uri, path: RepoRelativePath) => openRemoteFileLink(repo, uri, path, true),
+  ),
 
   ['sapling.revert-file']: commandWithUriOrResourceState(async function (
     this: Context,
@@ -64,6 +72,7 @@ type ExternalVSCodeCommands = {
   'sapling.open-isl': () => Thenable<void>;
   'sapling.close-isl': () => Thenable<void>;
   'sapling.isl.focus': () => Thenable<void>;
+  setContext: (key: string, value: unknown) => Thenable<void>;
   'fb-hg.open-or-focus-interactive-smartlog': (
     _: unknown,
     __?: unknown,
@@ -151,6 +160,50 @@ async function openDiffView(uri: vscode.Uri, comparison: Comparison): Promise<un
   return executeVSCodeCommand('vscode.diff', uriForComparisonParent, uriForComparison, title);
 }
 
+function openRemoteFileLink(
+  repo: Repository,
+  uri: vscode.Uri,
+  path: RepoRelativePath,
+  copyToClipboard = false,
+): void {
+  {
+    if (!repo.codeReviewProvider?.getRemoteFileURL) {
+      vscode.window.showErrorMessage(
+        t(
+          `Remote link unsupported for this code review provider (${repo.codeReviewProvider?.getSummaryName()})`,
+        ),
+      );
+      return;
+    }
+
+    // Grab the selection if the command is for the active file (may not be true if triggered via file explorer)
+    const selection =
+      vscode.window.activeTextEditor?.document.uri.fsPath === uri.fsPath
+        ? vscode.window.activeTextEditor?.selection
+        : null;
+
+    const commits = repo.getSmartlogCommits()?.commits.value;
+    const head = repo.getHeadCommit();
+    if (!commits || !head) {
+      vscode.window.showErrorMessage(t(`No commits loaded in this repository yet`));
+      return;
+    }
+    const publicCommit = findPublicAncestor(commits, head);
+    const url = repo.codeReviewProvider.getRemoteFileURL(
+      path,
+      publicCommit?.hash ?? null,
+      selection ? {line: selection.start.line, char: selection.start.character} : undefined,
+      selection ? {line: selection.end.line, char: selection.end.character} : undefined,
+    );
+
+    if (copyToClipboard) {
+      vscode.env.clipboard.writeText(url);
+    } else {
+      vscode.env.openExternal(vscode.Uri.parse(url));
+    }
+  }
+}
+
 /**
  * Wrap a command implementation so it can be called with any of:
  * - current active file Uri for use from the command palette
@@ -162,7 +215,7 @@ function commandWithUriOrResourceState<Ctx>(
     repo: Repository,
     uri: vscode.Uri,
     path: RepoRelativePath,
-  ) => undefined | Thenable<unknown>,
+  ) => unknown | Thenable<unknown>,
 ) {
   return function (
     this: Ctx,

--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -106,9 +106,39 @@
       {
         "command": "sapling.isl.focus",
         "title": "Focus Sapling ISL Sidebar"
+      },
+      {
+        "command": "sapling.open-remote-file-link",
+        "title": "Open in Code Review",
+        "enablement": "sapling:hasRemoteLinkRepo"
+      },
+      {
+        "command": "sapling.copy-remote-file-link",
+        "title": "Copy Code Review Link",
+        "enablement": "sapling:hasRemoteLinkRepo"
       }
     ],
     "menus": {
+      "editor/context": [
+        {
+          "command": "sapling.open-remote-file-link",
+          "when": "sapling:hasRemoteLinkRepo"
+        },
+        {
+          "command": "sapling.copy-remote-file-link",
+          "when": "sapling:hasRemoteLinkRepo"
+        }
+      ],
+      "explorer/context": [
+        {
+          "command": "sapling.open-remote-file-link",
+          "when": "sapling:hasRemoteLinkRepo && isFileSystemResource && resourceScheme =~ /^(?!output$|vscode-(?!remote|vfs$)).*$/"
+        },
+        {
+          "command": "sapling.copy-remote-file-link",
+          "when": "sapling:hasRemoteLinkRepo && isFileSystemResource && resourceScheme =~ /^(?!output$|vscode-(?!remote|vfs$)).*$/"
+        }
+      ],
       "commandPalette": [
         {
           "command": "sapling.isl.focus",


### PR DESCRIPTION
Add "open in code review" context menu action

A common feature from other SCM extensions is a context-menu item to copy a link / open the selection/file in the remote SCM provider (ex. open in Github). This adds support for that in the editor / file explorer.

Couple of things I wasn't totally confident about that I'd like thoughts on:
- I opted to just add this to context menu in vscode since that's where most other extensions do this, but I'm guessing this might be desired in ISL too, which might changed some implementation details
- Open to other titles for the commands, but afaict the message can't be dynamic (i.e. use code review provider's name), so I settled on "Open in Code Review"
- I went with the simple approach of copying a link to the file on main using the same line numbers. This won't necessarily work if the file is dirty or modified in remote main. This could be mitigated by using the most recent public commit instead of main, and perhaps some magic with blame, but seemed more complex
- Not sure the best way to grab the remote branch's name; just hard-coded "main" in my testing, but it could be "master" or something else as well. Is this easily retrievable from sapling?
- I started setting a context for "sapling:hasRepo" so the option would only show if the editor has some folder with a sapling repo. I could be smarter and check if the active file is in a repo, but this seemed effective enough and simpler (scmProvider used in other commands is only available with the SCM panel)
