### PR TITLE
feat: build and publish arm64 version of ubuntu 20.04 and 22.04 images

### DIFF
--- a/.github/workflows/sapling-cli-ubuntu-20.04-image.yml
+++ b/.github/workflows/sapling-cli-ubuntu-20.04-image.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
     - name: Login to GitHub Container Registry
@@ -23,4 +25,5 @@ jobs:
         context: .
         file: .github/workflows/sapling-cli-ubuntu-20.04.Dockerfile
         push: true
+        platforms: linux/amd64,linux/arm64
         tags: ${{ format('ghcr.io/{0}/build_ubuntu_20_04:latest', github.repository) }}

--- a/.github/workflows/sapling-cli-ubuntu-22.04-image.yml
+++ b/.github/workflows/sapling-cli-ubuntu-22.04-image.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
     - name: Login to GitHub Container Registry
@@ -23,4 +25,5 @@ jobs:
         context: .
         file: .github/workflows/sapling-cli-ubuntu-22.04.Dockerfile
         push: true
+        platforms: linux/amd64,linux/arm64
         tags: ${{ format('ghcr.io/{0}/build_ubuntu_22_04:latest', github.repository) }}


### PR DESCRIPTION
feat: build and publish arm64 version of ubuntu 20.04 and 22.04 images

### Summary:
Many people develop on arm64 machines like raspberry pi and ubuntu devcontainers. This change is a precursor to building and publishing arm64 deb packages, which requires runner changes.

### Test Plan:
Run in ci and check that ghcr.io/sapling/build_ubuntu_20_04:latest contains arm64 arch
