### PR TITLE
sapling getdeps cli build and test support for python 3.12

### DIFF
--- a/.github/workflows/sapling-cli-getdeps_linux.yml
+++ b/.github/workflows/sapling-cli-getdeps_linux.yml
@@ -30,8 +30,14 @@ jobs:
       run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive sapling
     - name: Install packaging system deps
       run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive patchelf
+    - name: Install locale-gen
+      run: sudo apt-get install locales
+    - name: Ensure en_US.UTF-8 locale present
+      run: sudo locale-gen en_US.UTF-8
     - name: Install Rust Stable
       uses: dtolnay/rust-toolchain@stable
+    - name: Fetch hexdump
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests hexdump
     - name: Fetch bz2
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests bz2
     - name: Fetch ninja
@@ -102,6 +108,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fb303
     - name: Fetch rust-shed
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests rust-shed
+    - name: Build hexdump
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests hexdump
     - name: Build bz2
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests bz2
     - name: Build ninja
@@ -181,6 +189,7 @@ jobs:
         name: sapling
         path: _artifacts
     - name: Test sapling
-      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages test --src-dir=. sapling  --project-install-prefix sapling:/
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages test --num-jobs 16 --src-dir=. sapling  --project-install-prefix sapling:/
     - name: Show disk space at end
+      if: always()
       run: df -h

--- a/.github/workflows/sapling-cli-getdeps_linux.yml
+++ b/.github/workflows/sapling-cli-getdeps_linux.yml
@@ -70,6 +70,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests snappy
     - name: Fetch zlib
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zlib
+    - name: Fetch python-setuptools
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests python-setuptools
     - name: Fetch openssl
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests openssl
     - name: Fetch liboqs
@@ -142,6 +144,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests snappy
     - name: Build zlib
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests zlib
+    - name: Build python-setuptools
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests python-setuptools
     - name: Build openssl
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests openssl
     - name: Build liboqs

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ target/
 
 # Getdeps
 /eden/mononoke/tests/integration/getdeps_build.log
+/build/Testing/Temporary/LastTest.log

--- a/build/fbcode_builder/getdeps/manifest.py
+++ b/build/fbcode_builder/getdeps/manifest.py
@@ -87,6 +87,7 @@ SCHEMA = {
         "optional_section": True,
         "fields": {
             "run_tests": OPTIONAL,
+            "required_locales": OPTIONAL,
         },
     },
     "crate.pathmap": {"optional_section": True},

--- a/build/fbcode_builder/manifests/bz2
+++ b/build/fbcode_builder/manifests/bz2
@@ -3,12 +3,14 @@ name = bz2
 
 [debs]
 libbz2-dev
+bzip2
 
 [homebrew]
 bzip2
 
 [rpms]
 bzip2-devel
+bzip2
 
 [download]
 url = https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz

--- a/build/fbcode_builder/manifests/hexdump
+++ b/build/fbcode_builder/manifests/hexdump
@@ -1,0 +1,12 @@
+[manifest]
+name = hexdump
+
+[rpms]
+util-linux
+
+[debs]
+bsdmainutils
+
+# only used from system packages currently
+[build]
+builder = nop

--- a/build/fbcode_builder/manifests/mononoke_integration
+++ b/build/fbcode_builder/manifests/mononoke_integration
@@ -45,9 +45,3 @@ zstd
 
 [dependencies.os=linux]
 sqlite3
-
-[dependencies.os=darwin]
-gnu-bash
-gnu-coreutils
-gnu-grep
-gnu-sed

--- a/build/fbcode_builder/manifests/python-setuptools
+++ b/build/fbcode_builder/manifests/python-setuptools
@@ -7,3 +7,12 @@ sha256 = 02fa291a0471b3a18b2b2481ed902af520c69e8ae0919c13da936542754b4c56
 
 [build]
 builder = python-wheel
+
+[rpms]
+python3-setuptools
+
+[homebrew]
+python-setuptools
+
+[debs]
+python3-setuptools

--- a/build/fbcode_builder/manifests/sapling
+++ b/build/fbcode_builder/manifests/sapling
@@ -4,6 +4,9 @@ fbsource_path = fbcode/eden
 shipit_project = eden
 shipit_fbcode_builder = true
 
+[github.actions]
+required_locales = en_US.UTF-8
+
 [git]
 repo_url = https://github.com/facebook/sapling.git
 
@@ -56,6 +59,9 @@ fbcode/tools/lfs = tools/lfs
 fb303
 fbthrift
 rust-shed
+
+[dependencies.test=on]
+hexdump
 
 [dependencies.not(os=windows)]
 python

--- a/build/fbcode_builder/manifests/sapling
+++ b/build/fbcode_builder/manifests/sapling
@@ -65,6 +65,7 @@ hexdump
 
 [dependencies.not(os=windows)]
 python
+python-setuptools
 
 # We use the system openssl on linux
 [dependencies.not(os=linux)]

--- a/eden/integration/lib/find_executables.py
+++ b/eden/integration/lib/find_executables.py
@@ -9,11 +9,12 @@ These utilities are only expected to work if `sys.argv[0]` is an executable
 being run in buck-out.
 """
 
-# pyre-strict
-
-import distutils.spawn
 import logging
 import os
+
+# pyre-strict
+
+import shutil
 import sys
 from pathlib import Path
 from typing import Any, Callable, Dict, Generic, List, Optional, Tuple, Type, TypeVar
@@ -192,9 +193,7 @@ class FindExeClass:
 
     @cached_property
     def GIT(self) -> str:
-        git = distutils.spawn.find_executable(
-            "git.real"
-        ) or distutils.spawn.find_executable("git")
+        git = shutil.which("git.real") or shutil.which("git")
         if git is None:
             raise Exception("unable to find git binary")
         return git
@@ -224,7 +223,7 @@ class FindExeClass:
         if hg_bin:
             return hg_bin
 
-        hg_real_bin = distutils.spawn.find_executable("hg")
+        hg_real_bin = shutil.which("hg")
         if hg_real_bin:
             return hg_real_bin
 
@@ -238,11 +237,11 @@ class FindExeClass:
         if hg_real_bin:
             return hg_real_bin
 
-        hg_real_bin = distutils.spawn.find_executable("hg.real")
+        hg_real_bin = shutil.which("hg.real")
         if hg_real_bin:
             return hg_real_bin
 
-        hg_real_bin = distutils.spawn.find_executable("hg")
+        hg_real_bin = shutil.which("hg")
         if hg_real_bin:
             return hg_real_bin
 

--- a/eden/scm/Makefile
+++ b/eden/scm/Makefile
@@ -65,6 +65,9 @@ COMPILERFLAG_tmp_ =
 COMPILERFLAG_tmp_${COMPILER} ?= -c $(COMPILER)
 COMPILERFLAG=${COMPILERFLAG_tmp_${COMPILER}}
 
+MAKE_PID := $(shell echo $$PPID)
+JOBS := $(shell ps T | sed -n 's%.*$(MAKE_PID).*$(MAKE).* \(-j\|--jobs=\) *\([0-9][0-9]*\).*%\2%p')
+
 # Mac Big Sur doesn't find the standard library without this.
 export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
 
@@ -172,17 +175,86 @@ install: build
 install-home: build
 	$(PYTHON) setup.py $(PURE) install --home="$(HOME)" --prefix="" --force
 
-install-getdeps: getdepsbuild
+install-getdeps:
 	PYTHON_SYS_EXECUTABLE=$(shell $(PYTHON3) contrib/pick_python.py $(PYTHON3)) \
 	    GETDEPS_BUILD=1 $(shell $(PYTHON3) contrib/pick_python.py $(PYTHON3)) \
-		setup.py $(PURE) install --root="$(DESTDIR)/" --prefix="$(PREFIX)" --install-lib="$(PREFIX)/bin" --force
+		setup.py $(PURE) install --skip-build --prefix="$(PREFIX)" --install-scripts="$(PREFIX)/bin"  --install-lib="$(PREFIX)/bin" --force && \
+		cd "$(PREFIX)/bin" && ln -f "$(SL_BIN_NAME)" "$(HG_BIN_NAME)"
+
+# Exclusions for OSS getdeps cli tests.  Newline separated
+# test-cats.t: internal crpyto token test
+# test-check-execute.t: fails on CI, passes locally on ubuntu-22.04
+# test-clone-per-repo-config.t: fails in oss, looks like depends on fb hgrc.dynamic
+# test-clone-resume.t: fails on CI, passes locally on ubuntu-22.04
+# test-commitcloud-sync.t: flaky Last Sync Version on line 812, flips beteen 17 and 16
+# test-config-precedence.t:  output mismatch: DEBUG configloader::hg: spawn ["false"] because * (glob)
+# test-dynamicconfig-unicode.t: output mismatch: cat: .hg/hgrc.dynamic: $ENOENT$
+# test-debugrefreshconfig.t: assumes an internal config location
+# test-fb-ext-fastlog.t: timesout, maybe due to internal endpoint assumptions
+# test-fb-ext-sampling.t: timeout
+# test-fb-ext-smartlog.t: output mismatch
+# test-help.t: help is different vs internal build
+# test-include-fail.t: fails on CI, passes locally on ubuntu-22.04
+# test-matcher-lots-of-globs.t: fails on CI, passes locally on ubuntu-22.04 (needs ~40GiB RAM)
+# test-network-doctor.t: times out
+# test-rust-checkout.t: fails on CI, passes locally on ubuntu-22.04
+# test-smartlog-interactive.t: smartlog format is different causing output mismatch
+# test-smartlog-interactive-highlighting.t: smartlog format is different causing output mismatch
+GETDEPS_TEST_EXCLUSION_LIST := test-cats.t \
+	test-check-execute.t \
+	test-clone-per-repo-config.t \
+	test-clone-resume.t \
+	test-commitcloud-sync.t \
+	test-config-precedence.t \
+	test-dynamicconfig-unicode.t \
+	test-debugrefreshconfig.t \
+	test-fb-ext-fastlog.t \
+	test-fb-ext-sampling.t \
+	test-fb-ext-smartlog.t \
+	test-help.t \
+	test-include-fail.t \
+	test-matcher-lots-of-globs.t \
+	test-network-doctor.t \
+	test-rust-checkout.t \
+	test-smartlog-interactive.t \
+	test-smartlog-interactive-highlighting.t
+	
+# convert to a sed expression
+GETDEPS_TEST_EXCLUSIONS := $(subst $() $(),|,$(GETDEPS_TEST_EXCLUSION_LIST))
 
 .PHONY: test-getdeps
 test-getdeps:
-	# Run indicative tests to check the binary is minimally good as will be used later in Mononoke getdeps tests
-	# Running all the tests requires a bit of filtering to run the good set (or deleting flaky ones)
-	cd tests && PYTHON_SYS_EXECUTABLE=$(shell $(PYTHON3) contrib/pick_python.py $(PYTHON3)) \
-	    $(shell $(PYTHON3) contrib/pick_python.py $(PYTHON3)) run-tests.py -j2 --getdeps-build --with-hg="$(PREFIX)/bin/$(HGNAME)" test-status.t test-commit.t
+    # Remove the .testfailed and .testerrored files so that after this next
+	# step they are written clean
+	rm -f ./tests/.test*
+	# ensure that fbpython is present, as some tests depend on it being on PATH
+	if ! which fbpython >/dev/null 2>&1; then \
+		FBPYTHON="$(GETDEPS_INSTALL_DIR)/sapling/bin/fbpython"; \
+		PYTHON_SYS_EXECUTABLE=$(shell $(PYTHON3) contrib/pick_python.py $(PYTHON3)); \
+		printf "#!/bin/sh\nexec \"$$PYTHON_SYS_EXECUTABLE\" \"\$$@\"\n"  > $$FBPYTHON; \
+		chmod +x "$$FBPYTHON"; \
+	fi;
+	# Run tests and retry any failures
+	export GETDEPS_BUILD=1; \
+	export HGTEST_HG=$(GETDEPS_INSTALL_DIR)/sapling/bin/$(HG_BIN_NAME); \
+	cd tests && export PYTHON_SYS_EXECUTABLE=$(shell $(PYTHON3) contrib/pick_python.py $(PYTHON3)); \
+	for try in $$(seq 0 $(GETDEPS_TEST_RETRY)); do \
+		RERUN_ARG=""; \
+		GETDEPS_TEST_FILTER=$(GETDEPS_TEST_FILTER); \
+		if [ $$try -gt 0 ]; then \
+			GETDEPS_TEST_FILTER=$$(cat .testfailed .testerrored | sort -u | grep -v '^$$'); \
+			if [ -z "$$GETDEPS_TEST_FILTER" ]; then "Echo no tests found for rerun on try $$try"; exit 2; fi; \
+			echo "Rerunning: $$GETDEPS_TEST_FILTER on try $$try" 1>&2; \
+			rm -f .testfailed .testerrored; \
+		elif [ -z "$$GETDEPS_TEST_FILTER" ]; then \
+		    GETDEPS_TEST_FILTER=$$(echo *.t | sed -Ee 's/($(GETDEPS_TEST_EXCLUSIONS))//g'); \
+		fi; \
+		$$PYTHON_SYS_EXECUTABLE run-tests.py -j $(JOBS) --getdeps-build --with-hg="$(PREFIX)/bin/$(HGNAME)" $$GETDEPS_TEST_FILTER; \
+		status=$$?; \
+		# stop if all good \
+		if [ $$status = 0 ]; then echo "passed on try $$try"; exit 0; fi; \
+	done; \
+	exit $$status
 
 check: tests
 

--- a/eden/scm/README.md
+++ b/eden/scm/README.md
@@ -4,7 +4,7 @@ Sapling is a fast, easy to use, distributed revision control tool for software
 developers.
 
 
-Basic install:
+# Basic install
 
 ```
 $ make install-oss
@@ -20,6 +20,33 @@ $ make oss        # build for inplace usage
 $ ./sl --version  # should show the latest version
 ```
 
-
 See <https://sapling-scm.com/> for detailed installation instructions,
 platform-specific notes, and Sapling user information.
+
+# Thrift enabled getdeps CLI build for use with Mononoke or EdenFS
+
+Mononoke and EdenFS need the thrift enabled sapling CLI built via getdeps. Check github actions to see current OS version the Sapling CLI Getdeps CI runs with.
+
+This build also provides a way to run the sapling .t tests in github CI and locally.
+
+When building locally you don't need to separately build all the dependencies like the github CI does, command line steps are:
+
+make sure required system packages are installed:
+`./build/fbcode_builder/getdeps.py install-system-deps --recursive sapling`
+
+build sapling (and any dependencies it requires):
+`./build/fbcode_builder/getdeps.py build --allow-system-packages --src-dir=. sapling`
+
+you can find the built binaries via:
+`./build/fbcode_builder/getdeps.py show-inst-dir --allow-system-packages --src-dir=. sapling`
+
+run the tests (you can use --num-jobs=N to adjust concurrency):
+`./build/fbcode_builder/getdeps.py test --allow-system-packages --src-dir=. --num-jobs=64 sapling`
+
+to iterate on one test run with --retry 0 --filter:
+`./build/fbcode_builder/getdeps.py test --allow-system-packages --src-dir=. sapling --retry 0 --filter test-check-execute.t`
+
+to run multiple tests with --filter separate with spaces:
+`./build/fbcode_builder/getdeps.py test --allow-system-packages --src-dir=. sapling --retry 0 --filter "test-include-fail.t test-matcher-lots-of-globs.t"`
+
+The getdeps build doesn't currently build/test ISL or other node integration.

--- a/eden/scm/contrib/check-code.py
+++ b/eden/scm/contrib/check-code.py
@@ -415,7 +415,7 @@ txtfilters = []
 
 txtpats = [
     [
-        ("\s$", "trailing whitespace"),
+        ("\\s$", "trailing whitespace"),
         (".. note::[ \n][^\n]", "add two newlines after note::"),
     ],
     [],

--- a/eden/scm/contrib/fix-code.py
+++ b/eden/scm/contrib/fix-code.py
@@ -21,6 +21,10 @@ import glob
 import os
 import re
 import sys
+
+import setuptools  # noqa # usort:skip imported to get setuptools version of distutils
+
+# after setuptools so that python 3.12 can find it
 from distutils.version import LooseVersion
 
 

--- a/eden/scm/distutils_rust/__init__.py
+++ b/eden/scm/distutils_rust/__init__.py
@@ -7,14 +7,16 @@
 
 from __future__ import absolute_import
 
+import logging
+from sysconfig import get_platform
+
+import setuptools.errors
+
+from setuptools import Command
+
+log = logging.getLogger()
+
 import contextlib
-import distutils
-import distutils.command.build
-import distutils.command.install
-import distutils.command.install_scripts
-import distutils.core
-import distutils.errors
-import distutils.util
 import errno
 import io
 import os
@@ -23,6 +25,10 @@ import subprocess
 import sys
 import tempfile
 import threading
+from distutils.command.build import build
+from distutils.command.install import install
+from distutils.command.install_scripts import install_scripts
+from distutils.dist import Distribution
 
 
 # This manifest is merged with the default .exe manifest to allow
@@ -79,7 +85,7 @@ class RustExtension:
 
     @property
     def dstnametmp(self):
-        platform = distutils.util.get_platform()
+        platform = get_platform()
         if platform.startswith("win"):
             name = self.name + ".dll"
         elif platform.startswith("macosx"):
@@ -90,7 +96,7 @@ class RustExtension:
 
     @property
     def dstname(self):
-        platform = distutils.util.get_platform()
+        platform = get_platform()
         if platform.startswith("win"):
             name = self.name + ".pyd"
         else:
@@ -128,7 +134,7 @@ class RustBinary:
 
     @property
     def dstnametmp(self):
-        platform = distutils.util.get_platform()
+        platform = get_platform()
         if platform.startswith("win"):
             return self.name + ".exe"
         else:
@@ -136,14 +142,14 @@ class RustBinary:
 
     @property
     def dstname(self):
-        platform = distutils.util.get_platform()
+        platform = get_platform()
         if platform.startswith("win"):
             return self.final_name + ".exe"
         else:
             return self.final_name
 
 
-class BuildRustExt(distutils.core.Command):
+class BuildRustExt(Command):
 
     description = "build Rust extensions (compile/link to build directory)"
 
@@ -230,7 +236,7 @@ class BuildRustExt(distutils.core.Command):
         elif target.type == "binary":
             return os.path.join(self.build_exe, target.dstname)
         else:
-            raise distutils.errors.CompileError("Unknown Rust target type")
+            raise setuptools.errors.CompileError("Unknown Rust target type")
 
     def write_cargo_config(self):
         config = """
@@ -336,7 +342,7 @@ replace-with = "vendored-sources"
 
         rc = _callretry(cmd, env=env)
         if rc:
-            raise distutils.errors.CompileError(
+            raise setuptools.errors.CompileError(
                 "compilation of Rust target '%s' failed" % target.name
             )
 
@@ -344,7 +350,7 @@ replace-with = "vendored-sources"
 
         if (
             target.type == "binary"
-            and distutils.util.get_platform().startswith("win")
+            and get_platform().startswith("win")
             and self.long_paths_support
         ):
             retry = 0
@@ -358,7 +364,7 @@ replace-with = "vendored-sources"
                     if retry > 5:
                         raise
                     else:
-                        distutils.log.warn("Retrying setting long path on %s" % src)
+                        log.warning("Retrying setting long path on %s" % src)
                         continue
                 else:
                     break
@@ -379,9 +385,9 @@ replace-with = "vendored-sources"
             shutil.copy(pdbsrc, pdbdest)
 
     def set_long_paths_manifest(self, fname):
-        if not distutils.util.get_platform().startswith("win"):
+        if not get_platform().startswith("win"):
             # This only makes sense on Windows
-            distutils.log.info(
+            log.info(
                 "skipping set_long_paths_manifest call for %s "
                 "as the plaform in not Windows",
                 fname,
@@ -389,7 +395,7 @@ replace-with = "vendored-sources"
             return
         if not fname.endswith(".exe"):
             # we only care about executables
-            distutils.log.info(
+            log.info(
                 "skipping set_long_paths_manifest call for %s "
                 "as the file extension is not exe",
                 fname,
@@ -400,9 +406,7 @@ replace-with = "vendored-sources"
         os.close(fdauto)
         with open(manfname, "w") as f:
             f.write(LONG_PATHS_MANIFEST)
-        distutils.log.debug(
-            "LongPathsAware manifest written into tempfile: %s", manfname
-        )
+        log.debug("LongPathsAware manifest written into tempfile: %s", manfname)
         inputresource = "-inputresource:%s;#1" % fname
         outputresource = "-outputresource:%s;#1" % fname
         command = [
@@ -414,23 +418,19 @@ replace-with = "vendored-sources"
             inputresource,
         ]
         try:
-            distutils.log.debug(
+            log.debug(
                 "Trying to merge LongPathsAware manifest with the existing "
                 "manifest of the binary %s",
                 fname,
             )
             subprocess.check_output(command)
-            distutils.log.debug(
-                "LongPathsAware manifest successfully merged into %s", fname
-            )
+            log.debug("LongPathsAware manifest successfully merged into %s", fname)
         except subprocess.CalledProcessError as e:
             no_resource_err = b"c101008c"
             if no_resource_err not in e.output.lower():
-                distutils.log.error(
-                    "Setting LongPathsAware manifest failed: %r", e.output
-                )
+                log.error("Setting LongPathsAware manifest failed: %r", e.output)
                 raise
-            distutils.log.debug(
+            log.debug(
                 "The binary %s does not have an existing manifest. Writing "
                 "a LongPathsAware one",
                 fname,
@@ -439,18 +439,16 @@ replace-with = "vendored-sources"
             # but rather just write one.
             command.remove(inputresource)
             subprocess.check_output(command)
-            distutils.log.debug(
-                "LongPathsAware manifest successfully written into %s", fname
-            )
+            log.debug("LongPathsAware manifest successfully written into %s", fname)
         finally:
             os.remove(manfname)
 
     def build_binary(self, target):
-        distutils.log.info("building '%s' binary", target.name)
+        log.info("building '%s' binary", target.name)
         self.build_target(target)
 
     def build_library(self, target):
-        distutils.log.info("building '%s' library extension", target.name)
+        log.info("building '%s' library extension", target.name)
         self.build_target(target)
 
     try:
@@ -471,7 +469,7 @@ replace-with = "vendored-sources"
             return env
 
 
-class InstallRustExt(distutils.command.install_scripts.install_scripts):
+class InstallRustExt(install_scripts):
     description = "install Rust extensions and binaries"
 
     def run(self):
@@ -512,7 +510,7 @@ def _callattempt(cmd, env=None, retry=3):
     if retry > 0 and returncode != 0:
         stderr = sio.getvalue()
         if _isflaky(stderr):
-            distutils.log.warn("retrying %r on flaky error" % (cmd,))
+            log.warning("retrying %r on flaky error" % (cmd,))
             return _callattempt(cmd, env=env, retry=retry - 1)
     return returncode
 
@@ -528,16 +526,16 @@ def _isflaky(stderr):
     return False
 
 
-distutils.dist.Distribution.rust_ext_modules = ()
-distutils.dist.Distribution.rust_ext_binaries = ()
-distutils.command.build.build.sub_commands.append(
+Distribution.rust_ext_modules = ()
+Distribution.rust_ext_binaries = ()
+build.sub_commands.append(
     (
         "build_rust_ext",
         lambda self: bool(self.distribution.rust_ext_modules)
         or bool(self.distribution.rust_ext_binaries),
     )
 )
-distutils.command.install.install.sub_commands.append(
+install.sub_commands.append(
     (
         "install_rust_ext",
         lambda self: bool(self.distribution.rust_ext_modules)

--- a/eden/scm/sapling/util.py
+++ b/eden/scm/sapling/util.py
@@ -2254,9 +2254,10 @@ def makedate(timestamp=None):
     if timestamp < 0:
         hint = _("check your clock")
         raise Abort(_("negative timestamp: %d") % timestamp, hint=hint)
-    delta = datetime.datetime.utcfromtimestamp(
-        timestamp
-    ) - datetime.datetime.fromtimestamp(timestamp)
+    as_utc = datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc)
+    converted = as_utc.astimezone()
+    forced = as_utc.replace(tzinfo=converted.tzinfo)
+    delta = forced - converted
     tz = delta.days * 86400 + delta.seconds
     return timestamp, tz
 

--- a/eden/scm/tests/test-eolfilename.t
+++ b/eden/scm/tests/test-eolfilename.t
@@ -37,27 +37,27 @@ Do error out if the naughty file is explicitly referenced:
   nothing changed
   [1]
   $ echo foo > "$A"
-  $ hg debugwalk
+  $ hg debugwalk 2>&1 | sort
   skipping invalid path 'he\rllo'
   skipping invalid path 'hell\no'
 
   $ echo bla > quickfox
-  $ hg add quickfox
+  $ hg add quickfox 2>&1  | sort
   skipping invalid path 'he\rllo'
   skipping invalid path 'hell\no'
-  $ hg ci -m 2
+  $ hg ci -m 2 2>&1 | sort
   skipping invalid path 'he\rllo'
   skipping invalid path 'hell\no'
   $ A=`printf 'quick\rfox'`
-  $ hg cp quickfox "$A"
+  $ (hg cp quickfox "$A" 2>&1; echo "[$?]" 1>&2) | sort
+  abort: '\n' and '\r' disallowed in filenames: 'quick\rfox'
   skipping invalid path 'he\rllo'
   skipping invalid path 'hell\no'
-  abort: '\n' and '\r' disallowed in filenames: 'quick\rfox'
   [255]
-  $ hg mv quickfox "$A"
+  $ (hg mv quickfox "$A" 2>&1; echo "[$?]" 1>&2) | sort
+  abort: '\n' and '\r' disallowed in filenames: 'quick\rfox'
   skipping invalid path 'he\rllo'
   skipping invalid path 'hell\no'
-  abort: '\n' and '\r' disallowed in filenames: 'quick\rfox'
   [255]
 
 https://bz.mercurial-scm.org/2036
@@ -78,10 +78,8 @@ test issue2039
   $ touch "$A"
   $ touch "$B"
 
-  $ hg status --color=always
-  skipping invalid filename: 'foo
-  bar.baz'
-  skipping invalid filename: 'foo
-  bar'
+  $ hg status --color=always 2>&1 | sed -e 's/foo\n/foo<NEWLINE>/'| sort
+  skipping invalid filename: 'foo<NEWLINE>bar'
+  skipping invalid filename: 'foo<NEWLINE>bar.baz'
 
   $ cd ..

--- a/eden/scm/tests/test-identity.t
+++ b/eden/scm/tests/test-identity.t
@@ -97,7 +97,7 @@ Test we prefer ".sl" over ".hg"
 
 Can choose flavor of dot dir using REPO_IDENTITY override:
   $ SL_IDENTITY=sl SL_REPO_IDENTITY=hg hg version -q
-  Sapling 4.4.2_dev
+  Sapling 4.* (glob)
   $ SL_IDENTITY=sl SL_REPO_IDENTITY=hg newrepo
   $ ls .hg/requires
   .hg/requires

--- a/eden/scm/tests/test-import-eol.t
+++ b/eden/scm/tests/test-import-eol.t
@@ -2,7 +2,7 @@
 #debugruntest-incompatible
 
 
-  $ cat > makepatch.py <<EOF
+  $ cat > makepatch.py <<'EOF'
   > f = open('eol.diff', 'wb')
   > w = f.write
   > _ = w(b'test message\n')
@@ -17,9 +17,9 @@
   > _ = w(b' \n')
   > _ = w(b' d\n')
   > _ = w(b'-e\n')
-  > _ = w(b'\ No newline at end of file\n')
+  > _ = w(b' No newline at end of file\n')
   > _ = w(b'+z\r\n')
-  > _ = w(b'\ No newline at end of file\r\n')
+  > _ = w(b' No newline at end of file\r\n')
   > EOF
 
   $ configure modern

--- a/eden/scm/tests/test-install.t
+++ b/eden/scm/tests/test-install.t
@@ -1,11 +1,9 @@
 #debugruntest-incompatible
   $ eagerepo
 hg debuginstall
-  $ hg debuginstall
+  $ hg debuginstall 2>&1 | grep -v 'checking Python version ' | grep -v 'checking Python lib '
   checking encoding (utf-8)...
   checking Python executable (*) (glob)
-  checking Python version (*) (glob)
-  checking Python lib (*lib*)... (glob)
   checking Python security support (*) (glob)
     TLS 1.2 not supported by Python install; network connections lack modern security (?)
     SNI not supported by Python install; may have connectivity issues with some servers (?)
@@ -44,11 +42,9 @@ hg debuginstall JSON
   ]
 
 hg debuginstall with no username
-  $ HGUSER= hg debuginstall
+  $ (HGUSER= hg debuginstall; echo [$?]) | grep -v 'checking Python version ' | grep -v 'checking Python lib '
   checking encoding (utf-8)...
   checking Python executable (*) (glob)
-  checking Python version (*) (glob)
-  checking Python lib (*lib*)... (glob)
   checking Python security support (*) (glob)
     TLS 1.2 not supported by Python install; network connections lack modern security (?)
     SNI not supported by Python install; may have connectivity issues with some servers (?)
@@ -83,11 +79,9 @@ path variables are expanded (~ is the same as $TESTTMP)
 #if execbit
   $ chmod 755 tools/testeditor.exe
 #endif
-  $ hg debuginstall --config ui.editor=~/tools/testeditor.exe
+  $ hg debuginstall --config ui.editor="~/tools/testeditor.exe" | grep -v 'checking Python version ' | grep -v 'checking Python lib '
   checking encoding (utf-8)...
   checking Python executable (*) (glob)
-  checking Python version (*) (glob)
-  checking Python lib (*lib*)... (glob)
   checking Python security support (*) (glob)
     TLS 1.2 not supported by Python install; network connections lack modern security (?)
     SNI not supported by Python install; may have connectivity issues with some servers (?)
@@ -100,4 +94,3 @@ path variables are expanded (~ is the same as $TESTTMP)
   checking commit editor (internal:none)
   checking username (test)
   no problems detected
-

--- a/eden/scm/tests/test-rust-hooks.t
+++ b/eden/scm/tests/test-rust-hooks.t
@@ -136,7 +136,7 @@ Warn about python hooks since we can't fall back to Python:
   [255]
 #else
   $ hg debugtestcommand --echo running
-  * command not found (glob)
+  * not found (glob)
   abort: pre-debugtestcommand hook exited with status 127
   [255]
 #endif

--- a/eden/scm/tests/test-sign-commit.t
+++ b/eden/scm/tests/test-sign-commit.t
@@ -35,7 +35,7 @@ Clone a Sapling repo from a Git repo:
 Create a GPG key and configure signing.
 
   $ export HGUSER="Test User <testuser@example.com>"
-  $ gpg --batch --passphrase '' --quick-gen-key "$HGUSER" rsa2048 default 2> /dev/null
+  $ gpg --batch --passphrase '' --yes --quick-gen-key "$HGUSER" rsa2048 default 2>/dev/null
   $ KEYID=$(gpg --list-secret-keys --keyid-format LONG --no-auto-check-trustdb | grep -oP '^sec\s+ rsa2048/\K(\w+)')
   gpg: please do a --check-trustdb
   $ hg config --local gpg.key "$KEYID"


### PR DESCRIPTION

Summary:
Ubuntu 24.04 and Fedora 40 are both python 3.12 based.  Update sapling's OSS getdeps build to allow build/run/test on python 3.12 while keeping 3.10 support.

* distutils is deprecated in python 3.12 stdlib, but fortunately setuptools is pretty similar and includes a vendored distutils, so updated to use setuptools's version and removed deprecated usage like `find_executable` in favor of `shutil.which()`.
* added a manifest so we get python3-setuptools installed.
* found some tests needed bunzip2, so update manifest for sapling and bz2 to install it
* util.py makedate():  datetime.utcfromtimestamp is deprecated in 3.12, so updated to use non-deprecated methods..
 Tested with test-command-template.t which shows tz offset.
* Makefile: disabled a few tests on 3.12 where updating the expectation to run on 3.12 and 3.10 is tricky
* tests modified to run on 3.12 and 3.10:
 * test-import-eol.t:  updated for invalid escape sequence warnings
 * test-install.t: updated to filter out message that appears in different order on 3.12 vs earlier versions
 * test-sign-commit.t: updated to add --yes for newer gpg that python 3.12 using distros have

Test Plan:

enter ubuntu 24.04 toolbox:
`toolbox enter ubuntu-toolbox-24.04 `

make sure system packages are installed
`./build/fbcode_builder/getdeps.py install-system-deps --recursive  sapling`

check oss non-thrift build:
```
make oss
$ ./sl --version
Fri Oct  4 17:14:19 BST 2024
Sapling 4.4.2_20241004_170203_06bd09bd1dd2
(see https://sapling-scm.com/ for more information)
```

build sapling getdepts
`./build/fbcode_builder/getdeps.py build --allow-system-packages --no-facebook-internal --src-dir=. sapling  --project-install-prefix sapling:/`

run the tests locally to validate python 3.12 operation:
```
./build/fbcode_builder/getdeps.py --allow-system-packages test --src-dir=. sapling --num-jobs=64 --project-install-prefix sapling:/'
```

generate github actions CI to pick up python3-setuptools
```
./build/fbcode_builder/getdeps.py --allow-system-packages generate-github-actions --free-up-disk --os-type=linux --src-dir=. --output-dir=.github/workflows --job-name "Sapling CLI Getdeps " --job-file-prefix=sapling-cli-getdeps_ sapling --num-jobs=16  --project-install-prefix sapling:/
```

github CI
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/sapling/pull/964).
* __->__ #964
* #963