### PR TITLE
Fix an issue where github.preserve-pull-request-description=true was adding \n to commit message.

### DIFF
--- a/eden/scm/sapling/ext/github/mock_utils.py
+++ b/eden/scm/sapling/ext/github/mock_utils.py
@@ -296,7 +296,8 @@ class MockGitHubServer:
                 f"* __->__ #{n}" if n == pr_number else f"* #{n}" for n in stack_pr_ids
             ]
             body += (
-                "\n---\n"
+                ("" if body.endswith("\n") else "\n") +
+                "---\n"
                 "[//]: # (BEGIN SAPLING FOOTER)\n"
                 "Stack created with [Sapling](https://sapling-scm.com). Best reviewed"
                 f" with [ReviewStack](https://reviewstack.dev/{owner}/{name}/pull/{pr_number}).\n"

--- a/eden/scm/sapling/ext/github/pull_request_body.py
+++ b/eden/scm/sapling/ext/github/pull_request_body.py
@@ -47,12 +47,33 @@ def create_pull_request_title_and_body(
     * __->__ #42
     * #4
 
+    Add trailing whitespace to commit_msg and ensure it is preserved.
+    >>> commit_msg += '\n\n'
+    >>> title, body = create_pull_request_title_and_body(
+    ...     commit_msg,
+    ...     pr_numbers_and_num_commits,
+    ...     pr_numbers_index,
+    ...     contributor_repo,
+    ... )
+    >>> print(body.replace(reviewstack_url, "{reviewstack_url}"))
+    The original commit message.
+    Second line of message.
+    <BLANKLINE>
+    ---
+    [//]: # (BEGIN SAPLING FOOTER)
+    Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack]({reviewstack_url}).
+    * #1
+    * #2 (2 commits)
+    * __->__ #42
+    * #4
+
     Disable reviewstack message:
     >>> title, body = create_pull_request_title_and_body(commit_msg, pr_numbers_and_num_commits,
     ...     pr_numbers_index, contributor_repo, reviewstack=False)
     >>> print(body)
     The original commit message.
     Second line of message.
+    <BLANKLINE>
     ---
     [//]: # (BEGIN SAPLING FOOTER)
     * #1
@@ -84,7 +105,9 @@ def create_pull_request_title_and_body(
         )
         extra.append(bulleted_list)
     if extra:
-        body = "\n".join([body, _HORIZONTAL_RULE, _SAPLING_FOOTER_MARKER] + extra)
+        if not body.endswith("\n"):
+            body += "\n"
+        body += "\n".join([_HORIZONTAL_RULE, _SAPLING_FOOTER_MARKER] + extra)
     return title, body
 
 


### PR DESCRIPTION
Fix an issue where github.preserve-pull-request-description=true was adding \n to commit message.

Summary:
While https://github.com/facebook/sapling/pull/863 fixed some important
issues with respect to recognizing `\r\n`, it also introduced a new
issue where running `sl pr s` with `github.preserve-pull-request-description=true`
would inadvertently add an extra `\n` before the horizontal rule
delimiting the Sapling stack information.

This fixes `create_pull_request_title_and_body()` to preserve whatever
whitespace was originally present before the horizontal rule,
only adding a new `\n` to the end of the commit message if it did not
already have one.

Test Plan:
```
./tests/run-tests.py ./tests/test-doctest.py
```
