### PR TITLE
fix eden cmake missing eden/common/utils/DirType.h

### DIFF
--- a/eden/fs/nfs/CMakeLists.txt
+++ b/eden/fs/nfs/CMakeLists.txt
@@ -54,6 +54,8 @@ target_link_libraries(
   PRIVATE
     eden_nfs_nfsd_rpc
     Folly::folly
+  PUBLIC
+    eden_utils
 )
 
 
@@ -113,6 +115,7 @@ target_link_libraries(
   PUBLIC
     eden_nfs_nfsd_rpc
     eden_inodes_inodenumber
+    eden_utils
 )
 
 add_subdirectory(portmap)

--- a/eden/scm/lib/backingstore/CMakeLists.txt
+++ b/eden/scm/lib/backingstore/CMakeLists.txt
@@ -50,6 +50,7 @@ target_include_directories(
 target_link_libraries(
   backingstore
   PUBLIC
+  edencommon::edencommon_os
   rust_backingstore
   fmt::fmt
   Folly::folly


### PR DESCRIPTION
fix eden cmake missing eden/common/utils/DirType.h

Summary:
fix missing header errors due to edencommon not in target link libraries

Test Plan:

Run local cmake build with: `./build/fbcode_builder/getdeps.py --allow-system-packages build eden`

Before, broken:
```
[12/387] Building CXX object eden/fs/nfs/CMakeFiles/eden_nfs_utils.dir/NfsUtils.cpp.o
FAILED: eden/fs/nfs/CMakeFiles/eden_nfs_utils.dir/NfsUtils.cpp.o
/usr/bin/c++ -DBOOST_ATOMIC_NO_LIB -DBOOST_CONTEXT_NO_LIB -DBOOST_FILESYSTEM_NO_LIB -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_REGEX_NO_LIB -DBOOST_SYSTEM_NO_LIB -DBOOST_THREAD_NO_LIB -DFOLLY_XLOG_STRIP_PREFIXES=\"/home/alex/local/sapling:/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/build/eden\" -DGFLAGS_IS_A_DLL=0 -I/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/build/eden -I/home/alex/local/sapling -I/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/installed/fb303/include -I/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/installed/fizz/include -I/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/installed/wangle/include -I/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/installed/fbthrift/include -I/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/installed/googletest-VdBlGUPMPJitek6Vixf2wJ0d-fkcsAem4x561Ipyl_c/include -I/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/installed/lmdb-EeqttKQ21Ssy0Z9v9Td5arfjclo9sZwEycvDeQZ707Q/include -isystem /home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/installed/gflags-4vXpjWHz7iQ-flj45DrshPtdnV00lhHzdluegsKfQv8/include -isystem /home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/installed/glog-rc1q5fRnLVjdS68JV9erzuj0hzjLqATGYHhZAKGSWHo/include -isystem /home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/installed/folly/include -isystem /home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/installed/boost-v767l9QNa5ozbwDxCGIOiS4txj6QsxfvDdR4F7KRbYY/include -isystem /home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/installed/zlib-I9YVwQvp3FsdWhYv3JD35W5331pwpP-NLFKrJNd9ubU/include -isystem /usr/include/libdwarf-0 -isystem /home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/installed/fmt-XC7kuS1-TdG_KzAiD4Q16Eb-s6mNRaeEz1OrK4d5f7c/include -g -Wall -Wextra -Wno-deprecated -Wno-deprecated-declarations -Wno-unknown-pragmas -O2 -g -DNDEBUG -std=gnu++17 -MD -MT eden/fs/nfs/CMakeFiles/eden_nfs_utils.dir/NfsUtils.cpp.o -MF eden/fs/nfs/CMakeFiles/eden_nfs_utils.dir/NfsUtils.cpp.o.d -o eden/fs/nfs/CMakeFiles/eden_nfs_utils.dir/NfsUtils.cpp.o -c /home/alex/local/sapling/eden/fs/nfs/NfsUtils.cpp
In file included from /home/alex/local/sapling/eden/fs/nfs/NfsUtils.cpp:8:
/home/alex/local/sapling/eden/fs/nfs/NfsUtils.h:13:10: fatal error: eden/common/utils/DirType.h: No such file or directory
   13 | #include "eden/common/utils/DirType.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
[13/387] Building CXX object eden/fs/nfs/test/CMakeFiles/eden_nfs_test.dir/AccessTest.cpp.o
FAILED: eden/fs/nfs/test/CMakeFiles/eden_nfs_test.dir/AccessTest.cpp.o
/usr/bin/c++ -DBOOST_ATOMIC_NO_LIB -DBOOST_CONTEXT_NO_LIB -DBOOST_FILESYSTEM_NO_LIB -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_REGEX_NO_LIB -DBOOST_SYSTEM_NO_LIB -DBOOST_THREAD_NO_LIB -DFOLLY_XLOG_STRIP_PREFIXES=\"/home/alex/local/sapling:/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/build/eden\" -DGFLAGS_IS_A_DLL=0 -I/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/build/eden -I/home/alex/local/sapling -I/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/installed/fb303/include -I/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/installed/fizz/include -I/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/installed/wangle/include -I/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/installed/fbthrift/include -I/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/installed/lmdb-EeqttKQ21Ssy0Z9v9Td5arfjclo9sZwEycvDeQZ707Q/include -isystem /home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/installed/gflags-4vXpjWHz7iQ-flj45DrshPtdnV00lhHzdluegsKfQv8/include -isystem /home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/installed/glog-rc1q5fRnLVjdS68JV9erzuj0hzjLqATGYHhZAKGSWHo/include -isystem /home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/installed/folly/include -isystem /home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/installed/googletest-VdBlGUPMPJitek6Vixf2wJ0d-fkcsAem4x561Ipyl_c/include -isystem /home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/installed/boost-v767l9QNa5ozbwDxCGIOiS4txj6QsxfvDdR4F7KRbYY/include -isystem /home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/installed/zlib-I9YVwQvp3FsdWhYv3JD35W5331pwpP-NLFKrJNd9ubU/include -isystem /usr/include/libdwarf-0 -isystem /home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsaplingZbuildZfbcode_builder/installed/fmt-XC7kuS1-TdG_KzAiD4Q16Eb-s6mNRaeEz1OrK4d5f7c/include -g -Wall -Wextra -Wno-deprecated -Wno-deprecated-declarations -Wno-unknown-pragmas -O2 -g -DNDEBUG -std=gnu++17 -MD -MT eden/fs/nfs/test/CMakeFiles/eden_nfs_test.dir/AccessTest.cpp.o -MF eden/fs/nfs/test/CMakeFiles/eden_nfs_test.dir/AccessTest.cpp.o.d -o eden/fs/nfs/test/CMakeFiles/eden_nfs_test.dir/AccessTest.cpp.o -c /home/alex/local/sapling/eden/fs/nfs/test/AccessTest.cpp
In file included from /home/alex/local/sapling/eden/fs/nfs/test/AccessTest.cpp:14:
/home/alex/local/sapling/eden/fs/nfs/NfsUtils.h:13:10: fatal error: eden/common/utils/DirType.h: No such file or directory
   13 | #include "eden/common/utils/DirType.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```

After, works
