### PR TITLE
Add missing `Eq`.

### DIFF
--- a/eden/scm/lib/types/src/fetch_mode.rs
+++ b/eden/scm/lib/types/src/fetch_mode.rs
@@ -8,7 +8,7 @@
 use serde::Deserialize;
 
 bitflags::bitflags! {
-    #[derive(Debug, Copy, Clone, PartialEq, Deserialize)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
     #[serde(transparent)]
     pub struct FetchMode: u16 {
         /// The fetch may hit remote servers.


### PR DESCRIPTION
Add missing `Eq`.

Running `rustc == 1.76.0`.

The following error was occurring:

```
error: to use a constant of type `FetchMode` in a pattern, `FetchMode` must be annotated with `#[derive(PartialEq, Eq)]`
   --> lib/revisionstore/src/scmstore/tree.rs:261:20
    |
261 |             if let FetchMode::AllowRemote = fetch_mode {
    |                    ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the traits must be derived, manual `impl`s are not sufficient
    = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
error: could not compile `revisionstore` (lib) due to 1 previous error; 1 warning emitted
```
