### PR TITLE
Allow websockets to connect to the current browser's protocol of choice (if available)

### DIFF
--- a/addons/isl/src/LocalWebSocketEventBus.ts
+++ b/addons/isl/src/LocalWebSocketEventBus.ts
@@ -54,7 +54,8 @@ export class LocalWebSocketEventBus {
     if (this.disposed || this.opening || this.status.type === 'open') {
       return this.websocket;
     }
-    const wsUrl = new URL(`ws://${this.host}/ws`);
+    const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+    const wsUrl = new URL(`${wsProtocol}//${this.host}/ws`);
     const token = initialParams.get('token');
     if (token) {
       wsUrl.searchParams.append('token', token);


### PR DESCRIPTION
Allow websockets to connect to the current browser's protocol of choice (if available)

Summary:
Adds a check for the current window's protocol. Defaults to ws:// but will switch to wss:// in secure contexts. This assumes the upstream server will handle converting from wss to ws.

Test plan:
Import github project to replit. Run a server by doing:
`sl web --no-app`

open the replit webview with the token, see if it loads the smartlog.
