### PR TITLE
[sl] tests: update docs for INTERP_TYPE_TABLE

### DIFF
--- a/eden/scm/sapling/testing/sh/interp.py
+++ b/eden/scm/sapling/testing/sh/interp.py
@@ -480,7 +480,7 @@ def interpremovelargestprefix(v, env: Env) -> InterpResult:
 # interp based on tree node type
 #
 # see enum variant names in conch-parser's ast.rs
-# use 'b.shparser.parse(code)' in debugshell to view parsed dict for code.
+# use 'b.conchparser.parse(code)' in debugshell to view parsed dict for code.
 # None means not yet implemented.
 INTERP_TYPE_TABLE = {
     # Command


### PR DESCRIPTION
[sl] tests: update docs for INTERP_TYPE_TABLE

Summary: It's been a while since we moved `shparser` to `conchparser`. This diff updates a comment regarding that

Test Plan: On `sl dbsh` ran `b.conchparser.parse('drawdaginput+=foo')` and made sure it worked

Reviewers: #mercurial
