### PR TITLE
perf(github): improve `gh` start time by skipping lookup table generation

### DIFF
--- a/eden/scm/ghstack/github_gh_cli.py
+++ b/eden/scm/ghstack/github_gh_cli.py
@@ -54,6 +54,7 @@ async def _make_request(
     # explicitly disable ANSI colors in our piped output.
     env = os.environ.copy()
     env["CLICOLOR_FORCE"] = "0"
+    env["TCELL_MINIMIZE"] = "1"
     proc = await asyncio.create_subprocess_exec(
         *args, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, env=env
     )

--- a/eden/scm/sapling/ext/github/github_repo_util.py
+++ b/eden/scm/sapling/ext/github/github_repo_util.py
@@ -129,6 +129,7 @@ def is_github_enterprise_hostname(hostname: str) -> bool:
             ["gh", "auth", "status", "--hostname", hostname],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
+            env=dict(os.environ, TCELL_MINIMIZE="1"),
         )
     except Exception:
         # The user may not be authenticated or may not even have `gh` installed.


### PR DESCRIPTION

Summary:
This change improves the start time of gh by skipping the generation of the
lookup table in tcell, a dependency of gh. This is done by setting the
`TCELL_MINIMIZE` environment variable when calling `gh`.

Here is a benchmark for a frequent command we run

```sh
$ hyperfine -w2 \
  'gh auth status --hostname github.com' \
  'TCELL_MINIMIZE=1 gh auth status --hostname github.com'

Benchmark 1: gh auth status --hostname github.com
  Time (mean ± σ):     406.5 ms ±  13.4 ms    [User: 63.9 ms, System: 25.6 ms]
  Range (min … max):   389.0 ms … 430.3 ms    10 runs

Benchmark 2: TCELL_MINIMIZE=1 gh auth status --hostname github.com
  Time (mean ± σ):     380.6 ms ±  10.9 ms    [User: 42.8 ms, System: 27.3 ms]
  Range (min … max):   364.1 ms … 404.2 ms    10 runs

Summary
  TCELL_MINIMIZE=1 gh auth status --hostname github.com ran
    1.07 ± 0.05 times faster than gh auth status --hostname github.com
```

I tried measuring the impact of this change on `sl pr list` but it's too noisy.
Are there any better examples?

```sh
$ hyperfine -w3 'CHGDISABLE=1 sl pr list' 'CHGDISABLE=1 ./sl pr list'
Benchmark 1: CHGDISABLE=1 sl pr list
  Time (mean ± σ):     772.0 ms ± 193.8 ms    [User: 227.0 ms, System: 55.2 ms]
  Range (min … max):   664.2 ms … 1313.6 ms    10 runs

Benchmark 2: CHGDISABLE=1 ./sl pr list
  Time (mean ± σ):     741.8 ms ±  29.5 ms    [User: 242.1 ms, System: 68.9 ms]
  Range (min … max):   689.8 ms … 778.1 ms    10 runs

Summary
  CHGDISABLE=1 ./sl pr list ran
    1.04 ± 0.26 times faster than CHGDISABLE=1 sl pr list
```
