### PR TITLE
fix(dotgit): set publicheads correctly for transparent git mode

### DIFF
--- a/eden/scm/tests/test-git-clone-sets-publicheads.t
+++ b/eden/scm/tests/test-git-clone-sets-publicheads.t
@@ -18,11 +18,18 @@ Prepare a git repo:
   $ git add beta
   $ git commit -q -mbeta
 
-Test git clone sets publicheads
-  $ hg clone --git "$TESTTMP/gitrepo" cloned
+
+Test hg clone sets publicheads
+  $ hg clone --git "$TESTTMP/gitrepo" cloned-hg
   From $TESTTMP/gitrepo
    * [new ref]         3f5848713286c67b8a71a450e98c7fa66787bde2 -> remote/foo
   2 files updated, 0 files merged, 0 files removed, 0 files unresolved
-  $ cd cloned
-  $ hg config remotenames.publicheads
+  $ (cd cloned-hg && hg config remotenames.publicheads)
   remote/foo,remote/main,remote/master
+
+Test git clone sets publicheads
+  $ git clone "$TESTTMP/gitrepo" cloned-git
+  Cloning into 'cloned-git'...
+  done.
+  $ (cd cloned-git && hg config remotenames.publicheads )
+  origin/foo,origin/master,origin/main


### PR DESCRIPTION

Summary:
0ce7010b7f taught Sapling to use the correct public head based on the upstream
default branch.  However, this doesn't work when using the transparent git mode
through `git clone`.

This diff will correctly set the publicheads config when initializing sapling

Test Plan: see test-git-clone-sets-publicheads.t
