### PR TITLE
Fix ReviewStack test after the _STACK_SECTION_START update

### DIFF
--- a/eden/contrib/reviewstack/src/saplingStack.test.ts
+++ b/eden/contrib/reviewstack/src/saplingStack.test.ts
@@ -24,8 +24,9 @@ so that each commit in the stack can be reviewed individually.
 This would be the original commit message of this fictitious commit.
 `);
     expect(parsedBody).toEqual({
-      firstLine: 'Stack created with [Sapling](https://sapling-scm.com/github).',
+      firstLine: '[//]: # (BEGIN SAPLING FOOTER)',
       introduction: `\
+Stack created with [Sapling](https://sapling-scm.com/github).
 
 Stacks created by Sapling are best viewed using ReviewStack
 so that each commit in the stack can be reviewed individually.
@@ -58,8 +59,9 @@ so that each commit in the stack can be reviewed individually.
 * #789 (2 commits)
 `);
     expect(parsedBody).toEqual({
-      firstLine: 'Stack created with [Sapling](https://sapling-scm.com/github).',
+      firstLine: '[//]: # (BEGIN SAPLING FOOTER)',
       introduction: `\
+Stack created with [Sapling](https://sapling-scm.com/github).
 
 Stacks created by Sapling are best viewed using ReviewStack
 so that each commit in the stack can be reviewed individually.
@@ -86,8 +88,8 @@ Stack created with [Sapling](https://sapling-scm.com/github).
 * __->__ #123
 `);
     expect(parsedBody).toEqual({
-      firstLine: 'Stack created with [Sapling](https://sapling-scm.com/github).',
-      introduction: '',
+      firstLine: '[//]: # (BEGIN SAPLING FOOTER)',
+      introduction: 'Stack created with [Sapling](https://sapling-scm.com/github).\n',
       stack: [
         {number: 1, numCommits: 1},
         {number: 123, numCommits: 1},


### PR DESCRIPTION
In https://github.com/facebook/sapling/pull/837, the `_STACK_SECTION_START` was updated to use the text mark introduced in https://github.com/facebook/sapling/pull/779 to recognize stacked PR. While this change successfully addressed the issue, this newest version was never deployed to [reviewstack.dev](https://reviewstack.dev/) because the tests weren't updated accordingly. As such, [the GitHub Actions workflow for publishing ReviewStack has been failing](https://github.com/facebook/sapling/actions/workflows/reviewstack.dev-deploy.yml) after https://github.com/facebook/sapling/pull/837 was merged.

Here I'm fixing those tests by updating the expected outputs accordingly, by moving what was the `firstLine` into the `introduction` section.

## Test Plan

I've verified that the changes in this PR are working by running:
```bash
yarn test --watchAll
```
In addition, I've also tried browsing through the PRs mentioned in https://github.com/facebook/sapling/issues/826 and verified that they all gets rendered correctly.

![image](https://github.com/facebook/sapling/assets/18493382/02822c94-3ca4-48d3-b9b3-019a393fd09a)

