### PR TITLE
Don't include commit title in PR body

### DIFF
--- a/eden/scm/sapling/ext/github/pull_request_body.py
+++ b/eden/scm/sapling/ext/github/pull_request_body.py
@@ -67,7 +67,10 @@ def create_pull_request_title_and_body(
     """
     owner, name = repository.get_upstream_owner_and_name()
     pr = pr_numbers_and_num_commits[pr_numbers_index][0]
-    title = title if title is not None else firstline(commit_msg)
+
+    if title is None:
+        title = firstline(commit_msg)
+        body = commit_msg[len(title)+1:]
     body = _strip_stack_information(commit_msg)
     extra = []
     if len(pr_numbers_and_num_commits) > 1:


### PR DESCRIPTION
Don't include commit title in PR body

Seems redundant to include the commit title in both the PR body and title, so this strips out the title.

Had some trouble building to test this out (ran into `error[E0658]: use of unstable library feature 'stdsimd'`)
