### PR TITLE
ISL: Show tag for PR "follower" commits

### DIFF
--- a/addons/isl-server/src/templates.ts
+++ b/addons/isl-server/src/templates.ts
@@ -44,9 +44,10 @@ export const FIELDS = {
   filesModified: '{file_mods|json}',
   filesRemoved: '{file_dels|json}',
   successorInfo: '{mutations % "{operation}:{successors % "{node}"},"}',
-  cloesestPredecessors: '{predecessors % "{node},"}',
+  closestPredecessors: '{predecessors % "{node},"}',
   // This would be more elegant as a new built-in template
   diffId: '{if(phabdiff, phabdiff, github_pull_request_number)}',
+  isFollower: '{sapling_pr_follower|json}',
   stableCommitMetadata: Internal.stableCommitConfig?.template ?? '',
   // Description must be last
   description: '{desc}',
@@ -96,12 +97,13 @@ export function parseCommitInfoOutput(logger: Logger, output: string): SmartlogC
         filesSample: files.slice(0, MAX_FETCHED_FILES_PER_COMMIT),
         totalFileCount: files.length,
         successorInfo: parseSuccessorData(lines[FIELD_INDEX.successorInfo]),
-        closestPredecessors: splitLine(lines[FIELD_INDEX.cloesestPredecessors], ','),
+        closestPredecessors: splitLine(lines[FIELD_INDEX.closestPredecessors], ','),
         description: lines
           .slice(FIELD_INDEX.description + 1 /* first field of description is title; skip it */)
           .join('\n')
           .trim(),
         diffId: lines[FIELD_INDEX.diffId] != '' ? lines[FIELD_INDEX.diffId] : undefined,
+        isFollower: JSON.parse(lines[FIELD_INDEX.isFollower]) as boolean,
         stableCommitMetadata:
           lines[FIELD_INDEX.stableCommitMetadata] != ''
             ? Internal.stableCommitConfig?.parse(lines[FIELD_INDEX.stableCommitMetadata])

--- a/addons/isl/src/Commit.tsx
+++ b/addons/isl/src/Commit.tsx
@@ -30,7 +30,7 @@ import {
   diffSummary,
   latestCommitMessageTitle,
 } from './codeReview/CodeReviewInfo';
-import {DiffInfo} from './codeReview/DiffBadge';
+import {DiffFollower, DiffInfo} from './codeReview/DiffBadge';
 import {SyncStatus, syncStatusAtom} from './codeReview/syncStatus';
 import {FoldButton, useRunFoldPreview} from './fold';
 import {t, T} from './i18n';
@@ -376,6 +376,7 @@ export const Commit = memo(
               <SuccessorInfoToDisplay successorInfo={commit.successorInfo} />
             ) : null}
             {inlineProgress && <InlineProgressSpan message={inlineProgress} />}
+            {commit.isFollower ? <DiffFollower commit={commit} /> : null}
           </DivIfChildren>
           {!isNarrow ? commitActions : null}
         </div>

--- a/addons/isl/src/codeReview/DiffBadge.tsx
+++ b/addons/isl/src/codeReview/DiffBadge.tsx
@@ -41,10 +41,11 @@ export const showDiffNumberConfig = configBackedAtom<boolean>('isl.show-diff-num
  */
 export function DiffInfo({commit, hideActions}: {commit: CommitInfo; hideActions: boolean}) {
   const repo = useAtomValue(codeReviewProvider);
-  const diffId = commit.diffId;
+  const {diffId} = commit;
   if (repo == null || diffId == null) {
     return null;
   }
+
   // Do not show diff info (and "Ship It" button) if there are successors.
   // Users should look at the diff info and buttons from the successor commit instead.
   // But the diff number can still be useful so show it.
@@ -69,6 +70,19 @@ const styles = stylex.create({
       ':hover': 'underline',
     },
   },
+  diffFollower: {
+    alignItems: 'center',
+    display: 'inline-flex',
+    gap: '5px',
+    opacity: '0.9',
+    fontSize: '90%',
+    padding: '0 var(--halfpad)',
+  },
+  diffFollowerIcon: {
+    '::before': {
+      fontSize: '90%',
+    },
+  },
 });
 
 export function DiffBadge({
@@ -90,6 +104,19 @@ export function DiffBadge({
     <Link href={openerUrl} xstyle={styles.diffBadge}>
       <provider.DiffBadgeContent diff={diff} children={children} syncStatus={syncStatus} />
     </Link>
+  );
+}
+
+export function DiffFollower({commit}: {commit: CommitInfo}) {
+  if (!commit.isFollower) {
+    return null;
+  }
+
+  return (
+    <span {...stylex.props(styles.diffFollower)}>
+      <Icon icon="fold-up" size="S" {...stylex.props(styles.diffFollowerIcon)} />
+      <T>follower</T>
+    </span>
   );
 }
 

--- a/addons/isl/src/dag/dagCommitInfo.ts
+++ b/addons/isl/src/dag/dagCommitInfo.ts
@@ -57,6 +57,7 @@ const CommitInfoExtRecord = Record<CommitInfoExtProps>({
   filesSample: [],
   totalFileCount: 0,
   diffId: undefined,
+  isFollower: undefined,
   stableCommitMetadata: undefined,
 
   // WithPreviewType
@@ -157,6 +158,10 @@ export class DagCommitInfo extends SelfUpdate<CommitInfoExtRecord> {
 
   get diffId(): string | undefined {
     return this.inner.diffId;
+  }
+
+  get isFollower(): boolean | undefined {
+    return this.inner.isFollower;
   }
 
   get stableCommitMetadata(): ReadonlyArray<StableCommitMetadata> | undefined {

--- a/addons/isl/src/types.ts
+++ b/addons/isl/src/types.ts
@@ -239,6 +239,7 @@ export type CommitInfo = {
   totalFileCount: number;
   /** @see {@link DiffId} */
   diffId?: DiffId;
+  isFollower?: boolean;
   stableCommitMetadata?: ReadonlyArray<StableCommitMetadata>;
 };
 export type SuccessorInfo = {


### PR DESCRIPTION
ISL: Show a tag for PR "follower" commits (i.e. after running `sl pr follow -r .` on a commit).

<img width="537" alt="image" src="https://github.com/facebook/sapling/assets/10001942/a6a31fd3-6b49-4750-82ea-2830d3942516">

Currently the `sl` smartlog shows this, but not the interactive smartlog:

<img width="433" alt="image" src="https://github.com/facebook/sapling/assets/10001942/11a4dfd2-8f06-4a67-8a25-c22e0143171c">

