### PR TITLE
Default to showing blame

### DIFF
--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -45,7 +45,8 @@
         },
         "sapling.showInlineBlame": {
           "type": "boolean",
-          "description": "%settings.showInlineBlame.description%"
+          "description": "%settings.showInlineBlame.description%",
+          "default": true
         },
         "sapling.isl.showInSidebar": {
           "type": "boolean",


### PR DESCRIPTION
Default to showing blame

Blame feature has been out for a while and seems functional generally. I often get questions about how to enable this.

Seems like it should be good to just enable by default, but if that conflicts with an internal blame or something I could try and ensure we set this setting in all our repos instead
