### PR TITLE
build: add corepack support

### DIFF
--- a/addons/package.json
+++ b/addons/package.json
@@ -25,5 +25,6 @@
     "prettier-check": "prettier --check .",
     "prettier-fix": "prettier --write ."
   },
-  "dependencies": {}
+  "dependencies": {},
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION

Summary:
[Corepack](https://nodejs.org/api/corepack.html) is an experimental package
manager manager for Node.js. It is a part of the Node.js project and is
intended to be a more secure and reliable alternative to other package manager
managers. This diff adds support for Corepack to the project.

Test Plan:
`corepack` comes with every Node.js installation (besides homebrew), so there
are no extra installation steps needed.
-1. If you installed Node.js with homebrew, run `brew install corepack`
0. Because corepack is experimental, run `corepack enable`.  Once it is
stabilized this step will be uneccesary
1. `cd addons/`
2. `yarn`

Now, depedencies will always be installed with the correct version of `yarn`.
In my case, `yarn` defaults to `4.3.1`, but when I run `yarn --version` in the
`addons/` directory, it returns `1.22.22`.
