### PR TITLE
Trim commit description from SSL

### DIFF
--- a/addons/isl-server/src/Repository.ts
+++ b/addons/isl-server/src/Repository.ts
@@ -1281,7 +1281,8 @@ export function parseCommitInfoOutput(logger: Logger, output: string): SmartlogC
         closestPredecessors: splitLine(lines[FIELD_INDEX.cloesestPredecessors], ','),
         description: lines
           .slice(FIELD_INDEX.description + 1 /* first field of description is title; skip it */)
-          .join('\n'),
+          .join('\n')
+          .trim(),
         diffId: lines[FIELD_INDEX.diffId] != '' ? lines[FIELD_INDEX.diffId] : undefined,
         stableCommitMetadata:
           lines[FIELD_INDEX.stableCommitMetadata] != ''


### PR DESCRIPTION
Trim commit description from SSL


Currently, when a commit is created with a title/description, the PR/commit description is:
```
{title}

{desc}
```

When the description was parsed out previously, the first line (and trailing linebreak) were stripped, but the line in between title/desc was left around. This meant every time you amended a commit/PR, another linebreak got added to the top.

I figure its probably fine to just trim whitespace from the description in general, but could update this to only trim leading whitespace (cant really just change the slice() index to ` + 2` because the commit may come from another source than sapling, and may not contain this extra linebreak)
