### PR TITLE
[isl] Convert <App> to use <Button>

### DIFF
--- a/addons/isl/src/App.tsx
+++ b/addons/isl/src/App.tsx
@@ -27,6 +27,7 @@ import {TopLevelToast} from './TopLevelToast';
 import {ViewportOverlayRoot} from './ViewportOverlay';
 import {tracker} from './analytics';
 import {enableReactTools, enableReduxTools} from './atoms/debugToolAtoms';
+import {Button} from './components/Button';
 import {islDrawerState} from './drawerState';
 import {GettingStartedModal} from './gettingStarted/GettingStartedModal';
 import {I18nSupport, t, T} from './i18n';
@@ -41,7 +42,6 @@ import {ModalContainer} from './useModal';
 import {usePromise} from './usePromise';
 import {isDev, isTest} from './utils';
 import * as stylex from '@stylexjs/stylex';
-import {VSCodeButton} from '@vscode/webview-ui-toolkit/react';
 import {Provider, atom, useAtomValue, useSetAtom, useStore} from 'jotai';
 import React, {useMemo} from 'react';
 import {ContextMenus} from 'shared/ContextMenu';
@@ -272,16 +272,15 @@ function ISLNullState({repoError}: {repoError: RepositoryError}) {
             )
           }
           buttons={[
-            <VSCodeButton
+            <Button
               key="help-button"
-              appearance="secondary"
               onClick={e => {
                 platform.openExternalLink('https://sapling-scm.com/docs/introduction/installation');
                 e.preventDefault();
                 e.stopPropagation();
               }}>
               <T>See installation docs</T>
-            </VSCodeButton>,
+            </Button>,
           ]}
         />
       );
@@ -298,9 +297,8 @@ function ISLNullState({repoError}: {repoError: RepositoryError}) {
             }
             details={<T replace={{$path: repoError.path ?? '(no path found)'}}>PATH: $path'</T>}
             buttons={[
-              <VSCodeButton
+              <Button
                 key="help-button"
-                appearance="secondary"
                 onClick={e => {
                   platform.openExternalLink(
                     'https://sapling-scm.com/docs/introduction/installation',
@@ -309,7 +307,7 @@ function ISLNullState({repoError}: {repoError: RepositoryError}) {
                   e.stopPropagation();
                 }}>
                 <T>See installation docs</T>
-              </VSCodeButton>,
+              </Button>,
             ]}
           />
         );


### PR DESCRIPTION
[isl] Convert <App> to use <Button>

Summary: Change uses of `VSCodeButton` to `Button`

Test Plan: CI

Reviewers: #isl

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/871).
* #872
* __->__ #871