### PR TITLE
Optionally limit the number of PRs created in each submission

### DIFF
--- a/eden/scm/sapling/ext/github/submit.py
+++ b/eden/scm/sapling/ext/github/submit.py
@@ -171,15 +171,21 @@ async def update_commits_in_stack(
             ui, partitions, github_repo, origin
         )
 
-    max_pull_requests_to_create = ui.configint("github", "max-prs-to-create", "-1")
+    max_pull_requests_to_create = ui.configint("github", "max-prs-to-create", "5")
     if (
         max_pull_requests_to_create >= 0
         and params.pull_requests_to_create
         and len(params.pull_requests_to_create) > max_pull_requests_to_create
     ):
         raise error.Abort(
-            _("refused to create %d pull requests, max is %d")
-            % (len(params.pull_requests_to_create), max_pull_requests_to_create)
+            _(
+                "refused to create %d pull requests, max is %d\nif you want to create %d pull requests at once, run again with `--config github.max-prs-to-create=-1`"
+            )
+            % (
+                len(params.pull_requests_to_create),
+                max_pull_requests_to_create,
+                len(params.pull_requests_to_create),
+            )
         )
 
     refs_to_update = params.refs_to_update

--- a/eden/scm/sapling/ext/github/submit.py
+++ b/eden/scm/sapling/ext/github/submit.py
@@ -170,6 +170,18 @@ async def update_commits_in_stack(
         params = await create_serial_strategy_params(
             ui, partitions, github_repo, origin
         )
+
+    max_pull_requests_to_create = ui.configint("github", "max-prs-to-create", "-1")
+    if (
+        max_pull_requests_to_create >= 0
+        and params.pull_requests_to_create
+        and len(params.pull_requests_to_create) > max_pull_requests_to_create
+    ):
+        raise error.Abort(
+            _("refused to create %d pull requests, max is %d")
+            % (len(params.pull_requests_to_create), max_pull_requests_to_create)
+        )
+
     refs_to_update = params.refs_to_update
 
     gitdir = None


### PR DESCRIPTION
Optionally limit the number of PRs created in each submission

Currently, when submitting a PR in Sapling, it's easy to accidentally create multiple PRs when only one was intended (e.g. forgetting to run `sl pr follow`, or editing a PR that is based off a different branch).

With this change, you can configure Sapling to limit the number of PRs that can be created in a single submit action, e.g. to just 1:
```
sl config --user github.max-prs-to-create=1
```
Now when attempting to create multiple PRs in a single `sl pr submit` action, Sapling will fail with:
```
abort: refused to create 2 pull requests, max is 1
if you want to create 2 pull requests at once, run again with `--config github.max-prs-to-create=-1`
```
(Note that this setting doesn't limit the size of a PR stack: a larger PR stack can be made by submitting each new PR separately. Re-submitting the top PR will still update the entire stack below it, no matter the size.)

Based on feedback and discussion, I've set the default for `github.max-prs-to-create` to be 5.