### PR TITLE
Update links for reviewstack github repo

### DIFF
--- a/eden/contrib/reviewstack.dev/src/Footer.tsx
+++ b/eden/contrib/reviewstack.dev/src/Footer.tsx
@@ -26,7 +26,7 @@ export default function Footer(): React.ReactElement {
   const projectLinks = [
     {
       text: 'GitHub Repository',
-      href: 'https://github.com/facebook/sapling/tree/main/addons/reviewstack',
+      href: 'https://github.com/facebook/sapling/tree/main/eden/contrib/reviewstack',
     },
     {
       text: 'Sapling SCM',

--- a/eden/contrib/reviewstack.dev/src/NetlifyLoginDialog.tsx
+++ b/eden/contrib/reviewstack.dev/src/NetlifyLoginDialog.tsx
@@ -134,7 +134,7 @@ function EndUserInstructions(props: CustomLoginDialogProps): React.ReactElement 
       <H3>Building From Source</H3>
       <Box>
         Finally, if you want to run your own instance of ReviewStack,{' '}
-        <Link href="https://github.com/facebook/sapling/tree/main/addons/reviewstack">
+        <Link href="https://github.com/facebook/sapling/tree/main/eden/contrib/reviewstack">
           the source code is available on GitHub
         </Link>
         . For example, you may want to deploy your own instance of ReviewStack that is hardcoded to


### PR DESCRIPTION
The reviewstack.dev website mentions that the source code is available on Github but the link seems to be out of date.