### PR TITLE
[website] fix: s/three/two/

### DIFF
--- a/website/docs/git/intro.md
+++ b/website/docs/git/intro.md
@@ -27,7 +27,7 @@ With the GitHub CLI caching your credentials, you will be able to run commands l
 
 ## Pull requests
 
-When it comes to working with pull requests from Sapling, you have three options: `sl pr`, and `sl push`. Each has its tradeoffs, so you may opt to use a different solution, depending on the scenario:
+When it comes to working with pull requests from Sapling, you have two options: `sl pr` and `sl push`. Each has its tradeoffs, so you may opt to use a different solution, depending on the scenario:
 
 ### `sl pr` (aka "Sapling stack")
 


### PR DESCRIPTION
I believe this was missed as part of https://github.com/facebook/sapling/commit/68cde3c87d1ad917d35e4e8b19a685cd501f1d2e.
