### PR TITLE
Don't force en_US.utf-8 as locale as it mgiht not exist.

### DIFF
--- a/addons/isl-server/src/Repository.ts
+++ b/addons/isl-server/src/Repository.ts
@@ -1208,7 +1208,7 @@ function getExecParams(
     env: {
       ...options_?.env,
       ...env,
-      LANG: 'en_US.utf-8', // make sure to use unicode if user hasn't set LANG themselves
+      LANG: 'C.UTF-8', // make sure to use unicode if user hasn't set LANG themselves
       // TODO: remove when SL_ENCODING is used everywhere
       HGENCODING: 'UTF-8',
       SL_ENCODING: 'UTF-8',


### PR DESCRIPTION
Don't force en_US.utf-8 as locale as it mgiht not exist.

glibc does not generate all combinations of locales by default, and Python
fails when requesting to enforce a locale that does not exist.

Since the extension is not caring for the translation chosen, but rather
only trying to enforce UTF-8 support, use the C.UTF-8 locale which is
guaranteed to exist as per https://www.gnu.org/software/libc/manual/html_node/Choosing-Locale.html

Fixes #814 where VSCode would intermittently be unable to identify
a valid Sapling checkout and/or pull from a repository.
