### PR TITLE
fix edenfs OSS build break on set[str]

### DIFF
--- a/eden/integration/hg/filteredhg_test.py
+++ b/eden/integration/hg/filteredhg_test.py
@@ -5,7 +5,7 @@
 
 
 import os
-from typing import Optional
+from typing import Set, Optional
 
 from eden.integration.hg.lib.hg_extension_test_base import (
     filteredhg_test,
@@ -104,7 +104,7 @@ bdir/README.md
         return os.path.exists(self.repo.get_path(path))
 
     def ensure_filtered_and_unfiltered(
-        self, filtered: set[str], unfiltered: set[str]
+        self, filtered: Set[str], unfiltered: Set[str]
     ) -> None:
         for f in filtered:
             self.assertFalse(


### PR DESCRIPTION
fix edenfs OSS build break on set[str]

Summary:
The eden OSS build is failing due to set[str] not being valid on python 3.8.  Fix
by import typing Set and using Set[str] like elsewhere in the code

Test Plan:

Run a build locally with:
`/build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. eden`

Before
```
FAILED: eden/integration/hg/CMakeFiles/hg_integration_tests.GEN_PY_EXE.util eden/integration/hg/hg_integration_tests_tests.cmake
cd /home/alex/local/tmp/ubuntu-20.04/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/build/eden/eden/integration/hg && /usr/bin/cmake -D TEST_TARGET=hg_integration_tests -D TEST_INTERPRETER=/usr/bin/python3.8 -D TEST_ENV=CMAKE_SOURCE_DIR=/home/alex/local/sapling -D TEST_EXECUTABLE=/home/alex/local/tmp/ubuntu-20.04/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/build/eden/eden/integration/hg/hg_integration_tests -D TEST_WORKING_DIR=/home/alex/local/tmp/ubuntu-20.04/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/build/eden -D TEST_LIST=hg_integration_tests_TESTS -D TEST_PREFIX=hg_integration_tests:: -D TEST_PROPERTIES= -D CTEST_FILE=/home/alex/local/tmp/ubuntu-20.04/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/build/eden/eden/integration/hg/hg_integration_tests_tests.cmake -P /home/alex/local/sapling/build/fbcode_builder/CMake/FBPythonTestAddTests.cmake
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/alex/local/tmp/ubuntu-20.04/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/build/eden/eden/integration/hg/hg_integration_tests/__main__.py", line 805, in <module>
  File "/home/alex/local/tmp/ubuntu-20.04/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/build/eden/eden/integration/hg/hg_integration_tests/__main__.py", line 801, in main
  File "/home/alex/local/tmp/ubuntu-20.04/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/build/eden/eden/integration/hg/hg_integration_tests/__main__.py", line 663, in run
  File "/home/alex/local/tmp/ubuntu-20.04/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/build/eden/eden/integration/hg/hg_integration_tests/__main__.py", line 646, in load_tests
  File "/home/alex/local/tmp/ubuntu-20.04/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/build/eden/eden/integration/hg/hg_integration_tests/__main__.py", line 443, in load_all
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 655, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 618, in _load_backward_compatible
  File "<frozen zipimport>", line 259, in load_module
  File "/home/alex/local/tmp/ubuntu-20.04/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/build/eden/eden/integration/hg/hg_integration_tests/eden/integration/hg/filteredhg_test.py", line 20, in <module>
  File "/home/alex/local/tmp/ubuntu-20.04/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/build/eden/eden/integration/hg/hg_integration_tests/eden/integration/hg/filteredhg_test.py", line 107, in FilteredFSBase
TypeError: 'type' object is not subscriptable
CMake Error at /home/alex/local/sapling/build/fbcode_builder/CMake/FBPythonTestAddTests.cmake:27 (message):
  Error running test executable:
  /home/alex/local/tmp/ubuntu-20.04/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/build/eden/eden/integration/hg/hg_integration_tests
```

After, works
