### PR TITLE
github: update node to 18.x in docker image builds

### DIFF
--- a/.github/workflows/sapling-cli-ubuntu-20.04.Dockerfile
+++ b/.github/workflows/sapling-cli-ubuntu-20.04.Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get -y install ca-certificates curl git gnupg
 # Ubuntu 20.04 is v10, which is too old):
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
 
 # Now we can install the bulk of the packages:
 RUN apt-get -y update

--- a/.github/workflows/sapling-cli-ubuntu-22.04.Dockerfile
+++ b/.github/workflows/sapling-cli-ubuntu-22.04.Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get -y install ca-certificates curl git gnupg
 # Ubuntu 20.04 is v10, which is too old):
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
 
 # Now we can install the bulk of the packages:
 RUN apt-get -y update


### PR DESCRIPTION
github: update node to 18.x in docker image builds

Summary:

I noticed GitHub verify-addons CI failing with error

```
vite@5.1.0-beta.2: The engine "node" is incompatible with this module. Expected version "^18.0.0 || >=20.0.0". Got "16.20.2"
```

From sapling discord chat, likely this is due to recent replacement pof create-react-apps with vite for ISL.

Update node to 18 on github to fix it.

Test Plan:

Run local docker builds and check nodejs version
```
docker build -t sapling-cli-ubuntu-20.04 -f .github/workflows/sapling-cli-ubuntu-20.04.Dockerfile . &&
docker build -t sapling-cli-ubuntu-22.04 -f .github/workflows/sapling-cli-ubuntu-22.04.Dockerfile .
```

Before:
```
$ docker run -ti sapling-cli-ubuntu-20.04 node --version
v16.20.2
$ docker run -ti sapling-cli-ubuntu-22.04 node --version
v16.20.2
```

After:
```
$ docker run -ti sapling-cli-ubuntu-20.04 node --version
v18.19.0
$ docker run -ti sapling-cli-ubuntu-22.04 node --version
v18.19.0
```
