### PR TITLE
fix(build): kill chg daemon before installing

### DIFF
--- a/eden/scm/Makefile
+++ b/eden/scm/Makefile
@@ -95,6 +95,9 @@ oss: HG_BIN_NAME=$(SL_BIN_NAME)
 oss: local
 
 install-oss: oss
+	$(SL_NAME) --kill-chg-daemon
+	killall $(SL_NAME)
+	sleep 1
 	mkdir -p $(DESTDIR)/$(PREFIX)/bin
 	cp $(SL_NAME) $(DESTDIR)/$(PREFIX)/bin
 	mkdir -p $(DESTDIR)/$(PREFIX)/lib


### PR DESCRIPTION

Summary:
Frequently, if I have sl running when trying to upgrade sl, I get this error
during `make install-oss`:

```sh
$ make install-oss
...
rm -f sl
cp build/scripts-3.11/sl sl
mkdir -p //usr/local/bin
cp sl //usr/local/bin
cp: cannot create regular file '//usr/local/bin/sl': Text file busy
make: *** [Makefile:99: install-oss] Error 1
```

This diff works around the issue by killing the chg daemon before installing
the new version of sl.

I also added a `sleep 1` after killing the chg daemon, because I was still
seeing the issue occasionally without it.  I really dislike adding this sleep,
so I'd appreciate any suggestions

Test Plan:

This happens to me about 75% of the time I try to upgrade sl, but I don't have
reliable reproduction steps
