### PR TITLE
sapling: demandimport: Fix unknown python exception, module `threading` has no attribute `Rlock`

### DIFF
--- a/eden/scm/sapling/hgdemandimport/__init__.py
+++ b/eden/scm/sapling/hgdemandimport/__init__.py
@@ -57,7 +57,10 @@ ignore = [
     "__builtin__",
     "builtins",
     "urwid.command_map",  # for pudb
-    "_thread",  # For RLock
+    # threading is locally imported by importlib.util.LazyLoader.exec_module
+    "_weakrefset",
+    "warnings",
+    "threading",  # For RLock
     "_scandir",  # for IPython
     "collections.abc",  # for IPython - pickleshare
     "sqlite3",  # for IPython to detect missing sqlite


### PR DESCRIPTION
Summary:

When using a recent version of python (3.12), running a sapling command returns the error `unknown python exception`: AttributeError: partially initialized module 'threading' has no attribute 'RLock' (most likely due to a circular import).

This is caused by cpython breaking demandimport by importing `threading` locally in `importlib.util.LazyLoader.exec_module`.

Adding `threading` along with `warnings`, and `_weakrefset` (which are imported by threading) to demandimport's ignore list resolves the issue.

Refs: https://github.com/python/cpython/issues/117983
      https://repo.mercurial-scm.org/hg/file/63ede7a43a37/hgdemandimport/__init__.py
      https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1076449
      https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1076747