### PR TITLE
[isl] Add baseRef/headRef/oid to github pull request fetches

### DIFF
--- a/addons/isl-server/src/github/generated/graphql.ts
+++ b/addons/isl-server/src/github/generated/graphql.ts
@@ -29508,7 +29508,7 @@ export type YourPullRequestsQueryVariables = Exact<{
 }>;
 
 
-export type YourPullRequestsQueryData = { __typename?: 'Query', search: { __typename?: 'SearchResultItemConnection', nodes?: Array<{ __typename?: 'App' } | { __typename?: 'Discussion' } | { __typename?: 'Issue' } | { __typename?: 'MarketplaceListing' } | { __typename?: 'Organization' } | { __typename: 'PullRequest', number: number, title: string, body: string, state: PullRequestState, isDraft: boolean, url: string, reviewDecision?: PullRequestReviewDecision | null, comments: { __typename?: 'IssueCommentConnection', totalCount: number }, mergeQueueEntry?: { __typename?: 'MergeQueueEntry', estimatedTimeToMerge?: number | null } | null, commits: { __typename?: 'PullRequestCommitConnection', nodes?: Array<{ __typename?: 'PullRequestCommit', commit: { __typename?: 'Commit', statusCheckRollup?: { __typename?: 'StatusCheckRollup', state: StatusState } | null } } | null> | null } } | { __typename?: 'Repository' } | { __typename?: 'User' } | null> | null } };
+export type YourPullRequestsQueryData = { __typename?: 'Query', search: { __typename?: 'SearchResultItemConnection', nodes?: Array<{ __typename?: 'App' } | { __typename?: 'Discussion' } | { __typename?: 'Issue' } | { __typename?: 'MarketplaceListing' } | { __typename?: 'Organization' } | { __typename: 'PullRequest', number: number, title: string, body: string, state: PullRequestState, isDraft: boolean, url: string, reviewDecision?: PullRequestReviewDecision | null, comments: { __typename?: 'IssueCommentConnection', totalCount: number }, mergeQueueEntry?: { __typename?: 'MergeQueueEntry', estimatedTimeToMerge?: number | null } | null, baseRef?: { __typename?: 'Ref', name: string, target?: { __typename?: 'Blob', oid: string } | { __typename?: 'Commit', oid: string } | { __typename?: 'Tag', oid: string } | { __typename?: 'Tree', oid: string } | null } | null, headRef?: { __typename?: 'Ref', name: string, target?: { __typename?: 'Blob', oid: string } | { __typename?: 'Commit', oid: string } | { __typename?: 'Tag', oid: string } | { __typename?: 'Tree', oid: string } | null } | null, commits: { __typename?: 'PullRequestCommitConnection', nodes?: Array<{ __typename?: 'PullRequestCommit', commit: { __typename?: 'Commit', oid: string, statusCheckRollup?: { __typename?: 'StatusCheckRollup', state: StatusState } | null } } | null> | null } } | { __typename?: 'Repository' } | { __typename?: 'User' } | null> | null } };
 
 export type YourPullRequestsWithoutMergeQueueQueryVariables = Exact<{
   searchQuery: Scalars['String'];
@@ -29516,7 +29516,7 @@ export type YourPullRequestsWithoutMergeQueueQueryVariables = Exact<{
 }>;
 
 
-export type YourPullRequestsWithoutMergeQueueQueryData = { __typename?: 'Query', search: { __typename?: 'SearchResultItemConnection', nodes?: Array<{ __typename?: 'App' } | { __typename?: 'Discussion' } | { __typename?: 'Issue' } | { __typename?: 'MarketplaceListing' } | { __typename?: 'Organization' } | { __typename: 'PullRequest', number: number, title: string, body: string, state: PullRequestState, isDraft: boolean, url: string, reviewDecision?: PullRequestReviewDecision | null, comments: { __typename?: 'IssueCommentConnection', totalCount: number }, commits: { __typename?: 'PullRequestCommitConnection', nodes?: Array<{ __typename?: 'PullRequestCommit', commit: { __typename?: 'Commit', statusCheckRollup?: { __typename?: 'StatusCheckRollup', state: StatusState } | null } } | null> | null } } | { __typename?: 'Repository' } | { __typename?: 'User' } | null> | null } };
+export type YourPullRequestsWithoutMergeQueueQueryData = { __typename?: 'Query', search: { __typename?: 'SearchResultItemConnection', nodes?: Array<{ __typename?: 'App' } | { __typename?: 'Discussion' } | { __typename?: 'Issue' } | { __typename?: 'MarketplaceListing' } | { __typename?: 'Organization' } | { __typename: 'PullRequest', number: number, title: string, body: string, state: PullRequestState, isDraft: boolean, url: string, reviewDecision?: PullRequestReviewDecision | null, comments: { __typename?: 'IssueCommentConnection', totalCount: number }, baseRef?: { __typename?: 'Ref', name: string, target?: { __typename?: 'Blob', oid: string } | { __typename?: 'Commit', oid: string } | { __typename?: 'Tag', oid: string } | { __typename?: 'Tree', oid: string } | null } | null, headRef?: { __typename?: 'Ref', name: string, target?: { __typename?: 'Blob', oid: string } | { __typename?: 'Commit', oid: string } | { __typename?: 'Tag', oid: string } | { __typename?: 'Tree', oid: string } | null } | null, commits: { __typename?: 'PullRequestCommitConnection', nodes?: Array<{ __typename?: 'PullRequestCommit', commit: { __typename?: 'Commit', oid: string, statusCheckRollup?: { __typename?: 'StatusCheckRollup', state: StatusState } | null } } | null> | null } } | { __typename?: 'Repository' } | { __typename?: 'User' } | null> | null } };
 
 export const CommentParts = `
     fragment CommentParts on Comment {
@@ -29595,9 +29595,22 @@ export const YourPullRequestsQuery = `
         mergeQueueEntry {
           estimatedTimeToMerge
         }
-        commits(last: 1) {
+        baseRef {
+          target {
+            oid
+          }
+          name
+        }
+        headRef {
+          target {
+            oid
+          }
+          name
+        }
+        commits(last: 100) {
           nodes {
             commit {
+              oid
               statusCheckRollup {
                 state
               }
@@ -29625,9 +29638,22 @@ export const YourPullRequestsWithoutMergeQueueQuery = `
         comments {
           totalCount
         }
-        commits(last: 1) {
+        baseRef {
+          target {
+            oid
+          }
+          name
+        }
+        headRef {
+          target {
+            oid
+          }
+          name
+        }
+        commits(last: 100) {
           nodes {
             commit {
+              oid
               statusCheckRollup {
                 state
               }

--- a/addons/isl-server/src/github/queries/YourPullRequestsQuery.graphql
+++ b/addons/isl-server/src/github/queries/YourPullRequestsQuery.graphql
@@ -16,9 +16,22 @@ query YourPullRequestsQuery($searchQuery: String!, $numToFetch: Int!) {
         mergeQueueEntry {
           estimatedTimeToMerge
         }
-        commits(last: 1) {
+        baseRef {
+          target {
+            oid
+          }
+          name
+        }
+        headRef {
+          target {
+            oid
+          }
+          name
+        }
+        commits(last: 100) {
           nodes {
             commit {
+              oid
               statusCheckRollup {
                 state
               }

--- a/addons/isl-server/src/github/queries/YourPullRequestsWithoutMergeQueueQuery.graphql
+++ b/addons/isl-server/src/github/queries/YourPullRequestsWithoutMergeQueueQuery.graphql
@@ -13,9 +13,22 @@ query YourPullRequestsWithoutMergeQueueQuery($searchQuery: String!, $numToFetch:
         comments {
           totalCount
         }
-        commits(last: 1) {
+        baseRef {
+          target {
+            oid
+          }
+          name
+        }
+        headRef {
+          target {
+            oid
+          }
+          name
+        }
+        commits(last: 100) {
           nodes {
             commit {
+              oid
               statusCheckRollup {
                 state
               }


### PR DESCRIPTION

Summary: Add extra fields for the PR commit range (base and head) which lets us understand which PR branches exist in your repo

Test Plan: Used in later diffs
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/953).
* #954
* __->__ #953