### PR TITLE
fix(scm-prompt): suppress cd output

### DIFF
--- a/eden/scm/contrib/scm-prompt.sh
+++ b/eden/scm/contrib/scm-prompt.sh
@@ -257,7 +257,7 @@ _scm_prompt() {
     fi
     [[ "$dir" = "/" ]] && break
     # portable "realpath" equivalent
-    dir="$(builtin cd -P "$dir/.." && builtin echo "$PWD")"
+    dir="$(builtin cd -P "$dir/.." >/dev/null && builtin echo "$PWD")"
   done
 
   if [[ -n "$br" ]]; then


### PR DESCRIPTION

Summary:
If a user has a `chpwd` hook that prints output, it will be prepended to the
`dir` variable which breaks the prompt. This change suppresses the output of
`cd` to prevent this.

Alternatively I considered doing `cd -q` to skip running the chpwd hook, but
decided against it.

Test Plan:

```zsh
$ zsh --no-rcs
$ source ~/workspace/github.com/facebook/sapling/eden/scm/contrib/scm-prompt.sh && _scm_prompt
# things should be fine
$ say_hi() { echo hello } && chpwd_functions+=(say_hi) && _scm_prompt
```
prior to this commit, the prompt would be broken. After this commit, it should
be fine.

Background: in my particular case, I have a `chpwd` hook that
[sources custom scripts](https://github.com/vegerot/dotfiles/blob/032f88715fa2911bec6b3c09aa012145bb1dae7e/.zshrc#L250-L252)
depending on the directory, and will tell me if it does so. This was breaking
the prompt, so I added this change to fix it.
