### PR TITLE
[sl] alerts: make it compatible with Python3.8

### DIFF
--- a/eden/scm/sapling/alerts.py
+++ b/eden/scm/sapling/alerts.py
@@ -17,7 +17,7 @@ class Alert(NamedTuple):
     description: str
     key: str
     show_in_isl: bool
-    show_after_crashes_regex: Optional[re.Pattern[str]]
+    show_after_crashes_regex: Optional[re.Pattern]
 
 
 def parse_alert(ui, key: str, raw_alert: dict) -> Optional[Alert]:


### PR DESCRIPTION
Summary: 

`re.Pattern[str]` is not valid in Python 3.8

Test Plan:

```
Python 3.8.17 (default, Jul  9 2023, 20:57:35)
[Clang 14.0.3 (clang-1403.0.22.14.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import re
>>> from typing import Optional
>>> show_after_crashes_regex: Optional[re.Pattern[str]] = None
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'type' object is not subscriptable
>>> show_after_crashes_regex: Optional[re.Pattern] = None
>>>
```