### PR TITLE
Fix commit message template

### DIFF
--- a/addons/isl-server/src/Repository.ts
+++ b/addons/isl-server/src/Repository.ts
@@ -177,7 +177,7 @@ const CHANGED_FILES_TEMPLATE = [...Object.values(CHANGED_FILES_FIELDS), COMMIT_E
  * Prefer using `RepositoryCache.getOrCreate()` to access and dispose `Repository`s.
  */
 export class Repository {
-  public IGNORE_COMMIT_MESSAGE_LINES_REGEX = /^((?:HG|SL):.*)/gm;
+  public IGNORE_COMMIT_MESSAGE_LINES_REGEX = /^((?:HG|SL):.*)\n?/gm;
 
   private mergeConflicts: MergeConflicts | undefined = undefined;
   private uncommittedChanges: FetchedUncommittedChanges | null = null;

--- a/addons/isl-server/src/ServerToClientAPI.ts
+++ b/addons/isl-server/src/ServerToClientAPI.ts
@@ -838,7 +838,7 @@ export default class ServerToClientAPI {
         .replace(repo.IGNORE_COMMIT_MESSAGE_LINES_REGEX, '')
         .replace(/^<Replace this line with a title. Use 1 line only, 67 chars or less>/, '');
 
-      if (customTemplate?.trim() !== '') {
+      if (customTemplate && customTemplate?.trim() !== '') {
         template = customTemplate as string;
 
         this.tracker.track('UseCustomCommitMessageTemplate');


### PR DESCRIPTION
Fix commit message template

Fixing an issue where the commit template from `sl debugcommitmessage` would be overridden by `Internal.getCustomDefaultCommitTemplate()`. This is because the check `customTemplate?.trim() !== ''` would return `true` for undefined, leading to the template being overwritten with `undefined` when there is no internal template.

After this fix, a template correctly loads into ISL with "Summary" and "Test Plan" by default.

Also updated the "ignore line" regex to include the trailing linebreak (optionally), to prevent a bunch of blank lines in templates.

## Test Plan

Confirmed after this fix, the default template of:
```
<Replace this line with a title. Use 1 line only, 67 chars or less>

Summary:

Test Plan:


SL: Enter commit message.  Lines beginning with 'SL:' are removed.
SL: Leave message empty to abort commit.
SL: --
SL: user: Alex Coleman <alex@statsig.com>
SL: changed addons/isl-server/src/Repository.ts        |  5 +++--
SL: changed addons/isl-server/src/ServerToClientAPI.ts |  2 +-
SL:  2 files changed, 4 insertions(+), 3 deletions(-)
```

was now transformed to:
```

Summary:

Test Plan:


```

And then correctly appeared in ISL:
<img width="415" alt="Screenshot 2024-01-20 at 3 54 06 PM" src="https://github.com/facebook/sapling/assets/77301670/333872fd-cfff-4d0e-96f7-5456cd71866f">
