### PR TITLE
[github] exclude firstline from body in new pr

### DIFF
--- a/eden/scm/sapling/ext/github/submit.py
+++ b/eden/scm/sapling/ext/github/submit.py
@@ -449,8 +449,9 @@ async def create_pull_requests_serially(
         if workflow == SubmitWorkflow.SINGLE and parent:
             base = none_throws(parent.head_branch_name)
 
-        body = commit.get_msg()
-        title = firstline(body)
+        commit_msg = commit.get_msg()
+        title = firstline(commit_msg)
+        body = commit_msg[len(title) + 1 :]
         result = await gh_submit.create_pull_request(
             hostname=repository.hostname,
             owner=owner,


### PR DESCRIPTION
Currently, when I create a PR via Sapling, I inevitably end up deleting the duplicated first line from the body of the commit message in the generated pull request.

It appears that `create_pull_request_title_and_body()` in `pull_request_body.py` already has logic like what this PR introduces:

https://github.com/facebook/sapling/blob/5aff04c89e3473b0d7a95f1dc223858528e4a575/eden/scm/sapling/ext/github/pull_request_body.py#L92-L94

so this updates `create_pull_requests_serially()` to work the same way.
