### PR TITLE
get mononoke green in github CI

### DIFF
--- a/build/fbcode_builder/getdeps/buildopts.py
+++ b/build/fbcode_builder/getdeps/buildopts.py
@@ -304,12 +304,14 @@ class BuildOptions(object):
             is_direct_dep = (
                 manifest is not None and m.name in manifest.get_dependencies(ctx)
             )
-            self.add_prefix_to_env(
-                loader.get_project_install_dir(m),
-                env,
-                append=False,
-                is_direct_dep=is_direct_dep,
-            )
+            d = loader.get_project_install_dir(m)
+            if os.path.exists(d):
+                self.add_prefix_to_env(
+                    d,
+                    env,
+                    append=False,
+                    is_direct_dep=is_direct_dep,
+                )
 
         # Linux is always system openssl
         system_openssl = self.is_linux()

--- a/build/fbcode_builder/manifests/python-click
+++ b/build/fbcode_builder/manifests/python-click
@@ -7,3 +7,9 @@ sha256 = dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc
 
 [build]
 builder = python-wheel
+
+[rpms]
+python3-click
+
+[debs]
+python3-click

--- a/eden/mononoke/tests/integration/Makefile
+++ b/eden/mononoke/tests/integration/Makefile
@@ -6,6 +6,8 @@
 MAKE_PID := $(shell echo $$PPID)
 JOBS := $(shell ps T | sed -n 's%.*$(MAKE_PID).*$(MAKE).* \(-j\|--jobs=\) *\([0-9][0-9]*\).*%\2%p')
 
+PYTHON_SYS_EXECUTABLE=$(shell python3 ../../../scm/contrib/pick_python.py python3)
+
 help:
 	@echo 'This Makefile is supposed to be used by'
 	@echo 'fbcode_builder/getdeps.py script, DO NOT use it directly.'
@@ -17,7 +19,8 @@ all: help
 build-getdeps:
 	mkdir -p $(GETDEPS_BUILD_DIR)/mononoke_integration
 	# In this step just generate the manifest.json file
-	./run_tests_getdeps.py getdeps --jobs $(JOBS) $(GETDEPS_INSTALL_DIR) --generate_manifest
+	PYTHON_SYS_EXECUTABLE=$(PYTHON_SYS_EXECUTABLE) \
+	$(PYTHON_SYS_EXECUTABLE) ./run_tests_getdeps.py getdeps --jobs $(JOBS) $(GETDEPS_INSTALL_DIR) --generate_manifest
 
 install-getdeps:
 	mkdir -p $(GETDEPS_INSTALL_DIR)/mononoke_integration
@@ -44,7 +47,8 @@ test-getdeps:
 	  for try in $$(seq 0 $(GETDEPS_TEST_RETRY)); do \
 	    RERUN_ARG=""; \
 	    if [ $$try -gt 0 ]; then RERUN_ARG="--rerun-failed"; fi; \
-	    ./run_tests_getdeps.py getdeps --jobs $(JOBS) $(GETDEPS_INSTALL_DIR) $(GETDEPS_TEST_FILTER) $$RERUN_ARG; \
+	    	PYTHON_SYS_EXECUTABLE=$(PYTHON_SYS_EXECUTABLE) \
+			$(PYTHON_SYS_EXECUTABLE) ./run_tests_getdeps.py getdeps --jobs $(JOBS) $(GETDEPS_INSTALL_DIR) $(GETDEPS_TEST_FILTER) $$RERUN_ARG; \
 		status=$$?; \
 		# stop if all good \
 		if [ $$status = 0 ]; then echo "passed on try $$try"; exit 0; fi; \

--- a/eden/mononoke/tests/integration/mononoke_git_server/test-mononoke-git-server-missing-lfsconfig-hook.t
+++ b/eden/mononoke/tests/integration/mononoke_git_server/test-mononoke-git-server-missing-lfsconfig-hook.t
@@ -89,7 +89,7 @@
   $ git add another_large_file
   $ git commit -aqm "new commit with another large file"
   $ git_client push origin master_bookmark
-  Uploading LFS objects: 100% (1/1), 68 B | 0 B/s, done.
+  Uploading LFS objects: 100% (1/1), 68 B | 0 B/s, done. (?)
   To https://localhost:$LOCAL_PORT/repos/git/ro/repo.git
      02afe80..72162d7  master_bookmark -> master_bookmark
 

--- a/eden/mononoke/tests/integration/newadmin/test-newadmin-derived-data.t
+++ b/eden/mononoke/tests/integration/newadmin/test-newadmin-derived-data.t
@@ -45,9 +45,9 @@ Simple usage
   $ mononoke_newadmin derived-data -R repo count-underived -T unodes -i aa53d24251ff3f54b1b2c29ae02826701b2abeb0079f1bb13b8434b54cd87675
   aa53d24251ff3f54b1b2c29ae02826701b2abeb0079f1bb13b8434b54cd87675: 0
 Multiple changesets
-  $ mononoke_newadmin derived-data -R repo count-underived -T unodes -i aa53d24251ff3f54b1b2c29ae02826701b2abeb0079f1bb13b8434b54cd87675 -i 5a25c0a76794bbcc5180da0949a652750101597f0fbade488e611d5c0917e7be
-  aa53d24251ff3f54b1b2c29ae02826701b2abeb0079f1bb13b8434b54cd87675: 0
+  $ mononoke_newadmin derived-data -R repo count-underived -T unodes -i aa53d24251ff3f54b1b2c29ae02826701b2abeb0079f1bb13b8434b54cd87675 -i 5a25c0a76794bbcc5180da0949a652750101597f0fbade488e611d5c0917e7be | sort
   5a25c0a76794bbcc5180da0949a652750101597f0fbade488e611d5c0917e7be: 1
+  aa53d24251ff3f54b1b2c29ae02826701b2abeb0079f1bb13b8434b54cd87675: 0
 Bookmark
   $ mononoke_newadmin derived-data -R repo count-underived -T unodes -B main
   e32a1e342cdb1e38e88466b4c1a01ae9f410024017aa21dc0a1c5da6b3963bf2: 0

--- a/eden/scm/lib/commands/cmdpy/src/hgpython.rs
+++ b/eden/scm/lib/commands/cmdpy/src/hgpython.rs
@@ -222,8 +222,12 @@ impl HgPython {
                         Err(_) => 255,
                     }
                 } else {
-                    let message =
-                        format_py_error(py, &err).unwrap_or("unknown python exception".to_string());
+                    let message = format_py_error(py, &err).unwrap_or_else(|err| {
+                        format!(
+                            "unknown python exception {:?} {:?}",
+                            &err.ptype, &err.pvalue
+                        )
+                    });
                     let _ = io.write_err(message);
                     1
                 }


### PR DESCRIPTION

Summary:
* mononoke [unit tests are failing](https://github.com/facebook/sapling/actions/runs/11477571042/job/31939940450#step:85:8352),  fix them
* test-cross-repo-mononoke-git-sot.t deleted, remove from exclusion list

changes done to make this easier:
 * python-click wasn't found in sapling dir, added package mappings for rpm and deb so that we can pick up the installed version
 * add a bit more info to the "unknown python exception" message from hg
 * reduce paths set by getdeps, no point listing non-existing dir, makes it easier to see what is happening

Test Plan:

**Local run of unittest**
```
./build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. mononoke
./build/fbcode_builder/getdeps.py --allow-system-packages test--src-dir=. mononoke
```

Before fails:
```
failures:
    store::test::test_find_abandoned_requests
    store::test::test_get_stats
    store::test::test_mark_as_new
```

After, passes.

**Local run of integration test**
```
# first build sapling cli & install system deps
./build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. sapling
./build/fbcode_builder/getdeps.py install-system-deps --recursive mononoke_integration
# then test mononoke
./build/fbcode_builder/getdeps.py --allow-system-packages build --no-deps --src-dir=. mononoke_integration
./build/fbcode_builder/getdeps.py --allow-system-packages test --src-dir=. mononoke_integration --num-jobs=4
```

Before, fails
```
AssertionError: The test groups contain not existing tests: ['cross_repo/test-cross-repo-mononoke-git-sot-switch.t'] in /home/runner/work/sapling/sapling/eden/mononoke/tests/integration
```

After, passes
