### PR TITLE
getdeps: add xxhash ubuntu and homebrew packages, fix actions generation and regenerate

### DIFF
--- a/.github/workflows/edenfs_linux.yml
+++ b/.github/workflows/edenfs_linux.yml
@@ -27,9 +27,9 @@ jobs:
     - name: Update system package info
       run: sudo apt-get update
     - name: Install system deps
-      run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive eden
+      run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --no-tests --recursive eden
     - name: Install packaging system deps
-      run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive patchelf
+      run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --no-tests --recursive patchelf
     - name: Install Rust Stable
       uses: dtolnay/rust-toolchain@stable
     - name: Fetch lmdb
@@ -50,6 +50,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests glog
     - name: Fetch googletest
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests googletest
+    - name: Fetch xxhash
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests xxhash
     - name: Fetch zstd
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zstd
     - name: Fetch boost
@@ -148,6 +150,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests glog
     - name: Build googletest
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests googletest
+    - name: Build xxhash
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests xxhash
     - name: Build zstd
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests zstd
     - name: Build boost
@@ -237,4 +241,5 @@ jobs:
         name: eden
         path: _artifacts
     - name: Show disk space at end
+      if: always()
       run: df -h

--- a/.github/workflows/mononoke-integration_linux.yml
+++ b/.github/workflows/mononoke-integration_linux.yml
@@ -52,6 +52,10 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fmt
     - name: Fetch googletest
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests googletest
+    - name: Fetch xxhash
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests xxhash
+    - name: Fetch python-setuptools
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests python-setuptools
     - name: Fetch autoconf
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests autoconf
     - name: Fetch automake
@@ -136,6 +140,10 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fmt
     - name: Build googletest
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests googletest
+    - name: Build xxhash
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests xxhash
+    - name: Build python-setuptools
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests python-setuptools
     - name: Build autoconf
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests autoconf
     - name: Build automake

--- a/.github/workflows/mononoke_linux.yml
+++ b/.github/workflows/mononoke_linux.yml
@@ -32,6 +32,8 @@ jobs:
       run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive patchelf
     - name: Install Rust Stable
       uses: dtolnay/rust-toolchain@stable
+    - name: Fetch xxhash
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests xxhash
     - name: Fetch ninja
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests ninja
     - name: Fetch cmake
@@ -102,6 +104,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fb303
     - name: Fetch rust-shed
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests rust-shed
+    - name: Build xxhash
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests xxhash
     - name: Build ninja
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests ninja
     - name: Build cmake
@@ -183,4 +187,5 @@ jobs:
     - name: Test mononoke
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages test --src-dir=. mononoke  --project-install-prefix mononoke:/
     - name: Show disk space at end
+      if: always()
       run: df -h

--- a/.github/workflows/mononoke_mac.yml
+++ b/.github/workflows/mononoke_mac.yml
@@ -24,6 +24,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive mononoke
     - name: Install Rust Stable
       uses: dtolnay/rust-toolchain@stable
+    - name: Fetch xxhash
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests xxhash
     - name: Fetch openssl
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests openssl
     - name: Fetch ninja
@@ -82,6 +84,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fb303
     - name: Fetch rust-shed
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests rust-shed
+    - name: Build xxhash
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests xxhash
     - name: Build openssl
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests openssl
     - name: Build ninja
@@ -151,4 +155,5 @@ jobs:
     - name: Test mononoke
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages test --src-dir=. mononoke  --project-install-prefix mononoke:/usr/local
     - name: Show disk space at end
+      if: always()
       run: df -h

--- a/.github/workflows/sapling-cli-getdeps_linux.yml
+++ b/.github/workflows/sapling-cli-getdeps_linux.yml
@@ -38,6 +38,8 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
     - name: Fetch hexdump
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests hexdump
+    - name: Fetch xxhash
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests xxhash
     - name: Fetch bz2
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests bz2
     - name: Fetch ninja
@@ -112,6 +114,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests rust-shed
     - name: Build hexdump
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests hexdump
+    - name: Build xxhash
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests xxhash
     - name: Build bz2
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests bz2
     - name: Build ninja

--- a/build/fbcode_builder/manifests/xxhash
+++ b/build/fbcode_builder/manifests/xxhash
@@ -8,6 +8,13 @@ sha256 = baee0c6afd4f03165de7a4e67988d16f0f2b257b51d0e3cb91909302a26a79c4
 [rpms]
 xxhash-devel
 
+[debs]
+libxxhash-dev
+xxhash
+
+[homebrew]
+xxhash
+
 [build.not(os=windows)]
 builder = make
 subdir = xxHash-0.8.2


### PR DESCRIPTION

Summary:
EdenFS build on github CI was failing with missing xxhash include: https://github.com/facebook/sapling/actions/runs/11311478649/job/31457761727#step:108:3838

Add package mappings to the xxhash manifest

When I went to regenerate the github actions found I'd previously introduced a bug in the actions generation with a mis-merged run_tests check.  Fix it and regenerate

Test Plan:

Build locally on ubuntu-22.04 toolbox to repro issue, its broken,
```
./build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. eden
```

Install the packages:
```
./build/fbcode_builder/getdeps.py install-system-deps --recursive eden
```

Run again, it builds:
```
./build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. eden
```

Regenerate the github workflow:
```
 ./build/fbcode_builder/getdeps.py --allow-system-packages generate-github-actions --no-tests --free-up-disk --os-type=linux --src-dir=. --output-dir=.github/workflows --job-name "EdenFS " --job-file-prefix=edenfs_ eden --num-jobs=8  --project-install-prefix sapling:/usr/local
```
