### PR TITLE
hgmain: fix undefined python symbol at runtime.

### DIFF
--- a/eden/scm/saplingnative/bindings/modules/pygitcompat/Cargo.toml
+++ b/eden/scm/saplingnative/bindings/modules/pygitcompat/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 configmodel = { version = "0.1.0", path = "../../../../lib/config/model" }
-cpython = { version = "0.7.1", features = ["extension-module", "python3-sys", "serde-convert"], default-features = false }
+cpython = { version = "0.7.1", features = ["python3-sys", "serde-convert"], default-features = false }
 cpython_ext = { version = "0.1.0", path = "../../../../lib/cpython-ext" }
 gitcompat = { version = "0.1.0", path = "../../../../lib/gitcompat" }
 pyprocess = { version = "0.1.0", path = "../pyprocess" }


### PR DESCRIPTION
Commit [`dc45ccb`] introduced `pygitcompat` to talk to git from python.

`extension-module` is enabled:

https://github.com/facebook/sapling/blob/dc45ccbbc2bafb850e4535159d6c96793f27738e/eden/scm/saplingnative/bindings/modules/pygitcompat/Cargo.toml#L10

which ultimately enables `python3-sys/extension-module`.

According to [the `python3-sys` documentation](https://github.com/dgrunwald/rust-cpython/blob/e815555629e557be084813045ca1ddebc2f76ef9/Cargo.toml#L71-L74), `extension-module` prevents the final artifact from being linked against the shared Python library:

```toml
 # Use this feature when building an extension module.
 # It tells the linker to keep the python symbols unresolved,
 # so that the module can also be used with statically linked python interpreters.
extension-module = [ "python3-sys/extension-module" ]
```

It leads to a bug where the final binary `sl` is not linked against Python:

```
$ otool -L /tmp/sl_dc45ccb
/tmp/sl_dc45ccb:
        /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1700.255.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1345.100.2)
        /System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa (compatibility version 1.0.0, current version 24.0.0)
        /System/Library/Frameworks/WebKit.framework/Versions/A/WebKit (compatibility version 1.0.0, current version 618.1.15)
        /usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
        /System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 61123.100.169)
        /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 2420.0.0)
        /opt/homebrew/opt/openssl@3/lib/libssl.3.dylib (compatibility version 3.0.0, current version 3.0.0)
        /opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib (compatibility version 3.0.0, current version 3.0.0)
        /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices (compatibility version 1.0.0, current version 1226.0.0)
        /System/Library/Frameworks/SystemConfiguration.framework/Versions/A/SystemConfiguration (compatibility version 1.0.0, current version 1300.100.9)
        /usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.12)
        /usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
$ /tmp/sl_dc45ccb
dyld[8926]: symbol not found in flat namespace '_PyBool_Type'
Abort trap: 6
```

This commit removes the `extension-module` feature flag to link again against libpython:

```
$ otool -L /tmp/sl_fix
/tmp/sl_fix:
        /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1700.255.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1345.100.2)
        /System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa (compatibility version 1.0.0, current version 24.0.0)
        /System/Library/Frameworks/WebKit.framework/Versions/A/WebKit (compatibility version 1.0.0, current version 618.1.15)
        /usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
        /System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 61123.100.169)
        /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 2420.0.0)
        /opt/homebrew/opt/openssl@3/lib/libssl.3.dylib (compatibility version 3.0.0, current version 3.0.0)
        /opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib (compatibility version 3.0.0, current version 3.0.0)
        /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices (compatibility version 1.0.0, current version 1226.0.0)
        /System/Library/Frameworks/SystemConfiguration.framework/Versions/A/SystemConfiguration (compatibility version 1.0.0, current version 1300.100.9)
        /usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.12)
>>>>>   /opt/homebrew/opt/python@3.11/Frameworks/Python.framework/Versions/3.11/Python (compatibility version 3.11.0, current version 3.11.0)
        /usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
```

[`dc45ccb`]: https://github.com/facebook/sapling/commit/dc45ccbbc2bafb850e4535159d6c96793f27738e