### PR TITLE
project project_install_prefix for generate-github-actions

### DIFF
--- a/.github/workflows/mononoke_linux.yml
+++ b/.github/workflows/mononoke_linux.yml
@@ -177,14 +177,14 @@ jobs:
     - name: Build rust-shed
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests rust-shed
     - name: Build mononoke
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. mononoke  --project-install-prefix mononoke:/usr/local
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. mononoke  --project-install-prefix mononoke:/
     - name: Copy artifacts
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --strip --src-dir=. mononoke _artifacts/linux  --project-install-prefix mononoke:/usr/local --final-install-prefix /usr/local
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --strip --src-dir=. mononoke _artifacts/linux  --project-install-prefix mononoke:/ --final-install-prefix /usr/local
     - uses: actions/upload-artifact@v4
       with:
         name: mononoke
         path: _artifacts
     - name: Test mononoke
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages test --src-dir=. mononoke  --project-install-prefix mononoke:/usr/local
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages test --src-dir=. mononoke  --project-install-prefix mononoke:/
     - name: Show disk space at end
       run: df -h

--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -960,6 +960,7 @@ class GenerateGitHubActionsCmd(ProjectCmdBase):
         build_opts = setup_build_options(args, platform)
         ctx_gen = build_opts.get_context_generator()
         loader = ManifestLoader(build_opts, ctx_gen)
+        self.process_project_dir_arguments(args, loader)
         manifest = loader.load_manifest(args.project)
         manifest_ctx = loader.ctx_gen.get_context(manifest.name)
         run_on = self.get_run_on(args)
@@ -1147,8 +1148,10 @@ jobs:
 
             project_prefix = ""
             if not build_opts.is_windows():
-                project_prefix = (
-                    " --project-install-prefix %s:/usr/local" % manifest.name
+                prefix = loader.get_project_install_prefix(manifest) or "/usr/local"
+                project_prefix = " --project-install-prefix %s:%s" % (
+                    manifest.name,
+                    prefix,
                 )
 
             # If we have dep from same repo, we already built it and don't want to rebuild it again


### PR DESCRIPTION
Summary:
fix getdeps generate-github-actions by adding missing process_project_dir_arguments.  Without this couldn't specify any project_install_prefix other that the default /usr/local

mononoke installs directly to getdeps inst dir so needs a project_install_prefix of / for the artifact discovery to work

regenerated the gh actions with `python3 fbcode/opensource/fbcode_builder/getdeps.py generate-github-actions mononoke --os-type=linux --allow-system-packages --output-dir fbcode/eden/oss/.github/workflows --job-file-prefix mononoke_ --job-name-prefix "Mononoke " --free-up-disk --project-install-prefix mononoke:/`

Resolves https://github.com/facebook/sapling/issues/922

Differential Revision: D63031271
