### PR TITLE
add github actions caching

### DIFF
--- a/.github/workflows/edenfs_linux.yml
+++ b/.github/workflows/edenfs_linux.yml
@@ -27,210 +27,311 @@ jobs:
     - name: Update system package info
       run: sudo apt-get update
     - name: Install system deps
-      run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --no-tests --recursive eden
-    - name: Install packaging system deps
-      run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --no-tests --recursive patchelf
+      run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --no-tests --recursive eden && sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --no-tests --recursive patchelf
+    - id: paths
+      name: Query paths
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages query-paths --no-tests --recursive --src-dir=. eden  >> "$GITHUB_OUTPUT"
     - name: Install Rust Stable
       uses: dtolnay/rust-toolchain@stable
     - name: Fetch lmdb
+      if: ${{ steps.paths.outputs.lmdb_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests lmdb
     - name: Fetch ninja
+      if: ${{ steps.paths.outputs.ninja_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests ninja
     - name: Fetch cmake
+      if: ${{ steps.paths.outputs.cmake_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests cmake
     - name: Fetch blake3
+      if: ${{ steps.paths.outputs.blake3_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests blake3
     - name: Fetch cpptoml
+      if: ${{ steps.paths.outputs.cpptoml_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests cpptoml
     - name: Fetch fmt
+      if: ${{ steps.paths.outputs.fmt_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fmt
     - name: Fetch gflags
+      if: ${{ steps.paths.outputs.gflags_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests gflags
     - name: Fetch glog
+      if: ${{ steps.paths.outputs.glog_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests glog
     - name: Fetch googletest
+      if: ${{ steps.paths.outputs.googletest_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests googletest
     - name: Fetch xxhash
+      if: ${{ steps.paths.outputs.xxhash_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests xxhash
     - name: Fetch zstd
+      if: ${{ steps.paths.outputs.zstd_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zstd
     - name: Fetch boost
+      if: ${{ steps.paths.outputs.boost_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests boost
     - name: Fetch double-conversion
+      if: ${{ steps.paths.outputs.double-conversion_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests double-conversion
     - name: Fetch fast_float
+      if: ${{ steps.paths.outputs.fast_float_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fast_float
     - name: Fetch libdwarf
+      if: ${{ steps.paths.outputs.libdwarf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libdwarf
     - name: Fetch libevent
+      if: ${{ steps.paths.outputs.libevent_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libevent
     - name: Fetch lz4
+      if: ${{ steps.paths.outputs.lz4_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests lz4
     - name: Fetch snappy
+      if: ${{ steps.paths.outputs.snappy_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests snappy
     - name: Fetch libgit2
+      if: ${{ steps.paths.outputs.libgit2_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libgit2
     - name: Fetch python-ptyprocess
+      if: ${{ steps.paths.outputs.python-ptyprocess_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests python-ptyprocess
     - name: Fetch pexpect
+      if: ${{ steps.paths.outputs.pexpect_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests pexpect
     - name: Fetch bz2
+      if: ${{ steps.paths.outputs.bz2_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests bz2
     - name: Fetch python-filelock
+      if: ${{ steps.paths.outputs.python-filelock_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests python-filelock
     - name: Fetch python-toml
+      if: ${{ steps.paths.outputs.python-toml_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests python-toml
     - name: Fetch re2
+      if: ${{ steps.paths.outputs.re2_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests re2
     - name: Fetch rocksdb
+      if: ${{ steps.paths.outputs.rocksdb_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests rocksdb
     - name: Fetch sqlite3
+      if: ${{ steps.paths.outputs.sqlite3_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests sqlite3
     - name: Fetch zlib
+      if: ${{ steps.paths.outputs.zlib_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zlib
     - name: Fetch openssl
+      if: ${{ steps.paths.outputs.openssl_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests openssl
     - name: Fetch liboqs
+      if: ${{ steps.paths.outputs.liboqs_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests liboqs
     - name: Fetch autoconf
+      if: ${{ steps.paths.outputs.autoconf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests autoconf
     - name: Fetch automake
+      if: ${{ steps.paths.outputs.automake_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests automake
     - name: Fetch libtool
+      if: ${{ steps.paths.outputs.libtool_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libtool
     - name: Fetch nghttp2
+      if: ${{ steps.paths.outputs.nghttp2_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests nghttp2
     - name: Fetch libcurl
+      if: ${{ steps.paths.outputs.libcurl_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libcurl
     - name: Fetch libffi
+      if: ${{ steps.paths.outputs.libffi_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libffi
     - name: Fetch ncurses
+      if: ${{ steps.paths.outputs.ncurses_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests ncurses
     - name: Fetch python
+      if: ${{ steps.paths.outputs.python_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests python
     - name: Fetch libsodium
+      if: ${{ steps.paths.outputs.libsodium_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libsodium
     - name: Fetch libiberty
+      if: ${{ steps.paths.outputs.libiberty_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libiberty
     - name: Fetch libunwind
+      if: ${{ steps.paths.outputs.libunwind_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libunwind
     - name: Fetch xz
+      if: ${{ steps.paths.outputs.xz_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests xz
     - name: Fetch folly
+      if: ${{ steps.paths.outputs.folly_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests folly
     - name: Fetch fizz
+      if: ${{ steps.paths.outputs.fizz_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fizz
     - name: Fetch mvfst
+      if: ${{ steps.paths.outputs.mvfst_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests mvfst
     - name: Fetch wangle
+      if: ${{ steps.paths.outputs.wangle_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests wangle
     - name: Fetch fbthrift
+      if: ${{ steps.paths.outputs.fbthrift_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fbthrift
     - name: Fetch fb303
+      if: ${{ steps.paths.outputs.fb303_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fb303
     - name: Fetch rust-shed
+      if: ${{ steps.paths.outputs.rust-shed_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests rust-shed
     - name: Fetch edencommon
+      if: ${{ steps.paths.outputs.edencommon_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests edencommon
     - name: Build lmdb
+      if: ${{ steps.paths.outputs.lmdb_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests lmdb
     - name: Build ninja
+      if: ${{ steps.paths.outputs.ninja_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests ninja
     - name: Build cmake
+      if: ${{ steps.paths.outputs.cmake_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests cmake
     - name: Build blake3
+      if: ${{ steps.paths.outputs.blake3_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests blake3
     - name: Build cpptoml
+      if: ${{ steps.paths.outputs.cpptoml_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests cpptoml
     - name: Build fmt
+      if: ${{ steps.paths.outputs.fmt_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fmt
     - name: Build gflags
+      if: ${{ steps.paths.outputs.gflags_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests gflags
     - name: Build glog
+      if: ${{ steps.paths.outputs.glog_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests glog
     - name: Build googletest
+      if: ${{ steps.paths.outputs.googletest_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests googletest
     - name: Build xxhash
+      if: ${{ steps.paths.outputs.xxhash_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests xxhash
     - name: Build zstd
+      if: ${{ steps.paths.outputs.zstd_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests zstd
     - name: Build boost
+      if: ${{ steps.paths.outputs.boost_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests boost
     - name: Build double-conversion
+      if: ${{ steps.paths.outputs.double-conversion_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests double-conversion
     - name: Build fast_float
+      if: ${{ steps.paths.outputs.fast_float_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fast_float
     - name: Build libdwarf
+      if: ${{ steps.paths.outputs.libdwarf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libdwarf
     - name: Build libevent
+      if: ${{ steps.paths.outputs.libevent_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libevent
     - name: Build lz4
+      if: ${{ steps.paths.outputs.lz4_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests lz4
     - name: Build snappy
+      if: ${{ steps.paths.outputs.snappy_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests snappy
     - name: Build libgit2
+      if: ${{ steps.paths.outputs.libgit2_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libgit2
     - name: Build python-ptyprocess
+      if: ${{ steps.paths.outputs.python-ptyprocess_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests python-ptyprocess
     - name: Build pexpect
+      if: ${{ steps.paths.outputs.pexpect_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests pexpect
     - name: Build bz2
+      if: ${{ steps.paths.outputs.bz2_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests bz2
     - name: Build python-filelock
+      if: ${{ steps.paths.outputs.python-filelock_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests python-filelock
     - name: Build python-toml
+      if: ${{ steps.paths.outputs.python-toml_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests python-toml
     - name: Build re2
+      if: ${{ steps.paths.outputs.re2_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests re2
     - name: Build rocksdb
+      if: ${{ steps.paths.outputs.rocksdb_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests rocksdb
     - name: Build sqlite3
+      if: ${{ steps.paths.outputs.sqlite3_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests sqlite3
     - name: Build zlib
+      if: ${{ steps.paths.outputs.zlib_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests zlib
     - name: Build openssl
+      if: ${{ steps.paths.outputs.openssl_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests openssl
     - name: Build liboqs
+      if: ${{ steps.paths.outputs.liboqs_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests liboqs
     - name: Build autoconf
+      if: ${{ steps.paths.outputs.autoconf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests autoconf
     - name: Build automake
+      if: ${{ steps.paths.outputs.automake_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests automake
     - name: Build libtool
+      if: ${{ steps.paths.outputs.libtool_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libtool
     - name: Build nghttp2
+      if: ${{ steps.paths.outputs.nghttp2_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests nghttp2
     - name: Build libcurl
+      if: ${{ steps.paths.outputs.libcurl_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libcurl
     - name: Build libffi
+      if: ${{ steps.paths.outputs.libffi_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libffi
     - name: Build ncurses
+      if: ${{ steps.paths.outputs.ncurses_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests ncurses
     - name: Build python
+      if: ${{ steps.paths.outputs.python_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests python
     - name: Build libsodium
+      if: ${{ steps.paths.outputs.libsodium_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libsodium
     - name: Build libiberty
+      if: ${{ steps.paths.outputs.libiberty_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libiberty
     - name: Build libunwind
+      if: ${{ steps.paths.outputs.libunwind_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libunwind
     - name: Build xz
+      if: ${{ steps.paths.outputs.xz_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests xz
     - name: Build folly
+      if: ${{ steps.paths.outputs.folly_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests folly
     - name: Build fizz
+      if: ${{ steps.paths.outputs.fizz_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fizz
     - name: Build mvfst
+      if: ${{ steps.paths.outputs.mvfst_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests mvfst
     - name: Build wangle
+      if: ${{ steps.paths.outputs.wangle_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests wangle
     - name: Build fbthrift
+      if: ${{ steps.paths.outputs.fbthrift_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fbthrift
     - name: Build fb303
+      if: ${{ steps.paths.outputs.fb303_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fb303
     - name: Build rust-shed
+      if: ${{ steps.paths.outputs.rust-shed_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests rust-shed
     - name: Build edencommon
+      if: ${{ steps.paths.outputs.edencommon_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests edencommon
     - name: Build eden
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests --src-dir=. eden  --project-install-prefix eden:/usr/local

--- a/.github/workflows/edenfs_linux.yml
+++ b/.github/workflows/edenfs_linux.yml
@@ -183,156 +183,806 @@ jobs:
     - name: Fetch edencommon
       if: ${{ steps.paths.outputs.edencommon_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests edencommon
-    - name: Build lmdb
+    - name: Restore lmdb from cache
+      id: restore_lmdb
       if: ${{ steps.paths.outputs.lmdb_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.lmdb_INSTALL }}
+       key: ${{ steps.paths.outputs.lmdb_CACHE_KEY }}-install
+    - name: Build lmdb
+      if: ${{ steps.paths.outputs.lmdb_SOURCE && ! steps.restore_lmdb.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests lmdb
-    - name: Build ninja
+    - name: Save lmdb to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.lmdb_SOURCE && ! steps.restore_lmdb.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.lmdb_INSTALL }}
+       key: ${{ steps.paths.outputs.lmdb_CACHE_KEY }}-install
+    - name: Restore ninja from cache
+      id: restore_ninja
       if: ${{ steps.paths.outputs.ninja_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.ninja_INSTALL }}
+       key: ${{ steps.paths.outputs.ninja_CACHE_KEY }}-install
+    - name: Build ninja
+      if: ${{ steps.paths.outputs.ninja_SOURCE && ! steps.restore_ninja.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests ninja
-    - name: Build cmake
+    - name: Save ninja to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.ninja_SOURCE && ! steps.restore_ninja.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.ninja_INSTALL }}
+       key: ${{ steps.paths.outputs.ninja_CACHE_KEY }}-install
+    - name: Restore cmake from cache
+      id: restore_cmake
       if: ${{ steps.paths.outputs.cmake_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.cmake_INSTALL }}
+       key: ${{ steps.paths.outputs.cmake_CACHE_KEY }}-install
+    - name: Build cmake
+      if: ${{ steps.paths.outputs.cmake_SOURCE && ! steps.restore_cmake.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests cmake
-    - name: Build blake3
+    - name: Save cmake to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.cmake_SOURCE && ! steps.restore_cmake.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.cmake_INSTALL }}
+       key: ${{ steps.paths.outputs.cmake_CACHE_KEY }}-install
+    - name: Restore blake3 from cache
+      id: restore_blake3
       if: ${{ steps.paths.outputs.blake3_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.blake3_INSTALL }}
+       key: ${{ steps.paths.outputs.blake3_CACHE_KEY }}-install
+    - name: Build blake3
+      if: ${{ steps.paths.outputs.blake3_SOURCE && ! steps.restore_blake3.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests blake3
-    - name: Build cpptoml
+    - name: Save blake3 to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.blake3_SOURCE && ! steps.restore_blake3.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.blake3_INSTALL }}
+       key: ${{ steps.paths.outputs.blake3_CACHE_KEY }}-install
+    - name: Restore cpptoml from cache
+      id: restore_cpptoml
       if: ${{ steps.paths.outputs.cpptoml_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.cpptoml_INSTALL }}
+       key: ${{ steps.paths.outputs.cpptoml_CACHE_KEY }}-install
+    - name: Build cpptoml
+      if: ${{ steps.paths.outputs.cpptoml_SOURCE && ! steps.restore_cpptoml.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests cpptoml
-    - name: Build fmt
+    - name: Save cpptoml to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.cpptoml_SOURCE && ! steps.restore_cpptoml.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.cpptoml_INSTALL }}
+       key: ${{ steps.paths.outputs.cpptoml_CACHE_KEY }}-install
+    - name: Restore fmt from cache
+      id: restore_fmt
       if: ${{ steps.paths.outputs.fmt_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fmt_INSTALL }}
+       key: ${{ steps.paths.outputs.fmt_CACHE_KEY }}-install
+    - name: Build fmt
+      if: ${{ steps.paths.outputs.fmt_SOURCE && ! steps.restore_fmt.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fmt
-    - name: Build gflags
+    - name: Save fmt to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fmt_SOURCE && ! steps.restore_fmt.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fmt_INSTALL }}
+       key: ${{ steps.paths.outputs.fmt_CACHE_KEY }}-install
+    - name: Restore gflags from cache
+      id: restore_gflags
       if: ${{ steps.paths.outputs.gflags_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.gflags_INSTALL }}
+       key: ${{ steps.paths.outputs.gflags_CACHE_KEY }}-install
+    - name: Build gflags
+      if: ${{ steps.paths.outputs.gflags_SOURCE && ! steps.restore_gflags.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests gflags
-    - name: Build glog
+    - name: Save gflags to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.gflags_SOURCE && ! steps.restore_gflags.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.gflags_INSTALL }}
+       key: ${{ steps.paths.outputs.gflags_CACHE_KEY }}-install
+    - name: Restore glog from cache
+      id: restore_glog
       if: ${{ steps.paths.outputs.glog_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.glog_INSTALL }}
+       key: ${{ steps.paths.outputs.glog_CACHE_KEY }}-install
+    - name: Build glog
+      if: ${{ steps.paths.outputs.glog_SOURCE && ! steps.restore_glog.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests glog
-    - name: Build googletest
+    - name: Save glog to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.glog_SOURCE && ! steps.restore_glog.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.glog_INSTALL }}
+       key: ${{ steps.paths.outputs.glog_CACHE_KEY }}-install
+    - name: Restore googletest from cache
+      id: restore_googletest
       if: ${{ steps.paths.outputs.googletest_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.googletest_INSTALL }}
+       key: ${{ steps.paths.outputs.googletest_CACHE_KEY }}-install
+    - name: Build googletest
+      if: ${{ steps.paths.outputs.googletest_SOURCE && ! steps.restore_googletest.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests googletest
-    - name: Build xxhash
+    - name: Save googletest to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.googletest_SOURCE && ! steps.restore_googletest.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.googletest_INSTALL }}
+       key: ${{ steps.paths.outputs.googletest_CACHE_KEY }}-install
+    - name: Restore xxhash from cache
+      id: restore_xxhash
       if: ${{ steps.paths.outputs.xxhash_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.xxhash_INSTALL }}
+       key: ${{ steps.paths.outputs.xxhash_CACHE_KEY }}-install
+    - name: Build xxhash
+      if: ${{ steps.paths.outputs.xxhash_SOURCE && ! steps.restore_xxhash.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests xxhash
-    - name: Build zstd
+    - name: Save xxhash to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.xxhash_SOURCE && ! steps.restore_xxhash.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.xxhash_INSTALL }}
+       key: ${{ steps.paths.outputs.xxhash_CACHE_KEY }}-install
+    - name: Restore zstd from cache
+      id: restore_zstd
       if: ${{ steps.paths.outputs.zstd_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.zstd_INSTALL }}
+       key: ${{ steps.paths.outputs.zstd_CACHE_KEY }}-install
+    - name: Build zstd
+      if: ${{ steps.paths.outputs.zstd_SOURCE && ! steps.restore_zstd.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests zstd
-    - name: Build boost
+    - name: Save zstd to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.zstd_SOURCE && ! steps.restore_zstd.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.zstd_INSTALL }}
+       key: ${{ steps.paths.outputs.zstd_CACHE_KEY }}-install
+    - name: Restore boost from cache
+      id: restore_boost
       if: ${{ steps.paths.outputs.boost_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.boost_INSTALL }}
+       key: ${{ steps.paths.outputs.boost_CACHE_KEY }}-install
+    - name: Build boost
+      if: ${{ steps.paths.outputs.boost_SOURCE && ! steps.restore_boost.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests boost
-    - name: Build double-conversion
+    - name: Save boost to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.boost_SOURCE && ! steps.restore_boost.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.boost_INSTALL }}
+       key: ${{ steps.paths.outputs.boost_CACHE_KEY }}-install
+    - name: Restore double-conversion from cache
+      id: restore_double-conversion
       if: ${{ steps.paths.outputs.double-conversion_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.double-conversion_INSTALL }}
+       key: ${{ steps.paths.outputs.double-conversion_CACHE_KEY }}-install
+    - name: Build double-conversion
+      if: ${{ steps.paths.outputs.double-conversion_SOURCE && ! steps.restore_double-conversion.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests double-conversion
-    - name: Build fast_float
+    - name: Save double-conversion to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.double-conversion_SOURCE && ! steps.restore_double-conversion.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.double-conversion_INSTALL }}
+       key: ${{ steps.paths.outputs.double-conversion_CACHE_KEY }}-install
+    - name: Restore fast_float from cache
+      id: restore_fast_float
       if: ${{ steps.paths.outputs.fast_float_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fast_float_INSTALL }}
+       key: ${{ steps.paths.outputs.fast_float_CACHE_KEY }}-install
+    - name: Build fast_float
+      if: ${{ steps.paths.outputs.fast_float_SOURCE && ! steps.restore_fast_float.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fast_float
-    - name: Build libdwarf
+    - name: Save fast_float to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fast_float_SOURCE && ! steps.restore_fast_float.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fast_float_INSTALL }}
+       key: ${{ steps.paths.outputs.fast_float_CACHE_KEY }}-install
+    - name: Restore libdwarf from cache
+      id: restore_libdwarf
       if: ${{ steps.paths.outputs.libdwarf_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libdwarf_INSTALL }}
+       key: ${{ steps.paths.outputs.libdwarf_CACHE_KEY }}-install
+    - name: Build libdwarf
+      if: ${{ steps.paths.outputs.libdwarf_SOURCE && ! steps.restore_libdwarf.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libdwarf
-    - name: Build libevent
+    - name: Save libdwarf to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libdwarf_SOURCE && ! steps.restore_libdwarf.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libdwarf_INSTALL }}
+       key: ${{ steps.paths.outputs.libdwarf_CACHE_KEY }}-install
+    - name: Restore libevent from cache
+      id: restore_libevent
       if: ${{ steps.paths.outputs.libevent_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libevent_INSTALL }}
+       key: ${{ steps.paths.outputs.libevent_CACHE_KEY }}-install
+    - name: Build libevent
+      if: ${{ steps.paths.outputs.libevent_SOURCE && ! steps.restore_libevent.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libevent
-    - name: Build lz4
+    - name: Save libevent to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libevent_SOURCE && ! steps.restore_libevent.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libevent_INSTALL }}
+       key: ${{ steps.paths.outputs.libevent_CACHE_KEY }}-install
+    - name: Restore lz4 from cache
+      id: restore_lz4
       if: ${{ steps.paths.outputs.lz4_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.lz4_INSTALL }}
+       key: ${{ steps.paths.outputs.lz4_CACHE_KEY }}-install
+    - name: Build lz4
+      if: ${{ steps.paths.outputs.lz4_SOURCE && ! steps.restore_lz4.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests lz4
-    - name: Build snappy
+    - name: Save lz4 to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.lz4_SOURCE && ! steps.restore_lz4.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.lz4_INSTALL }}
+       key: ${{ steps.paths.outputs.lz4_CACHE_KEY }}-install
+    - name: Restore snappy from cache
+      id: restore_snappy
       if: ${{ steps.paths.outputs.snappy_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.snappy_INSTALL }}
+       key: ${{ steps.paths.outputs.snappy_CACHE_KEY }}-install
+    - name: Build snappy
+      if: ${{ steps.paths.outputs.snappy_SOURCE && ! steps.restore_snappy.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests snappy
-    - name: Build libgit2
+    - name: Save snappy to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.snappy_SOURCE && ! steps.restore_snappy.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.snappy_INSTALL }}
+       key: ${{ steps.paths.outputs.snappy_CACHE_KEY }}-install
+    - name: Restore libgit2 from cache
+      id: restore_libgit2
       if: ${{ steps.paths.outputs.libgit2_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libgit2_INSTALL }}
+       key: ${{ steps.paths.outputs.libgit2_CACHE_KEY }}-install
+    - name: Build libgit2
+      if: ${{ steps.paths.outputs.libgit2_SOURCE && ! steps.restore_libgit2.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libgit2
-    - name: Build python-ptyprocess
+    - name: Save libgit2 to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libgit2_SOURCE && ! steps.restore_libgit2.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libgit2_INSTALL }}
+       key: ${{ steps.paths.outputs.libgit2_CACHE_KEY }}-install
+    - name: Restore python-ptyprocess from cache
+      id: restore_python-ptyprocess
       if: ${{ steps.paths.outputs.python-ptyprocess_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.python-ptyprocess_INSTALL }}
+       key: ${{ steps.paths.outputs.python-ptyprocess_CACHE_KEY }}-install
+    - name: Build python-ptyprocess
+      if: ${{ steps.paths.outputs.python-ptyprocess_SOURCE && ! steps.restore_python-ptyprocess.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests python-ptyprocess
-    - name: Build pexpect
+    - name: Save python-ptyprocess to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.python-ptyprocess_SOURCE && ! steps.restore_python-ptyprocess.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.python-ptyprocess_INSTALL }}
+       key: ${{ steps.paths.outputs.python-ptyprocess_CACHE_KEY }}-install
+    - name: Restore pexpect from cache
+      id: restore_pexpect
       if: ${{ steps.paths.outputs.pexpect_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.pexpect_INSTALL }}
+       key: ${{ steps.paths.outputs.pexpect_CACHE_KEY }}-install
+    - name: Build pexpect
+      if: ${{ steps.paths.outputs.pexpect_SOURCE && ! steps.restore_pexpect.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests pexpect
-    - name: Build bz2
+    - name: Save pexpect to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.pexpect_SOURCE && ! steps.restore_pexpect.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.pexpect_INSTALL }}
+       key: ${{ steps.paths.outputs.pexpect_CACHE_KEY }}-install
+    - name: Restore bz2 from cache
+      id: restore_bz2
       if: ${{ steps.paths.outputs.bz2_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.bz2_INSTALL }}
+       key: ${{ steps.paths.outputs.bz2_CACHE_KEY }}-install
+    - name: Build bz2
+      if: ${{ steps.paths.outputs.bz2_SOURCE && ! steps.restore_bz2.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests bz2
-    - name: Build python-filelock
+    - name: Save bz2 to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.bz2_SOURCE && ! steps.restore_bz2.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.bz2_INSTALL }}
+       key: ${{ steps.paths.outputs.bz2_CACHE_KEY }}-install
+    - name: Restore python-filelock from cache
+      id: restore_python-filelock
       if: ${{ steps.paths.outputs.python-filelock_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.python-filelock_INSTALL }}
+       key: ${{ steps.paths.outputs.python-filelock_CACHE_KEY }}-install
+    - name: Build python-filelock
+      if: ${{ steps.paths.outputs.python-filelock_SOURCE && ! steps.restore_python-filelock.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests python-filelock
-    - name: Build python-toml
+    - name: Save python-filelock to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.python-filelock_SOURCE && ! steps.restore_python-filelock.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.python-filelock_INSTALL }}
+       key: ${{ steps.paths.outputs.python-filelock_CACHE_KEY }}-install
+    - name: Restore python-toml from cache
+      id: restore_python-toml
       if: ${{ steps.paths.outputs.python-toml_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.python-toml_INSTALL }}
+       key: ${{ steps.paths.outputs.python-toml_CACHE_KEY }}-install
+    - name: Build python-toml
+      if: ${{ steps.paths.outputs.python-toml_SOURCE && ! steps.restore_python-toml.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests python-toml
-    - name: Build re2
+    - name: Save python-toml to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.python-toml_SOURCE && ! steps.restore_python-toml.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.python-toml_INSTALL }}
+       key: ${{ steps.paths.outputs.python-toml_CACHE_KEY }}-install
+    - name: Restore re2 from cache
+      id: restore_re2
       if: ${{ steps.paths.outputs.re2_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.re2_INSTALL }}
+       key: ${{ steps.paths.outputs.re2_CACHE_KEY }}-install
+    - name: Build re2
+      if: ${{ steps.paths.outputs.re2_SOURCE && ! steps.restore_re2.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests re2
-    - name: Build rocksdb
+    - name: Save re2 to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.re2_SOURCE && ! steps.restore_re2.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.re2_INSTALL }}
+       key: ${{ steps.paths.outputs.re2_CACHE_KEY }}-install
+    - name: Restore rocksdb from cache
+      id: restore_rocksdb
       if: ${{ steps.paths.outputs.rocksdb_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.rocksdb_INSTALL }}
+       key: ${{ steps.paths.outputs.rocksdb_CACHE_KEY }}-install
+    - name: Build rocksdb
+      if: ${{ steps.paths.outputs.rocksdb_SOURCE && ! steps.restore_rocksdb.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests rocksdb
-    - name: Build sqlite3
+    - name: Save rocksdb to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.rocksdb_SOURCE && ! steps.restore_rocksdb.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.rocksdb_INSTALL }}
+       key: ${{ steps.paths.outputs.rocksdb_CACHE_KEY }}-install
+    - name: Restore sqlite3 from cache
+      id: restore_sqlite3
       if: ${{ steps.paths.outputs.sqlite3_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.sqlite3_INSTALL }}
+       key: ${{ steps.paths.outputs.sqlite3_CACHE_KEY }}-install
+    - name: Build sqlite3
+      if: ${{ steps.paths.outputs.sqlite3_SOURCE && ! steps.restore_sqlite3.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests sqlite3
-    - name: Build zlib
+    - name: Save sqlite3 to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.sqlite3_SOURCE && ! steps.restore_sqlite3.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.sqlite3_INSTALL }}
+       key: ${{ steps.paths.outputs.sqlite3_CACHE_KEY }}-install
+    - name: Restore zlib from cache
+      id: restore_zlib
       if: ${{ steps.paths.outputs.zlib_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.zlib_INSTALL }}
+       key: ${{ steps.paths.outputs.zlib_CACHE_KEY }}-install
+    - name: Build zlib
+      if: ${{ steps.paths.outputs.zlib_SOURCE && ! steps.restore_zlib.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests zlib
-    - name: Build openssl
+    - name: Save zlib to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.zlib_SOURCE && ! steps.restore_zlib.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.zlib_INSTALL }}
+       key: ${{ steps.paths.outputs.zlib_CACHE_KEY }}-install
+    - name: Restore openssl from cache
+      id: restore_openssl
       if: ${{ steps.paths.outputs.openssl_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.openssl_INSTALL }}
+       key: ${{ steps.paths.outputs.openssl_CACHE_KEY }}-install
+    - name: Build openssl
+      if: ${{ steps.paths.outputs.openssl_SOURCE && ! steps.restore_openssl.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests openssl
-    - name: Build liboqs
+    - name: Save openssl to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.openssl_SOURCE && ! steps.restore_openssl.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.openssl_INSTALL }}
+       key: ${{ steps.paths.outputs.openssl_CACHE_KEY }}-install
+    - name: Restore liboqs from cache
+      id: restore_liboqs
       if: ${{ steps.paths.outputs.liboqs_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.liboqs_INSTALL }}
+       key: ${{ steps.paths.outputs.liboqs_CACHE_KEY }}-install
+    - name: Build liboqs
+      if: ${{ steps.paths.outputs.liboqs_SOURCE && ! steps.restore_liboqs.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests liboqs
-    - name: Build autoconf
+    - name: Save liboqs to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.liboqs_SOURCE && ! steps.restore_liboqs.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.liboqs_INSTALL }}
+       key: ${{ steps.paths.outputs.liboqs_CACHE_KEY }}-install
+    - name: Restore autoconf from cache
+      id: restore_autoconf
       if: ${{ steps.paths.outputs.autoconf_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.autoconf_INSTALL }}
+       key: ${{ steps.paths.outputs.autoconf_CACHE_KEY }}-install
+    - name: Build autoconf
+      if: ${{ steps.paths.outputs.autoconf_SOURCE && ! steps.restore_autoconf.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests autoconf
-    - name: Build automake
+    - name: Save autoconf to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.autoconf_SOURCE && ! steps.restore_autoconf.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.autoconf_INSTALL }}
+       key: ${{ steps.paths.outputs.autoconf_CACHE_KEY }}-install
+    - name: Restore automake from cache
+      id: restore_automake
       if: ${{ steps.paths.outputs.automake_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.automake_INSTALL }}
+       key: ${{ steps.paths.outputs.automake_CACHE_KEY }}-install
+    - name: Build automake
+      if: ${{ steps.paths.outputs.automake_SOURCE && ! steps.restore_automake.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests automake
-    - name: Build libtool
+    - name: Save automake to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.automake_SOURCE && ! steps.restore_automake.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.automake_INSTALL }}
+       key: ${{ steps.paths.outputs.automake_CACHE_KEY }}-install
+    - name: Restore libtool from cache
+      id: restore_libtool
       if: ${{ steps.paths.outputs.libtool_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libtool_INSTALL }}
+       key: ${{ steps.paths.outputs.libtool_CACHE_KEY }}-install
+    - name: Build libtool
+      if: ${{ steps.paths.outputs.libtool_SOURCE && ! steps.restore_libtool.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libtool
-    - name: Build nghttp2
+    - name: Save libtool to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libtool_SOURCE && ! steps.restore_libtool.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libtool_INSTALL }}
+       key: ${{ steps.paths.outputs.libtool_CACHE_KEY }}-install
+    - name: Restore nghttp2 from cache
+      id: restore_nghttp2
       if: ${{ steps.paths.outputs.nghttp2_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.nghttp2_INSTALL }}
+       key: ${{ steps.paths.outputs.nghttp2_CACHE_KEY }}-install
+    - name: Build nghttp2
+      if: ${{ steps.paths.outputs.nghttp2_SOURCE && ! steps.restore_nghttp2.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests nghttp2
-    - name: Build libcurl
+    - name: Save nghttp2 to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.nghttp2_SOURCE && ! steps.restore_nghttp2.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.nghttp2_INSTALL }}
+       key: ${{ steps.paths.outputs.nghttp2_CACHE_KEY }}-install
+    - name: Restore libcurl from cache
+      id: restore_libcurl
       if: ${{ steps.paths.outputs.libcurl_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libcurl_INSTALL }}
+       key: ${{ steps.paths.outputs.libcurl_CACHE_KEY }}-install
+    - name: Build libcurl
+      if: ${{ steps.paths.outputs.libcurl_SOURCE && ! steps.restore_libcurl.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libcurl
-    - name: Build libffi
+    - name: Save libcurl to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libcurl_SOURCE && ! steps.restore_libcurl.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libcurl_INSTALL }}
+       key: ${{ steps.paths.outputs.libcurl_CACHE_KEY }}-install
+    - name: Restore libffi from cache
+      id: restore_libffi
       if: ${{ steps.paths.outputs.libffi_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libffi_INSTALL }}
+       key: ${{ steps.paths.outputs.libffi_CACHE_KEY }}-install
+    - name: Build libffi
+      if: ${{ steps.paths.outputs.libffi_SOURCE && ! steps.restore_libffi.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libffi
-    - name: Build ncurses
+    - name: Save libffi to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libffi_SOURCE && ! steps.restore_libffi.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libffi_INSTALL }}
+       key: ${{ steps.paths.outputs.libffi_CACHE_KEY }}-install
+    - name: Restore ncurses from cache
+      id: restore_ncurses
       if: ${{ steps.paths.outputs.ncurses_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.ncurses_INSTALL }}
+       key: ${{ steps.paths.outputs.ncurses_CACHE_KEY }}-install
+    - name: Build ncurses
+      if: ${{ steps.paths.outputs.ncurses_SOURCE && ! steps.restore_ncurses.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests ncurses
-    - name: Build python
+    - name: Save ncurses to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.ncurses_SOURCE && ! steps.restore_ncurses.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.ncurses_INSTALL }}
+       key: ${{ steps.paths.outputs.ncurses_CACHE_KEY }}-install
+    - name: Restore python from cache
+      id: restore_python
       if: ${{ steps.paths.outputs.python_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.python_INSTALL }}
+       key: ${{ steps.paths.outputs.python_CACHE_KEY }}-install
+    - name: Build python
+      if: ${{ steps.paths.outputs.python_SOURCE && ! steps.restore_python.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests python
-    - name: Build libsodium
+    - name: Save python to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.python_SOURCE && ! steps.restore_python.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.python_INSTALL }}
+       key: ${{ steps.paths.outputs.python_CACHE_KEY }}-install
+    - name: Restore libsodium from cache
+      id: restore_libsodium
       if: ${{ steps.paths.outputs.libsodium_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libsodium_INSTALL }}
+       key: ${{ steps.paths.outputs.libsodium_CACHE_KEY }}-install
+    - name: Build libsodium
+      if: ${{ steps.paths.outputs.libsodium_SOURCE && ! steps.restore_libsodium.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libsodium
-    - name: Build libiberty
+    - name: Save libsodium to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libsodium_SOURCE && ! steps.restore_libsodium.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libsodium_INSTALL }}
+       key: ${{ steps.paths.outputs.libsodium_CACHE_KEY }}-install
+    - name: Restore libiberty from cache
+      id: restore_libiberty
       if: ${{ steps.paths.outputs.libiberty_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libiberty_INSTALL }}
+       key: ${{ steps.paths.outputs.libiberty_CACHE_KEY }}-install
+    - name: Build libiberty
+      if: ${{ steps.paths.outputs.libiberty_SOURCE && ! steps.restore_libiberty.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libiberty
-    - name: Build libunwind
+    - name: Save libiberty to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libiberty_SOURCE && ! steps.restore_libiberty.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libiberty_INSTALL }}
+       key: ${{ steps.paths.outputs.libiberty_CACHE_KEY }}-install
+    - name: Restore libunwind from cache
+      id: restore_libunwind
       if: ${{ steps.paths.outputs.libunwind_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libunwind_INSTALL }}
+       key: ${{ steps.paths.outputs.libunwind_CACHE_KEY }}-install
+    - name: Build libunwind
+      if: ${{ steps.paths.outputs.libunwind_SOURCE && ! steps.restore_libunwind.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libunwind
-    - name: Build xz
+    - name: Save libunwind to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libunwind_SOURCE && ! steps.restore_libunwind.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libunwind_INSTALL }}
+       key: ${{ steps.paths.outputs.libunwind_CACHE_KEY }}-install
+    - name: Restore xz from cache
+      id: restore_xz
       if: ${{ steps.paths.outputs.xz_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.xz_INSTALL }}
+       key: ${{ steps.paths.outputs.xz_CACHE_KEY }}-install
+    - name: Build xz
+      if: ${{ steps.paths.outputs.xz_SOURCE && ! steps.restore_xz.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests xz
-    - name: Build folly
+    - name: Save xz to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.xz_SOURCE && ! steps.restore_xz.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.xz_INSTALL }}
+       key: ${{ steps.paths.outputs.xz_CACHE_KEY }}-install
+    - name: Restore folly from cache
+      id: restore_folly
       if: ${{ steps.paths.outputs.folly_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.folly_INSTALL }}
+       key: ${{ steps.paths.outputs.folly_CACHE_KEY }}-install
+    - name: Build folly
+      if: ${{ steps.paths.outputs.folly_SOURCE && ! steps.restore_folly.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests folly
-    - name: Build fizz
+    - name: Save folly to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.folly_SOURCE && ! steps.restore_folly.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.folly_INSTALL }}
+       key: ${{ steps.paths.outputs.folly_CACHE_KEY }}-install
+    - name: Restore fizz from cache
+      id: restore_fizz
       if: ${{ steps.paths.outputs.fizz_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fizz_INSTALL }}
+       key: ${{ steps.paths.outputs.fizz_CACHE_KEY }}-install
+    - name: Build fizz
+      if: ${{ steps.paths.outputs.fizz_SOURCE && ! steps.restore_fizz.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fizz
-    - name: Build mvfst
+    - name: Save fizz to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fizz_SOURCE && ! steps.restore_fizz.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fizz_INSTALL }}
+       key: ${{ steps.paths.outputs.fizz_CACHE_KEY }}-install
+    - name: Restore mvfst from cache
+      id: restore_mvfst
       if: ${{ steps.paths.outputs.mvfst_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.mvfst_INSTALL }}
+       key: ${{ steps.paths.outputs.mvfst_CACHE_KEY }}-install
+    - name: Build mvfst
+      if: ${{ steps.paths.outputs.mvfst_SOURCE && ! steps.restore_mvfst.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests mvfst
-    - name: Build wangle
+    - name: Save mvfst to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.mvfst_SOURCE && ! steps.restore_mvfst.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.mvfst_INSTALL }}
+       key: ${{ steps.paths.outputs.mvfst_CACHE_KEY }}-install
+    - name: Restore wangle from cache
+      id: restore_wangle
       if: ${{ steps.paths.outputs.wangle_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.wangle_INSTALL }}
+       key: ${{ steps.paths.outputs.wangle_CACHE_KEY }}-install
+    - name: Build wangle
+      if: ${{ steps.paths.outputs.wangle_SOURCE && ! steps.restore_wangle.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests wangle
-    - name: Build fbthrift
+    - name: Save wangle to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.wangle_SOURCE && ! steps.restore_wangle.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.wangle_INSTALL }}
+       key: ${{ steps.paths.outputs.wangle_CACHE_KEY }}-install
+    - name: Restore fbthrift from cache
+      id: restore_fbthrift
       if: ${{ steps.paths.outputs.fbthrift_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fbthrift_INSTALL }}
+       key: ${{ steps.paths.outputs.fbthrift_CACHE_KEY }}-install
+    - name: Build fbthrift
+      if: ${{ steps.paths.outputs.fbthrift_SOURCE && ! steps.restore_fbthrift.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fbthrift
-    - name: Build fb303
+    - name: Save fbthrift to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fbthrift_SOURCE && ! steps.restore_fbthrift.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fbthrift_INSTALL }}
+       key: ${{ steps.paths.outputs.fbthrift_CACHE_KEY }}-install
+    - name: Restore fb303 from cache
+      id: restore_fb303
       if: ${{ steps.paths.outputs.fb303_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fb303_INSTALL }}
+       key: ${{ steps.paths.outputs.fb303_CACHE_KEY }}-install
+    - name: Build fb303
+      if: ${{ steps.paths.outputs.fb303_SOURCE && ! steps.restore_fb303.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fb303
-    - name: Build rust-shed
+    - name: Save fb303 to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fb303_SOURCE && ! steps.restore_fb303.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fb303_INSTALL }}
+       key: ${{ steps.paths.outputs.fb303_CACHE_KEY }}-install
+    - name: Restore rust-shed from cache
+      id: restore_rust-shed
       if: ${{ steps.paths.outputs.rust-shed_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.rust-shed_INSTALL }}
+       key: ${{ steps.paths.outputs.rust-shed_CACHE_KEY }}-install
+    - name: Build rust-shed
+      if: ${{ steps.paths.outputs.rust-shed_SOURCE && ! steps.restore_rust-shed.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests rust-shed
-    - name: Build edencommon
+    - name: Save rust-shed to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.rust-shed_SOURCE && ! steps.restore_rust-shed.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.rust-shed_INSTALL }}
+       key: ${{ steps.paths.outputs.rust-shed_CACHE_KEY }}-install
+    - name: Restore edencommon from cache
+      id: restore_edencommon
       if: ${{ steps.paths.outputs.edencommon_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.edencommon_INSTALL }}
+       key: ${{ steps.paths.outputs.edencommon_CACHE_KEY }}-install
+    - name: Build edencommon
+      if: ${{ steps.paths.outputs.edencommon_SOURCE && ! steps.restore_edencommon.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests edencommon
+    - name: Save edencommon to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.edencommon_SOURCE && ! steps.restore_edencommon.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.edencommon_INSTALL }}
+       key: ${{ steps.paths.outputs.edencommon_CACHE_KEY }}-install
     - name: Build eden
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests --src-dir=. eden  --project-install-prefix eden:/usr/local
     - name: Copy artifacts

--- a/.github/workflows/mononoke-integration_linux.yml
+++ b/.github/workflows/mononoke-integration_linux.yml
@@ -21,186 +21,275 @@ jobs:
     - name: Update system package info
       run: sudo apt-get update
     - name: Install system deps
-      run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive mononoke_integration
-    - name: Install packaging system deps
-      run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive patchelf
+      run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive mononoke_integration && sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive patchelf
+    - id: paths
+      name: Query paths
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages query-paths --recursive --src-dir=. mononoke_integration  >> "$GITHUB_OUTPUT"
     - name: Install Rust Stable
       uses: dtolnay/rust-toolchain@stable
     - name: Fetch git-lfs
+      if: ${{ steps.paths.outputs.git-lfs_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests git-lfs
     - name: Fetch ripgrep
+      if: ${{ steps.paths.outputs.ripgrep_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests ripgrep
     - name: Fetch tree
+      if: ${{ steps.paths.outputs.tree_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests tree
     - name: Fetch bz2
+      if: ${{ steps.paths.outputs.bz2_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests bz2
     - name: Fetch ninja
+      if: ${{ steps.paths.outputs.ninja_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests ninja
     - name: Fetch cmake
+      if: ${{ steps.paths.outputs.cmake_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests cmake
     - name: Fetch zstd
+      if: ${{ steps.paths.outputs.zstd_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zstd
     - name: Fetch python-click
+      if: ${{ steps.paths.outputs.python-click_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests python-click
     - name: Fetch sqlite3
+      if: ${{ steps.paths.outputs.sqlite3_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests sqlite3
     - name: Fetch gflags
+      if: ${{ steps.paths.outputs.gflags_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests gflags
     - name: Fetch glog
+      if: ${{ steps.paths.outputs.glog_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests glog
     - name: Fetch fmt
+      if: ${{ steps.paths.outputs.fmt_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fmt
     - name: Fetch googletest
+      if: ${{ steps.paths.outputs.googletest_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests googletest
     - name: Fetch xxhash
+      if: ${{ steps.paths.outputs.xxhash_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests xxhash
     - name: Fetch python-setuptools
+      if: ${{ steps.paths.outputs.python-setuptools_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests python-setuptools
     - name: Fetch autoconf
+      if: ${{ steps.paths.outputs.autoconf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests autoconf
     - name: Fetch automake
+      if: ${{ steps.paths.outputs.automake_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests automake
     - name: Fetch libtool
+      if: ${{ steps.paths.outputs.libtool_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libtool
     - name: Fetch jq
+      if: ${{ steps.paths.outputs.jq_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests jq
     - name: Fetch libsodium
+      if: ${{ steps.paths.outputs.libsodium_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libsodium
     - name: Fetch boost
+      if: ${{ steps.paths.outputs.boost_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests boost
     - name: Fetch double-conversion
+      if: ${{ steps.paths.outputs.double-conversion_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests double-conversion
     - name: Fetch fast_float
+      if: ${{ steps.paths.outputs.fast_float_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fast_float
     - name: Fetch libdwarf
+      if: ${{ steps.paths.outputs.libdwarf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libdwarf
     - name: Fetch libevent
+      if: ${{ steps.paths.outputs.libevent_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libevent
     - name: Fetch libunwind
+      if: ${{ steps.paths.outputs.libunwind_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libunwind
     - name: Fetch lz4
+      if: ${{ steps.paths.outputs.lz4_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests lz4
     - name: Fetch snappy
+      if: ${{ steps.paths.outputs.snappy_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests snappy
     - name: Fetch xz
+      if: ${{ steps.paths.outputs.xz_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests xz
     - name: Fetch zlib
+      if: ${{ steps.paths.outputs.zlib_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zlib
     - name: Fetch libiberty
+      if: ${{ steps.paths.outputs.libiberty_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libiberty
     - name: Fetch folly
+      if: ${{ steps.paths.outputs.folly_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests folly
     - name: Fetch libffi
+      if: ${{ steps.paths.outputs.libffi_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libffi
     - name: Fetch ncurses
+      if: ${{ steps.paths.outputs.ncurses_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests ncurses
     - name: Fetch python
+      if: ${{ steps.paths.outputs.python_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests python
     - name: Fetch nmap
+      if: ${{ steps.paths.outputs.nmap_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests nmap
     - name: Fetch openssl
+      if: ${{ steps.paths.outputs.openssl_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests openssl
     - name: Fetch liboqs
+      if: ${{ steps.paths.outputs.liboqs_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests liboqs
     - name: Fetch fizz
+      if: ${{ steps.paths.outputs.fizz_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fizz
     - name: Fetch mvfst
+      if: ${{ steps.paths.outputs.mvfst_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests mvfst
     - name: Fetch wangle
+      if: ${{ steps.paths.outputs.wangle_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests wangle
     - name: Fetch fbthrift
+      if: ${{ steps.paths.outputs.fbthrift_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fbthrift
     - name: Fetch fb303
+      if: ${{ steps.paths.outputs.fb303_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fb303
     - name: Fetch rust-shed
+      if: ${{ steps.paths.outputs.rust-shed_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests rust-shed
     - name: Build git-lfs
+      if: ${{ steps.paths.outputs.git-lfs_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests git-lfs
     - name: Build ripgrep
+      if: ${{ steps.paths.outputs.ripgrep_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests ripgrep
     - name: Build tree
+      if: ${{ steps.paths.outputs.tree_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests tree
     - name: Build bz2
+      if: ${{ steps.paths.outputs.bz2_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests bz2
     - name: Build ninja
+      if: ${{ steps.paths.outputs.ninja_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests ninja
     - name: Build cmake
+      if: ${{ steps.paths.outputs.cmake_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests cmake
     - name: Build zstd
+      if: ${{ steps.paths.outputs.zstd_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests zstd
     - name: Build python-click
+      if: ${{ steps.paths.outputs.python-click_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests python-click
     - name: Build sqlite3
+      if: ${{ steps.paths.outputs.sqlite3_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests sqlite3
     - name: Build gflags
+      if: ${{ steps.paths.outputs.gflags_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests gflags
     - name: Build glog
+      if: ${{ steps.paths.outputs.glog_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests glog
     - name: Build fmt
+      if: ${{ steps.paths.outputs.fmt_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fmt
     - name: Build googletest
+      if: ${{ steps.paths.outputs.googletest_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests googletest
     - name: Build xxhash
+      if: ${{ steps.paths.outputs.xxhash_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests xxhash
     - name: Build python-setuptools
+      if: ${{ steps.paths.outputs.python-setuptools_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests python-setuptools
     - name: Build autoconf
+      if: ${{ steps.paths.outputs.autoconf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests autoconf
     - name: Build automake
+      if: ${{ steps.paths.outputs.automake_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests automake
     - name: Build libtool
+      if: ${{ steps.paths.outputs.libtool_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libtool
     - name: Build jq
+      if: ${{ steps.paths.outputs.jq_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests jq
     - name: Build libsodium
+      if: ${{ steps.paths.outputs.libsodium_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libsodium
     - name: Build boost
+      if: ${{ steps.paths.outputs.boost_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests boost
     - name: Build double-conversion
+      if: ${{ steps.paths.outputs.double-conversion_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests double-conversion
     - name: Build fast_float
+      if: ${{ steps.paths.outputs.fast_float_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fast_float
     - name: Build libdwarf
+      if: ${{ steps.paths.outputs.libdwarf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libdwarf
     - name: Build libevent
+      if: ${{ steps.paths.outputs.libevent_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libevent
     - name: Build libunwind
+      if: ${{ steps.paths.outputs.libunwind_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libunwind
     - name: Build lz4
+      if: ${{ steps.paths.outputs.lz4_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests lz4
     - name: Build snappy
+      if: ${{ steps.paths.outputs.snappy_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests snappy
     - name: Build xz
+      if: ${{ steps.paths.outputs.xz_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests xz
     - name: Build zlib
+      if: ${{ steps.paths.outputs.zlib_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests zlib
     - name: Build libiberty
+      if: ${{ steps.paths.outputs.libiberty_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libiberty
     - name: Build folly
+      if: ${{ steps.paths.outputs.folly_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests folly
     - name: Build libffi
+      if: ${{ steps.paths.outputs.libffi_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libffi
     - name: Build ncurses
+      if: ${{ steps.paths.outputs.ncurses_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests ncurses
     - name: Build python
+      if: ${{ steps.paths.outputs.python_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests python
     - name: Build nmap
+      if: ${{ steps.paths.outputs.nmap_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests nmap
     - name: Build openssl
+      if: ${{ steps.paths.outputs.openssl_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests openssl
     - name: Build liboqs
+      if: ${{ steps.paths.outputs.liboqs_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests liboqs
     - name: Build fizz
+      if: ${{ steps.paths.outputs.fizz_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fizz
     - name: Build mvfst
+      if: ${{ steps.paths.outputs.mvfst_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests mvfst
     - name: Build wangle
+      if: ${{ steps.paths.outputs.wangle_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests wangle
     - name: Build fbthrift
+      if: ${{ steps.paths.outputs.fbthrift_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fbthrift
     - name: Build fb303
+      if: ${{ steps.paths.outputs.fb303_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fb303
     - name: Build rust-shed
+      if: ${{ steps.paths.outputs.rust-shed_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests rust-shed
     - name: Build mononoke
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. --no-tests mononoke

--- a/.github/workflows/mononoke-integration_linux.yml
+++ b/.github/workflows/mononoke-integration_linux.yml
@@ -159,138 +159,710 @@ jobs:
     - name: Fetch rust-shed
       if: ${{ steps.paths.outputs.rust-shed_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests rust-shed
-    - name: Build git-lfs
+    - name: Restore git-lfs from cache
+      id: restore_git-lfs
       if: ${{ steps.paths.outputs.git-lfs_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.git-lfs_INSTALL }}
+       key: ${{ steps.paths.outputs.git-lfs_CACHE_KEY }}-install
+    - name: Build git-lfs
+      if: ${{ steps.paths.outputs.git-lfs_SOURCE && ! steps.restore_git-lfs.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests git-lfs
-    - name: Build ripgrep
+    - name: Save git-lfs to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.git-lfs_SOURCE && ! steps.restore_git-lfs.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.git-lfs_INSTALL }}
+       key: ${{ steps.paths.outputs.git-lfs_CACHE_KEY }}-install
+    - name: Restore ripgrep from cache
+      id: restore_ripgrep
       if: ${{ steps.paths.outputs.ripgrep_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.ripgrep_INSTALL }}
+       key: ${{ steps.paths.outputs.ripgrep_CACHE_KEY }}-install
+    - name: Build ripgrep
+      if: ${{ steps.paths.outputs.ripgrep_SOURCE && ! steps.restore_ripgrep.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests ripgrep
-    - name: Build tree
+    - name: Save ripgrep to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.ripgrep_SOURCE && ! steps.restore_ripgrep.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.ripgrep_INSTALL }}
+       key: ${{ steps.paths.outputs.ripgrep_CACHE_KEY }}-install
+    - name: Restore tree from cache
+      id: restore_tree
       if: ${{ steps.paths.outputs.tree_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.tree_INSTALL }}
+       key: ${{ steps.paths.outputs.tree_CACHE_KEY }}-install
+    - name: Build tree
+      if: ${{ steps.paths.outputs.tree_SOURCE && ! steps.restore_tree.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests tree
-    - name: Build bz2
+    - name: Save tree to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.tree_SOURCE && ! steps.restore_tree.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.tree_INSTALL }}
+       key: ${{ steps.paths.outputs.tree_CACHE_KEY }}-install
+    - name: Restore bz2 from cache
+      id: restore_bz2
       if: ${{ steps.paths.outputs.bz2_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.bz2_INSTALL }}
+       key: ${{ steps.paths.outputs.bz2_CACHE_KEY }}-install
+    - name: Build bz2
+      if: ${{ steps.paths.outputs.bz2_SOURCE && ! steps.restore_bz2.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests bz2
-    - name: Build ninja
+    - name: Save bz2 to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.bz2_SOURCE && ! steps.restore_bz2.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.bz2_INSTALL }}
+       key: ${{ steps.paths.outputs.bz2_CACHE_KEY }}-install
+    - name: Restore ninja from cache
+      id: restore_ninja
       if: ${{ steps.paths.outputs.ninja_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.ninja_INSTALL }}
+       key: ${{ steps.paths.outputs.ninja_CACHE_KEY }}-install
+    - name: Build ninja
+      if: ${{ steps.paths.outputs.ninja_SOURCE && ! steps.restore_ninja.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests ninja
-    - name: Build cmake
+    - name: Save ninja to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.ninja_SOURCE && ! steps.restore_ninja.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.ninja_INSTALL }}
+       key: ${{ steps.paths.outputs.ninja_CACHE_KEY }}-install
+    - name: Restore cmake from cache
+      id: restore_cmake
       if: ${{ steps.paths.outputs.cmake_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.cmake_INSTALL }}
+       key: ${{ steps.paths.outputs.cmake_CACHE_KEY }}-install
+    - name: Build cmake
+      if: ${{ steps.paths.outputs.cmake_SOURCE && ! steps.restore_cmake.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests cmake
-    - name: Build zstd
+    - name: Save cmake to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.cmake_SOURCE && ! steps.restore_cmake.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.cmake_INSTALL }}
+       key: ${{ steps.paths.outputs.cmake_CACHE_KEY }}-install
+    - name: Restore zstd from cache
+      id: restore_zstd
       if: ${{ steps.paths.outputs.zstd_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.zstd_INSTALL }}
+       key: ${{ steps.paths.outputs.zstd_CACHE_KEY }}-install
+    - name: Build zstd
+      if: ${{ steps.paths.outputs.zstd_SOURCE && ! steps.restore_zstd.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests zstd
-    - name: Build python-click
+    - name: Save zstd to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.zstd_SOURCE && ! steps.restore_zstd.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.zstd_INSTALL }}
+       key: ${{ steps.paths.outputs.zstd_CACHE_KEY }}-install
+    - name: Restore python-click from cache
+      id: restore_python-click
       if: ${{ steps.paths.outputs.python-click_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.python-click_INSTALL }}
+       key: ${{ steps.paths.outputs.python-click_CACHE_KEY }}-install
+    - name: Build python-click
+      if: ${{ steps.paths.outputs.python-click_SOURCE && ! steps.restore_python-click.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests python-click
-    - name: Build sqlite3
+    - name: Save python-click to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.python-click_SOURCE && ! steps.restore_python-click.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.python-click_INSTALL }}
+       key: ${{ steps.paths.outputs.python-click_CACHE_KEY }}-install
+    - name: Restore sqlite3 from cache
+      id: restore_sqlite3
       if: ${{ steps.paths.outputs.sqlite3_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.sqlite3_INSTALL }}
+       key: ${{ steps.paths.outputs.sqlite3_CACHE_KEY }}-install
+    - name: Build sqlite3
+      if: ${{ steps.paths.outputs.sqlite3_SOURCE && ! steps.restore_sqlite3.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests sqlite3
-    - name: Build gflags
+    - name: Save sqlite3 to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.sqlite3_SOURCE && ! steps.restore_sqlite3.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.sqlite3_INSTALL }}
+       key: ${{ steps.paths.outputs.sqlite3_CACHE_KEY }}-install
+    - name: Restore gflags from cache
+      id: restore_gflags
       if: ${{ steps.paths.outputs.gflags_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.gflags_INSTALL }}
+       key: ${{ steps.paths.outputs.gflags_CACHE_KEY }}-install
+    - name: Build gflags
+      if: ${{ steps.paths.outputs.gflags_SOURCE && ! steps.restore_gflags.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests gflags
-    - name: Build glog
+    - name: Save gflags to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.gflags_SOURCE && ! steps.restore_gflags.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.gflags_INSTALL }}
+       key: ${{ steps.paths.outputs.gflags_CACHE_KEY }}-install
+    - name: Restore glog from cache
+      id: restore_glog
       if: ${{ steps.paths.outputs.glog_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.glog_INSTALL }}
+       key: ${{ steps.paths.outputs.glog_CACHE_KEY }}-install
+    - name: Build glog
+      if: ${{ steps.paths.outputs.glog_SOURCE && ! steps.restore_glog.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests glog
-    - name: Build fmt
+    - name: Save glog to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.glog_SOURCE && ! steps.restore_glog.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.glog_INSTALL }}
+       key: ${{ steps.paths.outputs.glog_CACHE_KEY }}-install
+    - name: Restore fmt from cache
+      id: restore_fmt
       if: ${{ steps.paths.outputs.fmt_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fmt_INSTALL }}
+       key: ${{ steps.paths.outputs.fmt_CACHE_KEY }}-install
+    - name: Build fmt
+      if: ${{ steps.paths.outputs.fmt_SOURCE && ! steps.restore_fmt.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fmt
-    - name: Build googletest
+    - name: Save fmt to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fmt_SOURCE && ! steps.restore_fmt.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fmt_INSTALL }}
+       key: ${{ steps.paths.outputs.fmt_CACHE_KEY }}-install
+    - name: Restore googletest from cache
+      id: restore_googletest
       if: ${{ steps.paths.outputs.googletest_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.googletest_INSTALL }}
+       key: ${{ steps.paths.outputs.googletest_CACHE_KEY }}-install
+    - name: Build googletest
+      if: ${{ steps.paths.outputs.googletest_SOURCE && ! steps.restore_googletest.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests googletest
-    - name: Build xxhash
+    - name: Save googletest to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.googletest_SOURCE && ! steps.restore_googletest.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.googletest_INSTALL }}
+       key: ${{ steps.paths.outputs.googletest_CACHE_KEY }}-install
+    - name: Restore xxhash from cache
+      id: restore_xxhash
       if: ${{ steps.paths.outputs.xxhash_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.xxhash_INSTALL }}
+       key: ${{ steps.paths.outputs.xxhash_CACHE_KEY }}-install
+    - name: Build xxhash
+      if: ${{ steps.paths.outputs.xxhash_SOURCE && ! steps.restore_xxhash.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests xxhash
-    - name: Build python-setuptools
+    - name: Save xxhash to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.xxhash_SOURCE && ! steps.restore_xxhash.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.xxhash_INSTALL }}
+       key: ${{ steps.paths.outputs.xxhash_CACHE_KEY }}-install
+    - name: Restore python-setuptools from cache
+      id: restore_python-setuptools
       if: ${{ steps.paths.outputs.python-setuptools_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.python-setuptools_INSTALL }}
+       key: ${{ steps.paths.outputs.python-setuptools_CACHE_KEY }}-install
+    - name: Build python-setuptools
+      if: ${{ steps.paths.outputs.python-setuptools_SOURCE && ! steps.restore_python-setuptools.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests python-setuptools
-    - name: Build autoconf
+    - name: Save python-setuptools to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.python-setuptools_SOURCE && ! steps.restore_python-setuptools.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.python-setuptools_INSTALL }}
+       key: ${{ steps.paths.outputs.python-setuptools_CACHE_KEY }}-install
+    - name: Restore autoconf from cache
+      id: restore_autoconf
       if: ${{ steps.paths.outputs.autoconf_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.autoconf_INSTALL }}
+       key: ${{ steps.paths.outputs.autoconf_CACHE_KEY }}-install
+    - name: Build autoconf
+      if: ${{ steps.paths.outputs.autoconf_SOURCE && ! steps.restore_autoconf.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests autoconf
-    - name: Build automake
+    - name: Save autoconf to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.autoconf_SOURCE && ! steps.restore_autoconf.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.autoconf_INSTALL }}
+       key: ${{ steps.paths.outputs.autoconf_CACHE_KEY }}-install
+    - name: Restore automake from cache
+      id: restore_automake
       if: ${{ steps.paths.outputs.automake_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.automake_INSTALL }}
+       key: ${{ steps.paths.outputs.automake_CACHE_KEY }}-install
+    - name: Build automake
+      if: ${{ steps.paths.outputs.automake_SOURCE && ! steps.restore_automake.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests automake
-    - name: Build libtool
+    - name: Save automake to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.automake_SOURCE && ! steps.restore_automake.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.automake_INSTALL }}
+       key: ${{ steps.paths.outputs.automake_CACHE_KEY }}-install
+    - name: Restore libtool from cache
+      id: restore_libtool
       if: ${{ steps.paths.outputs.libtool_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libtool_INSTALL }}
+       key: ${{ steps.paths.outputs.libtool_CACHE_KEY }}-install
+    - name: Build libtool
+      if: ${{ steps.paths.outputs.libtool_SOURCE && ! steps.restore_libtool.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libtool
-    - name: Build jq
+    - name: Save libtool to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libtool_SOURCE && ! steps.restore_libtool.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libtool_INSTALL }}
+       key: ${{ steps.paths.outputs.libtool_CACHE_KEY }}-install
+    - name: Restore jq from cache
+      id: restore_jq
       if: ${{ steps.paths.outputs.jq_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.jq_INSTALL }}
+       key: ${{ steps.paths.outputs.jq_CACHE_KEY }}-install
+    - name: Build jq
+      if: ${{ steps.paths.outputs.jq_SOURCE && ! steps.restore_jq.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests jq
-    - name: Build libsodium
+    - name: Save jq to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.jq_SOURCE && ! steps.restore_jq.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.jq_INSTALL }}
+       key: ${{ steps.paths.outputs.jq_CACHE_KEY }}-install
+    - name: Restore libsodium from cache
+      id: restore_libsodium
       if: ${{ steps.paths.outputs.libsodium_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libsodium_INSTALL }}
+       key: ${{ steps.paths.outputs.libsodium_CACHE_KEY }}-install
+    - name: Build libsodium
+      if: ${{ steps.paths.outputs.libsodium_SOURCE && ! steps.restore_libsodium.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libsodium
-    - name: Build boost
+    - name: Save libsodium to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libsodium_SOURCE && ! steps.restore_libsodium.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libsodium_INSTALL }}
+       key: ${{ steps.paths.outputs.libsodium_CACHE_KEY }}-install
+    - name: Restore boost from cache
+      id: restore_boost
       if: ${{ steps.paths.outputs.boost_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.boost_INSTALL }}
+       key: ${{ steps.paths.outputs.boost_CACHE_KEY }}-install
+    - name: Build boost
+      if: ${{ steps.paths.outputs.boost_SOURCE && ! steps.restore_boost.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests boost
-    - name: Build double-conversion
+    - name: Save boost to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.boost_SOURCE && ! steps.restore_boost.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.boost_INSTALL }}
+       key: ${{ steps.paths.outputs.boost_CACHE_KEY }}-install
+    - name: Restore double-conversion from cache
+      id: restore_double-conversion
       if: ${{ steps.paths.outputs.double-conversion_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.double-conversion_INSTALL }}
+       key: ${{ steps.paths.outputs.double-conversion_CACHE_KEY }}-install
+    - name: Build double-conversion
+      if: ${{ steps.paths.outputs.double-conversion_SOURCE && ! steps.restore_double-conversion.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests double-conversion
-    - name: Build fast_float
+    - name: Save double-conversion to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.double-conversion_SOURCE && ! steps.restore_double-conversion.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.double-conversion_INSTALL }}
+       key: ${{ steps.paths.outputs.double-conversion_CACHE_KEY }}-install
+    - name: Restore fast_float from cache
+      id: restore_fast_float
       if: ${{ steps.paths.outputs.fast_float_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fast_float_INSTALL }}
+       key: ${{ steps.paths.outputs.fast_float_CACHE_KEY }}-install
+    - name: Build fast_float
+      if: ${{ steps.paths.outputs.fast_float_SOURCE && ! steps.restore_fast_float.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fast_float
-    - name: Build libdwarf
+    - name: Save fast_float to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fast_float_SOURCE && ! steps.restore_fast_float.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fast_float_INSTALL }}
+       key: ${{ steps.paths.outputs.fast_float_CACHE_KEY }}-install
+    - name: Restore libdwarf from cache
+      id: restore_libdwarf
       if: ${{ steps.paths.outputs.libdwarf_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libdwarf_INSTALL }}
+       key: ${{ steps.paths.outputs.libdwarf_CACHE_KEY }}-install
+    - name: Build libdwarf
+      if: ${{ steps.paths.outputs.libdwarf_SOURCE && ! steps.restore_libdwarf.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libdwarf
-    - name: Build libevent
+    - name: Save libdwarf to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libdwarf_SOURCE && ! steps.restore_libdwarf.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libdwarf_INSTALL }}
+       key: ${{ steps.paths.outputs.libdwarf_CACHE_KEY }}-install
+    - name: Restore libevent from cache
+      id: restore_libevent
       if: ${{ steps.paths.outputs.libevent_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libevent_INSTALL }}
+       key: ${{ steps.paths.outputs.libevent_CACHE_KEY }}-install
+    - name: Build libevent
+      if: ${{ steps.paths.outputs.libevent_SOURCE && ! steps.restore_libevent.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libevent
-    - name: Build libunwind
+    - name: Save libevent to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libevent_SOURCE && ! steps.restore_libevent.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libevent_INSTALL }}
+       key: ${{ steps.paths.outputs.libevent_CACHE_KEY }}-install
+    - name: Restore libunwind from cache
+      id: restore_libunwind
       if: ${{ steps.paths.outputs.libunwind_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libunwind_INSTALL }}
+       key: ${{ steps.paths.outputs.libunwind_CACHE_KEY }}-install
+    - name: Build libunwind
+      if: ${{ steps.paths.outputs.libunwind_SOURCE && ! steps.restore_libunwind.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libunwind
-    - name: Build lz4
+    - name: Save libunwind to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libunwind_SOURCE && ! steps.restore_libunwind.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libunwind_INSTALL }}
+       key: ${{ steps.paths.outputs.libunwind_CACHE_KEY }}-install
+    - name: Restore lz4 from cache
+      id: restore_lz4
       if: ${{ steps.paths.outputs.lz4_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.lz4_INSTALL }}
+       key: ${{ steps.paths.outputs.lz4_CACHE_KEY }}-install
+    - name: Build lz4
+      if: ${{ steps.paths.outputs.lz4_SOURCE && ! steps.restore_lz4.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests lz4
-    - name: Build snappy
+    - name: Save lz4 to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.lz4_SOURCE && ! steps.restore_lz4.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.lz4_INSTALL }}
+       key: ${{ steps.paths.outputs.lz4_CACHE_KEY }}-install
+    - name: Restore snappy from cache
+      id: restore_snappy
       if: ${{ steps.paths.outputs.snappy_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.snappy_INSTALL }}
+       key: ${{ steps.paths.outputs.snappy_CACHE_KEY }}-install
+    - name: Build snappy
+      if: ${{ steps.paths.outputs.snappy_SOURCE && ! steps.restore_snappy.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests snappy
-    - name: Build xz
+    - name: Save snappy to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.snappy_SOURCE && ! steps.restore_snappy.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.snappy_INSTALL }}
+       key: ${{ steps.paths.outputs.snappy_CACHE_KEY }}-install
+    - name: Restore xz from cache
+      id: restore_xz
       if: ${{ steps.paths.outputs.xz_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.xz_INSTALL }}
+       key: ${{ steps.paths.outputs.xz_CACHE_KEY }}-install
+    - name: Build xz
+      if: ${{ steps.paths.outputs.xz_SOURCE && ! steps.restore_xz.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests xz
-    - name: Build zlib
+    - name: Save xz to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.xz_SOURCE && ! steps.restore_xz.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.xz_INSTALL }}
+       key: ${{ steps.paths.outputs.xz_CACHE_KEY }}-install
+    - name: Restore zlib from cache
+      id: restore_zlib
       if: ${{ steps.paths.outputs.zlib_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.zlib_INSTALL }}
+       key: ${{ steps.paths.outputs.zlib_CACHE_KEY }}-install
+    - name: Build zlib
+      if: ${{ steps.paths.outputs.zlib_SOURCE && ! steps.restore_zlib.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests zlib
-    - name: Build libiberty
+    - name: Save zlib to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.zlib_SOURCE && ! steps.restore_zlib.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.zlib_INSTALL }}
+       key: ${{ steps.paths.outputs.zlib_CACHE_KEY }}-install
+    - name: Restore libiberty from cache
+      id: restore_libiberty
       if: ${{ steps.paths.outputs.libiberty_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libiberty_INSTALL }}
+       key: ${{ steps.paths.outputs.libiberty_CACHE_KEY }}-install
+    - name: Build libiberty
+      if: ${{ steps.paths.outputs.libiberty_SOURCE && ! steps.restore_libiberty.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libiberty
-    - name: Build folly
+    - name: Save libiberty to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libiberty_SOURCE && ! steps.restore_libiberty.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libiberty_INSTALL }}
+       key: ${{ steps.paths.outputs.libiberty_CACHE_KEY }}-install
+    - name: Restore folly from cache
+      id: restore_folly
       if: ${{ steps.paths.outputs.folly_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.folly_INSTALL }}
+       key: ${{ steps.paths.outputs.folly_CACHE_KEY }}-install
+    - name: Build folly
+      if: ${{ steps.paths.outputs.folly_SOURCE && ! steps.restore_folly.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests folly
-    - name: Build libffi
+    - name: Save folly to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.folly_SOURCE && ! steps.restore_folly.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.folly_INSTALL }}
+       key: ${{ steps.paths.outputs.folly_CACHE_KEY }}-install
+    - name: Restore libffi from cache
+      id: restore_libffi
       if: ${{ steps.paths.outputs.libffi_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libffi_INSTALL }}
+       key: ${{ steps.paths.outputs.libffi_CACHE_KEY }}-install
+    - name: Build libffi
+      if: ${{ steps.paths.outputs.libffi_SOURCE && ! steps.restore_libffi.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests libffi
-    - name: Build ncurses
+    - name: Save libffi to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libffi_SOURCE && ! steps.restore_libffi.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libffi_INSTALL }}
+       key: ${{ steps.paths.outputs.libffi_CACHE_KEY }}-install
+    - name: Restore ncurses from cache
+      id: restore_ncurses
       if: ${{ steps.paths.outputs.ncurses_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.ncurses_INSTALL }}
+       key: ${{ steps.paths.outputs.ncurses_CACHE_KEY }}-install
+    - name: Build ncurses
+      if: ${{ steps.paths.outputs.ncurses_SOURCE && ! steps.restore_ncurses.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests ncurses
-    - name: Build python
+    - name: Save ncurses to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.ncurses_SOURCE && ! steps.restore_ncurses.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.ncurses_INSTALL }}
+       key: ${{ steps.paths.outputs.ncurses_CACHE_KEY }}-install
+    - name: Restore python from cache
+      id: restore_python
       if: ${{ steps.paths.outputs.python_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.python_INSTALL }}
+       key: ${{ steps.paths.outputs.python_CACHE_KEY }}-install
+    - name: Build python
+      if: ${{ steps.paths.outputs.python_SOURCE && ! steps.restore_python.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests python
-    - name: Build nmap
+    - name: Save python to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.python_SOURCE && ! steps.restore_python.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.python_INSTALL }}
+       key: ${{ steps.paths.outputs.python_CACHE_KEY }}-install
+    - name: Restore nmap from cache
+      id: restore_nmap
       if: ${{ steps.paths.outputs.nmap_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.nmap_INSTALL }}
+       key: ${{ steps.paths.outputs.nmap_CACHE_KEY }}-install
+    - name: Build nmap
+      if: ${{ steps.paths.outputs.nmap_SOURCE && ! steps.restore_nmap.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests nmap
-    - name: Build openssl
+    - name: Save nmap to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.nmap_SOURCE && ! steps.restore_nmap.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.nmap_INSTALL }}
+       key: ${{ steps.paths.outputs.nmap_CACHE_KEY }}-install
+    - name: Restore openssl from cache
+      id: restore_openssl
       if: ${{ steps.paths.outputs.openssl_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.openssl_INSTALL }}
+       key: ${{ steps.paths.outputs.openssl_CACHE_KEY }}-install
+    - name: Build openssl
+      if: ${{ steps.paths.outputs.openssl_SOURCE && ! steps.restore_openssl.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests openssl
-    - name: Build liboqs
+    - name: Save openssl to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.openssl_SOURCE && ! steps.restore_openssl.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.openssl_INSTALL }}
+       key: ${{ steps.paths.outputs.openssl_CACHE_KEY }}-install
+    - name: Restore liboqs from cache
+      id: restore_liboqs
       if: ${{ steps.paths.outputs.liboqs_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.liboqs_INSTALL }}
+       key: ${{ steps.paths.outputs.liboqs_CACHE_KEY }}-install
+    - name: Build liboqs
+      if: ${{ steps.paths.outputs.liboqs_SOURCE && ! steps.restore_liboqs.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests liboqs
-    - name: Build fizz
+    - name: Save liboqs to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.liboqs_SOURCE && ! steps.restore_liboqs.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.liboqs_INSTALL }}
+       key: ${{ steps.paths.outputs.liboqs_CACHE_KEY }}-install
+    - name: Restore fizz from cache
+      id: restore_fizz
       if: ${{ steps.paths.outputs.fizz_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fizz_INSTALL }}
+       key: ${{ steps.paths.outputs.fizz_CACHE_KEY }}-install
+    - name: Build fizz
+      if: ${{ steps.paths.outputs.fizz_SOURCE && ! steps.restore_fizz.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fizz
-    - name: Build mvfst
+    - name: Save fizz to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fizz_SOURCE && ! steps.restore_fizz.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fizz_INSTALL }}
+       key: ${{ steps.paths.outputs.fizz_CACHE_KEY }}-install
+    - name: Restore mvfst from cache
+      id: restore_mvfst
       if: ${{ steps.paths.outputs.mvfst_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.mvfst_INSTALL }}
+       key: ${{ steps.paths.outputs.mvfst_CACHE_KEY }}-install
+    - name: Build mvfst
+      if: ${{ steps.paths.outputs.mvfst_SOURCE && ! steps.restore_mvfst.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests mvfst
-    - name: Build wangle
+    - name: Save mvfst to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.mvfst_SOURCE && ! steps.restore_mvfst.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.mvfst_INSTALL }}
+       key: ${{ steps.paths.outputs.mvfst_CACHE_KEY }}-install
+    - name: Restore wangle from cache
+      id: restore_wangle
       if: ${{ steps.paths.outputs.wangle_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.wangle_INSTALL }}
+       key: ${{ steps.paths.outputs.wangle_CACHE_KEY }}-install
+    - name: Build wangle
+      if: ${{ steps.paths.outputs.wangle_SOURCE && ! steps.restore_wangle.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests wangle
-    - name: Build fbthrift
+    - name: Save wangle to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.wangle_SOURCE && ! steps.restore_wangle.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.wangle_INSTALL }}
+       key: ${{ steps.paths.outputs.wangle_CACHE_KEY }}-install
+    - name: Restore fbthrift from cache
+      id: restore_fbthrift
       if: ${{ steps.paths.outputs.fbthrift_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fbthrift_INSTALL }}
+       key: ${{ steps.paths.outputs.fbthrift_CACHE_KEY }}-install
+    - name: Build fbthrift
+      if: ${{ steps.paths.outputs.fbthrift_SOURCE && ! steps.restore_fbthrift.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fbthrift
-    - name: Build fb303
+    - name: Save fbthrift to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fbthrift_SOURCE && ! steps.restore_fbthrift.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fbthrift_INSTALL }}
+       key: ${{ steps.paths.outputs.fbthrift_CACHE_KEY }}-install
+    - name: Restore fb303 from cache
+      id: restore_fb303
       if: ${{ steps.paths.outputs.fb303_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fb303_INSTALL }}
+       key: ${{ steps.paths.outputs.fb303_CACHE_KEY }}-install
+    - name: Build fb303
+      if: ${{ steps.paths.outputs.fb303_SOURCE && ! steps.restore_fb303.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests fb303
-    - name: Build rust-shed
+    - name: Save fb303 to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fb303_SOURCE && ! steps.restore_fb303.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fb303_INSTALL }}
+       key: ${{ steps.paths.outputs.fb303_CACHE_KEY }}-install
+    - name: Restore rust-shed from cache
+      id: restore_rust-shed
       if: ${{ steps.paths.outputs.rust-shed_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.rust-shed_INSTALL }}
+       key: ${{ steps.paths.outputs.rust-shed_CACHE_KEY }}-install
+    - name: Build rust-shed
+      if: ${{ steps.paths.outputs.rust-shed_SOURCE && ! steps.restore_rust-shed.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests rust-shed
+    - name: Save rust-shed to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.rust-shed_SOURCE && ! steps.restore_rust-shed.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.rust-shed_INSTALL }}
+       key: ${{ steps.paths.outputs.rust-shed_CACHE_KEY }}-install
     - name: Build mononoke
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. --no-tests mononoke
     - name: Build sapling

--- a/.github/workflows/mononoke_linux.yml
+++ b/.github/workflows/mononoke_linux.yml
@@ -141,114 +141,582 @@ jobs:
     - name: Fetch rust-shed
       if: ${{ steps.paths.outputs.rust-shed_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests rust-shed
-    - name: Build xxhash
+    - name: Restore xxhash from cache
+      id: restore_xxhash
       if: ${{ steps.paths.outputs.xxhash_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.xxhash_INSTALL }}
+       key: ${{ steps.paths.outputs.xxhash_CACHE_KEY }}-install
+    - name: Build xxhash
+      if: ${{ steps.paths.outputs.xxhash_SOURCE && ! steps.restore_xxhash.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests xxhash
-    - name: Build ninja
+    - name: Save xxhash to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.xxhash_SOURCE && ! steps.restore_xxhash.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.xxhash_INSTALL }}
+       key: ${{ steps.paths.outputs.xxhash_CACHE_KEY }}-install
+    - name: Restore ninja from cache
+      id: restore_ninja
       if: ${{ steps.paths.outputs.ninja_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.ninja_INSTALL }}
+       key: ${{ steps.paths.outputs.ninja_CACHE_KEY }}-install
+    - name: Build ninja
+      if: ${{ steps.paths.outputs.ninja_SOURCE && ! steps.restore_ninja.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests ninja
-    - name: Build cmake
+    - name: Save ninja to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.ninja_SOURCE && ! steps.restore_ninja.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.ninja_INSTALL }}
+       key: ${{ steps.paths.outputs.ninja_CACHE_KEY }}-install
+    - name: Restore cmake from cache
+      id: restore_cmake
       if: ${{ steps.paths.outputs.cmake_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.cmake_INSTALL }}
+       key: ${{ steps.paths.outputs.cmake_CACHE_KEY }}-install
+    - name: Build cmake
+      if: ${{ steps.paths.outputs.cmake_SOURCE && ! steps.restore_cmake.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests cmake
-    - name: Build fmt
+    - name: Save cmake to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.cmake_SOURCE && ! steps.restore_cmake.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.cmake_INSTALL }}
+       key: ${{ steps.paths.outputs.cmake_CACHE_KEY }}-install
+    - name: Restore fmt from cache
+      id: restore_fmt
       if: ${{ steps.paths.outputs.fmt_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fmt_INSTALL }}
+       key: ${{ steps.paths.outputs.fmt_CACHE_KEY }}-install
+    - name: Build fmt
+      if: ${{ steps.paths.outputs.fmt_SOURCE && ! steps.restore_fmt.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fmt
-    - name: Build googletest
+    - name: Save fmt to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fmt_SOURCE && ! steps.restore_fmt.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fmt_INSTALL }}
+       key: ${{ steps.paths.outputs.fmt_CACHE_KEY }}-install
+    - name: Restore googletest from cache
+      id: restore_googletest
       if: ${{ steps.paths.outputs.googletest_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.googletest_INSTALL }}
+       key: ${{ steps.paths.outputs.googletest_CACHE_KEY }}-install
+    - name: Build googletest
+      if: ${{ steps.paths.outputs.googletest_SOURCE && ! steps.restore_googletest.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests googletest
-    - name: Build zstd
+    - name: Save googletest to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.googletest_SOURCE && ! steps.restore_googletest.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.googletest_INSTALL }}
+       key: ${{ steps.paths.outputs.googletest_CACHE_KEY }}-install
+    - name: Restore zstd from cache
+      id: restore_zstd
       if: ${{ steps.paths.outputs.zstd_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.zstd_INSTALL }}
+       key: ${{ steps.paths.outputs.zstd_CACHE_KEY }}-install
+    - name: Build zstd
+      if: ${{ steps.paths.outputs.zstd_SOURCE && ! steps.restore_zstd.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests zstd
-    - name: Build boost
+    - name: Save zstd to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.zstd_SOURCE && ! steps.restore_zstd.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.zstd_INSTALL }}
+       key: ${{ steps.paths.outputs.zstd_CACHE_KEY }}-install
+    - name: Restore boost from cache
+      id: restore_boost
       if: ${{ steps.paths.outputs.boost_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.boost_INSTALL }}
+       key: ${{ steps.paths.outputs.boost_CACHE_KEY }}-install
+    - name: Build boost
+      if: ${{ steps.paths.outputs.boost_SOURCE && ! steps.restore_boost.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests boost
-    - name: Build double-conversion
+    - name: Save boost to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.boost_SOURCE && ! steps.restore_boost.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.boost_INSTALL }}
+       key: ${{ steps.paths.outputs.boost_CACHE_KEY }}-install
+    - name: Restore double-conversion from cache
+      id: restore_double-conversion
       if: ${{ steps.paths.outputs.double-conversion_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.double-conversion_INSTALL }}
+       key: ${{ steps.paths.outputs.double-conversion_CACHE_KEY }}-install
+    - name: Build double-conversion
+      if: ${{ steps.paths.outputs.double-conversion_SOURCE && ! steps.restore_double-conversion.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests double-conversion
-    - name: Build fast_float
+    - name: Save double-conversion to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.double-conversion_SOURCE && ! steps.restore_double-conversion.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.double-conversion_INSTALL }}
+       key: ${{ steps.paths.outputs.double-conversion_CACHE_KEY }}-install
+    - name: Restore fast_float from cache
+      id: restore_fast_float
       if: ${{ steps.paths.outputs.fast_float_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fast_float_INSTALL }}
+       key: ${{ steps.paths.outputs.fast_float_CACHE_KEY }}-install
+    - name: Build fast_float
+      if: ${{ steps.paths.outputs.fast_float_SOURCE && ! steps.restore_fast_float.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fast_float
-    - name: Build gflags
+    - name: Save fast_float to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fast_float_SOURCE && ! steps.restore_fast_float.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fast_float_INSTALL }}
+       key: ${{ steps.paths.outputs.fast_float_CACHE_KEY }}-install
+    - name: Restore gflags from cache
+      id: restore_gflags
       if: ${{ steps.paths.outputs.gflags_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.gflags_INSTALL }}
+       key: ${{ steps.paths.outputs.gflags_CACHE_KEY }}-install
+    - name: Build gflags
+      if: ${{ steps.paths.outputs.gflags_SOURCE && ! steps.restore_gflags.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests gflags
-    - name: Build glog
+    - name: Save gflags to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.gflags_SOURCE && ! steps.restore_gflags.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.gflags_INSTALL }}
+       key: ${{ steps.paths.outputs.gflags_CACHE_KEY }}-install
+    - name: Restore glog from cache
+      id: restore_glog
       if: ${{ steps.paths.outputs.glog_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.glog_INSTALL }}
+       key: ${{ steps.paths.outputs.glog_CACHE_KEY }}-install
+    - name: Build glog
+      if: ${{ steps.paths.outputs.glog_SOURCE && ! steps.restore_glog.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests glog
-    - name: Build libdwarf
+    - name: Save glog to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.glog_SOURCE && ! steps.restore_glog.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.glog_INSTALL }}
+       key: ${{ steps.paths.outputs.glog_CACHE_KEY }}-install
+    - name: Restore libdwarf from cache
+      id: restore_libdwarf
       if: ${{ steps.paths.outputs.libdwarf_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libdwarf_INSTALL }}
+       key: ${{ steps.paths.outputs.libdwarf_CACHE_KEY }}-install
+    - name: Build libdwarf
+      if: ${{ steps.paths.outputs.libdwarf_SOURCE && ! steps.restore_libdwarf.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libdwarf
-    - name: Build libevent
+    - name: Save libdwarf to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libdwarf_SOURCE && ! steps.restore_libdwarf.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libdwarf_INSTALL }}
+       key: ${{ steps.paths.outputs.libdwarf_CACHE_KEY }}-install
+    - name: Restore libevent from cache
+      id: restore_libevent
       if: ${{ steps.paths.outputs.libevent_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libevent_INSTALL }}
+       key: ${{ steps.paths.outputs.libevent_CACHE_KEY }}-install
+    - name: Build libevent
+      if: ${{ steps.paths.outputs.libevent_SOURCE && ! steps.restore_libevent.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libevent
-    - name: Build lz4
+    - name: Save libevent to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libevent_SOURCE && ! steps.restore_libevent.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libevent_INSTALL }}
+       key: ${{ steps.paths.outputs.libevent_CACHE_KEY }}-install
+    - name: Restore lz4 from cache
+      id: restore_lz4
       if: ${{ steps.paths.outputs.lz4_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.lz4_INSTALL }}
+       key: ${{ steps.paths.outputs.lz4_CACHE_KEY }}-install
+    - name: Build lz4
+      if: ${{ steps.paths.outputs.lz4_SOURCE && ! steps.restore_lz4.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests lz4
-    - name: Build snappy
+    - name: Save lz4 to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.lz4_SOURCE && ! steps.restore_lz4.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.lz4_INSTALL }}
+       key: ${{ steps.paths.outputs.lz4_CACHE_KEY }}-install
+    - name: Restore snappy from cache
+      id: restore_snappy
       if: ${{ steps.paths.outputs.snappy_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.snappy_INSTALL }}
+       key: ${{ steps.paths.outputs.snappy_CACHE_KEY }}-install
+    - name: Build snappy
+      if: ${{ steps.paths.outputs.snappy_SOURCE && ! steps.restore_snappy.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests snappy
-    - name: Build zlib
+    - name: Save snappy to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.snappy_SOURCE && ! steps.restore_snappy.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.snappy_INSTALL }}
+       key: ${{ steps.paths.outputs.snappy_CACHE_KEY }}-install
+    - name: Restore zlib from cache
+      id: restore_zlib
       if: ${{ steps.paths.outputs.zlib_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.zlib_INSTALL }}
+       key: ${{ steps.paths.outputs.zlib_CACHE_KEY }}-install
+    - name: Build zlib
+      if: ${{ steps.paths.outputs.zlib_SOURCE && ! steps.restore_zlib.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests zlib
-    - name: Build bz2
+    - name: Save zlib to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.zlib_SOURCE && ! steps.restore_zlib.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.zlib_INSTALL }}
+       key: ${{ steps.paths.outputs.zlib_CACHE_KEY }}-install
+    - name: Restore bz2 from cache
+      id: restore_bz2
       if: ${{ steps.paths.outputs.bz2_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.bz2_INSTALL }}
+       key: ${{ steps.paths.outputs.bz2_CACHE_KEY }}-install
+    - name: Build bz2
+      if: ${{ steps.paths.outputs.bz2_SOURCE && ! steps.restore_bz2.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests bz2
-    - name: Build openssl
+    - name: Save bz2 to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.bz2_SOURCE && ! steps.restore_bz2.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.bz2_INSTALL }}
+       key: ${{ steps.paths.outputs.bz2_CACHE_KEY }}-install
+    - name: Restore openssl from cache
+      id: restore_openssl
       if: ${{ steps.paths.outputs.openssl_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.openssl_INSTALL }}
+       key: ${{ steps.paths.outputs.openssl_CACHE_KEY }}-install
+    - name: Build openssl
+      if: ${{ steps.paths.outputs.openssl_SOURCE && ! steps.restore_openssl.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests openssl
-    - name: Build liboqs
+    - name: Save openssl to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.openssl_SOURCE && ! steps.restore_openssl.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.openssl_INSTALL }}
+       key: ${{ steps.paths.outputs.openssl_CACHE_KEY }}-install
+    - name: Restore liboqs from cache
+      id: restore_liboqs
       if: ${{ steps.paths.outputs.liboqs_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.liboqs_INSTALL }}
+       key: ${{ steps.paths.outputs.liboqs_CACHE_KEY }}-install
+    - name: Build liboqs
+      if: ${{ steps.paths.outputs.liboqs_SOURCE && ! steps.restore_liboqs.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests liboqs
-    - name: Build autoconf
+    - name: Save liboqs to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.liboqs_SOURCE && ! steps.restore_liboqs.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.liboqs_INSTALL }}
+       key: ${{ steps.paths.outputs.liboqs_CACHE_KEY }}-install
+    - name: Restore autoconf from cache
+      id: restore_autoconf
       if: ${{ steps.paths.outputs.autoconf_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.autoconf_INSTALL }}
+       key: ${{ steps.paths.outputs.autoconf_CACHE_KEY }}-install
+    - name: Build autoconf
+      if: ${{ steps.paths.outputs.autoconf_SOURCE && ! steps.restore_autoconf.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests autoconf
-    - name: Build automake
+    - name: Save autoconf to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.autoconf_SOURCE && ! steps.restore_autoconf.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.autoconf_INSTALL }}
+       key: ${{ steps.paths.outputs.autoconf_CACHE_KEY }}-install
+    - name: Restore automake from cache
+      id: restore_automake
       if: ${{ steps.paths.outputs.automake_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.automake_INSTALL }}
+       key: ${{ steps.paths.outputs.automake_CACHE_KEY }}-install
+    - name: Build automake
+      if: ${{ steps.paths.outputs.automake_SOURCE && ! steps.restore_automake.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests automake
-    - name: Build libtool
+    - name: Save automake to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.automake_SOURCE && ! steps.restore_automake.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.automake_INSTALL }}
+       key: ${{ steps.paths.outputs.automake_CACHE_KEY }}-install
+    - name: Restore libtool from cache
+      id: restore_libtool
       if: ${{ steps.paths.outputs.libtool_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libtool_INSTALL }}
+       key: ${{ steps.paths.outputs.libtool_CACHE_KEY }}-install
+    - name: Build libtool
+      if: ${{ steps.paths.outputs.libtool_SOURCE && ! steps.restore_libtool.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libtool
-    - name: Build libsodium
+    - name: Save libtool to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libtool_SOURCE && ! steps.restore_libtool.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libtool_INSTALL }}
+       key: ${{ steps.paths.outputs.libtool_CACHE_KEY }}-install
+    - name: Restore libsodium from cache
+      id: restore_libsodium
       if: ${{ steps.paths.outputs.libsodium_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libsodium_INSTALL }}
+       key: ${{ steps.paths.outputs.libsodium_CACHE_KEY }}-install
+    - name: Build libsodium
+      if: ${{ steps.paths.outputs.libsodium_SOURCE && ! steps.restore_libsodium.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libsodium
-    - name: Build libiberty
+    - name: Save libsodium to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libsodium_SOURCE && ! steps.restore_libsodium.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libsodium_INSTALL }}
+       key: ${{ steps.paths.outputs.libsodium_CACHE_KEY }}-install
+    - name: Restore libiberty from cache
+      id: restore_libiberty
       if: ${{ steps.paths.outputs.libiberty_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libiberty_INSTALL }}
+       key: ${{ steps.paths.outputs.libiberty_CACHE_KEY }}-install
+    - name: Build libiberty
+      if: ${{ steps.paths.outputs.libiberty_SOURCE && ! steps.restore_libiberty.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libiberty
-    - name: Build libunwind
+    - name: Save libiberty to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libiberty_SOURCE && ! steps.restore_libiberty.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libiberty_INSTALL }}
+       key: ${{ steps.paths.outputs.libiberty_CACHE_KEY }}-install
+    - name: Restore libunwind from cache
+      id: restore_libunwind
       if: ${{ steps.paths.outputs.libunwind_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libunwind_INSTALL }}
+       key: ${{ steps.paths.outputs.libunwind_CACHE_KEY }}-install
+    - name: Build libunwind
+      if: ${{ steps.paths.outputs.libunwind_SOURCE && ! steps.restore_libunwind.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libunwind
-    - name: Build xz
+    - name: Save libunwind to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libunwind_SOURCE && ! steps.restore_libunwind.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libunwind_INSTALL }}
+       key: ${{ steps.paths.outputs.libunwind_CACHE_KEY }}-install
+    - name: Restore xz from cache
+      id: restore_xz
       if: ${{ steps.paths.outputs.xz_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.xz_INSTALL }}
+       key: ${{ steps.paths.outputs.xz_CACHE_KEY }}-install
+    - name: Build xz
+      if: ${{ steps.paths.outputs.xz_SOURCE && ! steps.restore_xz.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests xz
-    - name: Build folly
+    - name: Save xz to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.xz_SOURCE && ! steps.restore_xz.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.xz_INSTALL }}
+       key: ${{ steps.paths.outputs.xz_CACHE_KEY }}-install
+    - name: Restore folly from cache
+      id: restore_folly
       if: ${{ steps.paths.outputs.folly_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.folly_INSTALL }}
+       key: ${{ steps.paths.outputs.folly_CACHE_KEY }}-install
+    - name: Build folly
+      if: ${{ steps.paths.outputs.folly_SOURCE && ! steps.restore_folly.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests folly
-    - name: Build fizz
+    - name: Save folly to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.folly_SOURCE && ! steps.restore_folly.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.folly_INSTALL }}
+       key: ${{ steps.paths.outputs.folly_CACHE_KEY }}-install
+    - name: Restore fizz from cache
+      id: restore_fizz
       if: ${{ steps.paths.outputs.fizz_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fizz_INSTALL }}
+       key: ${{ steps.paths.outputs.fizz_CACHE_KEY }}-install
+    - name: Build fizz
+      if: ${{ steps.paths.outputs.fizz_SOURCE && ! steps.restore_fizz.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fizz
-    - name: Build mvfst
+    - name: Save fizz to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fizz_SOURCE && ! steps.restore_fizz.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fizz_INSTALL }}
+       key: ${{ steps.paths.outputs.fizz_CACHE_KEY }}-install
+    - name: Restore mvfst from cache
+      id: restore_mvfst
       if: ${{ steps.paths.outputs.mvfst_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.mvfst_INSTALL }}
+       key: ${{ steps.paths.outputs.mvfst_CACHE_KEY }}-install
+    - name: Build mvfst
+      if: ${{ steps.paths.outputs.mvfst_SOURCE && ! steps.restore_mvfst.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests mvfst
-    - name: Build libffi
+    - name: Save mvfst to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.mvfst_SOURCE && ! steps.restore_mvfst.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.mvfst_INSTALL }}
+       key: ${{ steps.paths.outputs.mvfst_CACHE_KEY }}-install
+    - name: Restore libffi from cache
+      id: restore_libffi
       if: ${{ steps.paths.outputs.libffi_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libffi_INSTALL }}
+       key: ${{ steps.paths.outputs.libffi_CACHE_KEY }}-install
+    - name: Build libffi
+      if: ${{ steps.paths.outputs.libffi_SOURCE && ! steps.restore_libffi.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libffi
-    - name: Build ncurses
+    - name: Save libffi to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libffi_SOURCE && ! steps.restore_libffi.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libffi_INSTALL }}
+       key: ${{ steps.paths.outputs.libffi_CACHE_KEY }}-install
+    - name: Restore ncurses from cache
+      id: restore_ncurses
       if: ${{ steps.paths.outputs.ncurses_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.ncurses_INSTALL }}
+       key: ${{ steps.paths.outputs.ncurses_CACHE_KEY }}-install
+    - name: Build ncurses
+      if: ${{ steps.paths.outputs.ncurses_SOURCE && ! steps.restore_ncurses.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests ncurses
-    - name: Build python
+    - name: Save ncurses to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.ncurses_SOURCE && ! steps.restore_ncurses.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.ncurses_INSTALL }}
+       key: ${{ steps.paths.outputs.ncurses_CACHE_KEY }}-install
+    - name: Restore python from cache
+      id: restore_python
       if: ${{ steps.paths.outputs.python_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.python_INSTALL }}
+       key: ${{ steps.paths.outputs.python_CACHE_KEY }}-install
+    - name: Build python
+      if: ${{ steps.paths.outputs.python_SOURCE && ! steps.restore_python.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests python
-    - name: Build wangle
+    - name: Save python to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.python_SOURCE && ! steps.restore_python.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.python_INSTALL }}
+       key: ${{ steps.paths.outputs.python_CACHE_KEY }}-install
+    - name: Restore wangle from cache
+      id: restore_wangle
       if: ${{ steps.paths.outputs.wangle_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.wangle_INSTALL }}
+       key: ${{ steps.paths.outputs.wangle_CACHE_KEY }}-install
+    - name: Build wangle
+      if: ${{ steps.paths.outputs.wangle_SOURCE && ! steps.restore_wangle.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests wangle
-    - name: Build fbthrift
+    - name: Save wangle to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.wangle_SOURCE && ! steps.restore_wangle.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.wangle_INSTALL }}
+       key: ${{ steps.paths.outputs.wangle_CACHE_KEY }}-install
+    - name: Restore fbthrift from cache
+      id: restore_fbthrift
       if: ${{ steps.paths.outputs.fbthrift_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fbthrift_INSTALL }}
+       key: ${{ steps.paths.outputs.fbthrift_CACHE_KEY }}-install
+    - name: Build fbthrift
+      if: ${{ steps.paths.outputs.fbthrift_SOURCE && ! steps.restore_fbthrift.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fbthrift
-    - name: Build fb303
+    - name: Save fbthrift to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fbthrift_SOURCE && ! steps.restore_fbthrift.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fbthrift_INSTALL }}
+       key: ${{ steps.paths.outputs.fbthrift_CACHE_KEY }}-install
+    - name: Restore fb303 from cache
+      id: restore_fb303
       if: ${{ steps.paths.outputs.fb303_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fb303_INSTALL }}
+       key: ${{ steps.paths.outputs.fb303_CACHE_KEY }}-install
+    - name: Build fb303
+      if: ${{ steps.paths.outputs.fb303_SOURCE && ! steps.restore_fb303.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fb303
-    - name: Build rust-shed
+    - name: Save fb303 to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fb303_SOURCE && ! steps.restore_fb303.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fb303_INSTALL }}
+       key: ${{ steps.paths.outputs.fb303_CACHE_KEY }}-install
+    - name: Restore rust-shed from cache
+      id: restore_rust-shed
       if: ${{ steps.paths.outputs.rust-shed_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.rust-shed_INSTALL }}
+       key: ${{ steps.paths.outputs.rust-shed_CACHE_KEY }}-install
+    - name: Build rust-shed
+      if: ${{ steps.paths.outputs.rust-shed_SOURCE && ! steps.restore_rust-shed.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests rust-shed
+    - name: Save rust-shed to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.rust-shed_SOURCE && ! steps.restore_rust-shed.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.rust-shed_INSTALL }}
+       key: ${{ steps.paths.outputs.rust-shed_CACHE_KEY }}-install
     - name: Build mononoke
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. mononoke  --project-install-prefix mononoke:/
     - name: Copy artifacts

--- a/.github/workflows/mononoke_linux.yml
+++ b/.github/workflows/mononoke_linux.yml
@@ -27,154 +27,227 @@ jobs:
     - name: Update system package info
       run: sudo apt-get update
     - name: Install system deps
-      run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive mononoke
-    - name: Install packaging system deps
-      run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive patchelf
+      run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive mononoke && sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive patchelf
+    - id: paths
+      name: Query paths
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages query-paths --recursive --src-dir=. mononoke  >> "$GITHUB_OUTPUT"
     - name: Install Rust Stable
       uses: dtolnay/rust-toolchain@stable
     - name: Fetch xxhash
+      if: ${{ steps.paths.outputs.xxhash_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests xxhash
     - name: Fetch ninja
+      if: ${{ steps.paths.outputs.ninja_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests ninja
     - name: Fetch cmake
+      if: ${{ steps.paths.outputs.cmake_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests cmake
     - name: Fetch fmt
+      if: ${{ steps.paths.outputs.fmt_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fmt
     - name: Fetch googletest
+      if: ${{ steps.paths.outputs.googletest_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests googletest
     - name: Fetch zstd
+      if: ${{ steps.paths.outputs.zstd_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zstd
     - name: Fetch boost
+      if: ${{ steps.paths.outputs.boost_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests boost
     - name: Fetch double-conversion
+      if: ${{ steps.paths.outputs.double-conversion_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests double-conversion
     - name: Fetch fast_float
+      if: ${{ steps.paths.outputs.fast_float_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fast_float
     - name: Fetch gflags
+      if: ${{ steps.paths.outputs.gflags_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests gflags
     - name: Fetch glog
+      if: ${{ steps.paths.outputs.glog_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests glog
     - name: Fetch libdwarf
+      if: ${{ steps.paths.outputs.libdwarf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libdwarf
     - name: Fetch libevent
+      if: ${{ steps.paths.outputs.libevent_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libevent
     - name: Fetch lz4
+      if: ${{ steps.paths.outputs.lz4_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests lz4
     - name: Fetch snappy
+      if: ${{ steps.paths.outputs.snappy_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests snappy
     - name: Fetch zlib
+      if: ${{ steps.paths.outputs.zlib_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zlib
     - name: Fetch bz2
+      if: ${{ steps.paths.outputs.bz2_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests bz2
     - name: Fetch openssl
+      if: ${{ steps.paths.outputs.openssl_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests openssl
     - name: Fetch liboqs
+      if: ${{ steps.paths.outputs.liboqs_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests liboqs
     - name: Fetch autoconf
+      if: ${{ steps.paths.outputs.autoconf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests autoconf
     - name: Fetch automake
+      if: ${{ steps.paths.outputs.automake_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests automake
     - name: Fetch libtool
+      if: ${{ steps.paths.outputs.libtool_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libtool
     - name: Fetch libsodium
+      if: ${{ steps.paths.outputs.libsodium_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libsodium
     - name: Fetch libiberty
+      if: ${{ steps.paths.outputs.libiberty_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libiberty
     - name: Fetch libunwind
+      if: ${{ steps.paths.outputs.libunwind_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libunwind
     - name: Fetch xz
+      if: ${{ steps.paths.outputs.xz_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests xz
     - name: Fetch folly
+      if: ${{ steps.paths.outputs.folly_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests folly
     - name: Fetch fizz
+      if: ${{ steps.paths.outputs.fizz_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fizz
     - name: Fetch mvfst
+      if: ${{ steps.paths.outputs.mvfst_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests mvfst
     - name: Fetch libffi
+      if: ${{ steps.paths.outputs.libffi_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libffi
     - name: Fetch ncurses
+      if: ${{ steps.paths.outputs.ncurses_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests ncurses
     - name: Fetch python
+      if: ${{ steps.paths.outputs.python_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests python
     - name: Fetch wangle
+      if: ${{ steps.paths.outputs.wangle_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests wangle
     - name: Fetch fbthrift
+      if: ${{ steps.paths.outputs.fbthrift_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fbthrift
     - name: Fetch fb303
+      if: ${{ steps.paths.outputs.fb303_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fb303
     - name: Fetch rust-shed
+      if: ${{ steps.paths.outputs.rust-shed_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests rust-shed
     - name: Build xxhash
+      if: ${{ steps.paths.outputs.xxhash_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests xxhash
     - name: Build ninja
+      if: ${{ steps.paths.outputs.ninja_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests ninja
     - name: Build cmake
+      if: ${{ steps.paths.outputs.cmake_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests cmake
     - name: Build fmt
+      if: ${{ steps.paths.outputs.fmt_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fmt
     - name: Build googletest
+      if: ${{ steps.paths.outputs.googletest_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests googletest
     - name: Build zstd
+      if: ${{ steps.paths.outputs.zstd_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests zstd
     - name: Build boost
+      if: ${{ steps.paths.outputs.boost_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests boost
     - name: Build double-conversion
+      if: ${{ steps.paths.outputs.double-conversion_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests double-conversion
     - name: Build fast_float
+      if: ${{ steps.paths.outputs.fast_float_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fast_float
     - name: Build gflags
+      if: ${{ steps.paths.outputs.gflags_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests gflags
     - name: Build glog
+      if: ${{ steps.paths.outputs.glog_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests glog
     - name: Build libdwarf
+      if: ${{ steps.paths.outputs.libdwarf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libdwarf
     - name: Build libevent
+      if: ${{ steps.paths.outputs.libevent_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libevent
     - name: Build lz4
+      if: ${{ steps.paths.outputs.lz4_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests lz4
     - name: Build snappy
+      if: ${{ steps.paths.outputs.snappy_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests snappy
     - name: Build zlib
+      if: ${{ steps.paths.outputs.zlib_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests zlib
     - name: Build bz2
+      if: ${{ steps.paths.outputs.bz2_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests bz2
     - name: Build openssl
+      if: ${{ steps.paths.outputs.openssl_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests openssl
     - name: Build liboqs
+      if: ${{ steps.paths.outputs.liboqs_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests liboqs
     - name: Build autoconf
+      if: ${{ steps.paths.outputs.autoconf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests autoconf
     - name: Build automake
+      if: ${{ steps.paths.outputs.automake_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests automake
     - name: Build libtool
+      if: ${{ steps.paths.outputs.libtool_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libtool
     - name: Build libsodium
+      if: ${{ steps.paths.outputs.libsodium_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libsodium
     - name: Build libiberty
+      if: ${{ steps.paths.outputs.libiberty_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libiberty
     - name: Build libunwind
+      if: ${{ steps.paths.outputs.libunwind_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libunwind
     - name: Build xz
+      if: ${{ steps.paths.outputs.xz_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests xz
     - name: Build folly
+      if: ${{ steps.paths.outputs.folly_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests folly
     - name: Build fizz
+      if: ${{ steps.paths.outputs.fizz_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fizz
     - name: Build mvfst
+      if: ${{ steps.paths.outputs.mvfst_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests mvfst
     - name: Build libffi
+      if: ${{ steps.paths.outputs.libffi_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libffi
     - name: Build ncurses
+      if: ${{ steps.paths.outputs.ncurses_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests ncurses
     - name: Build python
+      if: ${{ steps.paths.outputs.python_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests python
     - name: Build wangle
+      if: ${{ steps.paths.outputs.wangle_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests wangle
     - name: Build fbthrift
+      if: ${{ steps.paths.outputs.fbthrift_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fbthrift
     - name: Build fb303
+      if: ${{ steps.paths.outputs.fb303_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fb303
     - name: Build rust-shed
+      if: ${{ steps.paths.outputs.rust-shed_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests rust-shed
     - name: Build mononoke
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. mononoke  --project-install-prefix mononoke:/

--- a/.github/workflows/mononoke_mac.yml
+++ b/.github/workflows/mononoke_mac.yml
@@ -22,127 +22,190 @@ jobs:
       run: df -h
     - name: Install system deps
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive mononoke
+    - id: paths
+      name: Query paths
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages query-paths --recursive --src-dir=. mononoke  >> "$GITHUB_OUTPUT"
     - name: Install Rust Stable
       uses: dtolnay/rust-toolchain@stable
     - name: Fetch xxhash
+      if: ${{ steps.paths.outputs.xxhash_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests xxhash
     - name: Fetch openssl
+      if: ${{ steps.paths.outputs.openssl_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests openssl
     - name: Fetch ninja
+      if: ${{ steps.paths.outputs.ninja_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests ninja
     - name: Fetch cmake
+      if: ${{ steps.paths.outputs.cmake_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests cmake
     - name: Fetch fmt
+      if: ${{ steps.paths.outputs.fmt_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fmt
     - name: Fetch googletest
+      if: ${{ steps.paths.outputs.googletest_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests googletest
     - name: Fetch zstd
+      if: ${{ steps.paths.outputs.zstd_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zstd
     - name: Fetch boost
+      if: ${{ steps.paths.outputs.boost_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests boost
     - name: Fetch double-conversion
+      if: ${{ steps.paths.outputs.double-conversion_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests double-conversion
     - name: Fetch fast_float
+      if: ${{ steps.paths.outputs.fast_float_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fast_float
     - name: Fetch gflags
+      if: ${{ steps.paths.outputs.gflags_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests gflags
     - name: Fetch glog
+      if: ${{ steps.paths.outputs.glog_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests glog
     - name: Fetch libdwarf
+      if: ${{ steps.paths.outputs.libdwarf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libdwarf
     - name: Fetch libevent
+      if: ${{ steps.paths.outputs.libevent_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libevent
     - name: Fetch lz4
+      if: ${{ steps.paths.outputs.lz4_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests lz4
     - name: Fetch snappy
+      if: ${{ steps.paths.outputs.snappy_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests snappy
     - name: Fetch liboqs
+      if: ${{ steps.paths.outputs.liboqs_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests liboqs
     - name: Fetch zlib
+      if: ${{ steps.paths.outputs.zlib_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zlib
     - name: Fetch autoconf
+      if: ${{ steps.paths.outputs.autoconf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests autoconf
     - name: Fetch automake
+      if: ${{ steps.paths.outputs.automake_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests automake
     - name: Fetch libtool
+      if: ${{ steps.paths.outputs.libtool_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libtool
     - name: Fetch libsodium
+      if: ${{ steps.paths.outputs.libsodium_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libsodium
     - name: Fetch xz
+      if: ${{ steps.paths.outputs.xz_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests xz
     - name: Fetch folly
+      if: ${{ steps.paths.outputs.folly_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests folly
     - name: Fetch fizz
+      if: ${{ steps.paths.outputs.fizz_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fizz
     - name: Fetch mvfst
+      if: ${{ steps.paths.outputs.mvfst_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests mvfst
     - name: Fetch wangle
+      if: ${{ steps.paths.outputs.wangle_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests wangle
     - name: Fetch fbthrift
+      if: ${{ steps.paths.outputs.fbthrift_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fbthrift
     - name: Fetch fb303
+      if: ${{ steps.paths.outputs.fb303_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fb303
     - name: Fetch rust-shed
+      if: ${{ steps.paths.outputs.rust-shed_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests rust-shed
     - name: Build xxhash
+      if: ${{ steps.paths.outputs.xxhash_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests xxhash
     - name: Build openssl
+      if: ${{ steps.paths.outputs.openssl_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests openssl
     - name: Build ninja
+      if: ${{ steps.paths.outputs.ninja_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests ninja
     - name: Build cmake
+      if: ${{ steps.paths.outputs.cmake_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests cmake
     - name: Build fmt
+      if: ${{ steps.paths.outputs.fmt_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fmt
     - name: Build googletest
+      if: ${{ steps.paths.outputs.googletest_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests googletest
     - name: Build zstd
+      if: ${{ steps.paths.outputs.zstd_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests zstd
     - name: Build boost
+      if: ${{ steps.paths.outputs.boost_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests boost
     - name: Build double-conversion
+      if: ${{ steps.paths.outputs.double-conversion_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests double-conversion
     - name: Build fast_float
+      if: ${{ steps.paths.outputs.fast_float_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fast_float
     - name: Build gflags
+      if: ${{ steps.paths.outputs.gflags_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests gflags
     - name: Build glog
+      if: ${{ steps.paths.outputs.glog_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests glog
     - name: Build libdwarf
+      if: ${{ steps.paths.outputs.libdwarf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libdwarf
     - name: Build libevent
+      if: ${{ steps.paths.outputs.libevent_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libevent
     - name: Build lz4
+      if: ${{ steps.paths.outputs.lz4_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests lz4
     - name: Build snappy
+      if: ${{ steps.paths.outputs.snappy_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests snappy
     - name: Build liboqs
+      if: ${{ steps.paths.outputs.liboqs_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests liboqs
     - name: Build zlib
+      if: ${{ steps.paths.outputs.zlib_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests zlib
     - name: Build autoconf
+      if: ${{ steps.paths.outputs.autoconf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests autoconf
     - name: Build automake
+      if: ${{ steps.paths.outputs.automake_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests automake
     - name: Build libtool
+      if: ${{ steps.paths.outputs.libtool_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libtool
     - name: Build libsodium
+      if: ${{ steps.paths.outputs.libsodium_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libsodium
     - name: Build xz
+      if: ${{ steps.paths.outputs.xz_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests xz
     - name: Build folly
+      if: ${{ steps.paths.outputs.folly_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests folly
     - name: Build fizz
+      if: ${{ steps.paths.outputs.fizz_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fizz
     - name: Build mvfst
+      if: ${{ steps.paths.outputs.mvfst_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests mvfst
     - name: Build wangle
+      if: ${{ steps.paths.outputs.wangle_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests wangle
     - name: Build fbthrift
+      if: ${{ steps.paths.outputs.fbthrift_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fbthrift
     - name: Build fb303
+      if: ${{ steps.paths.outputs.fb303_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fb303
     - name: Build rust-shed
+      if: ${{ steps.paths.outputs.rust-shed_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests rust-shed
     - name: Build mononoke
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. mononoke  --project-install-prefix mononoke:/usr/local

--- a/.github/workflows/mononoke_mac.yml
+++ b/.github/workflows/mononoke_mac.yml
@@ -117,96 +117,486 @@ jobs:
     - name: Fetch rust-shed
       if: ${{ steps.paths.outputs.rust-shed_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests rust-shed
-    - name: Build xxhash
+    - name: Restore xxhash from cache
+      id: restore_xxhash
       if: ${{ steps.paths.outputs.xxhash_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.xxhash_INSTALL }}
+       key: ${{ steps.paths.outputs.xxhash_CACHE_KEY }}-install
+    - name: Build xxhash
+      if: ${{ steps.paths.outputs.xxhash_SOURCE && ! steps.restore_xxhash.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests xxhash
-    - name: Build openssl
+    - name: Save xxhash to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.xxhash_SOURCE && ! steps.restore_xxhash.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.xxhash_INSTALL }}
+       key: ${{ steps.paths.outputs.xxhash_CACHE_KEY }}-install
+    - name: Restore openssl from cache
+      id: restore_openssl
       if: ${{ steps.paths.outputs.openssl_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.openssl_INSTALL }}
+       key: ${{ steps.paths.outputs.openssl_CACHE_KEY }}-install
+    - name: Build openssl
+      if: ${{ steps.paths.outputs.openssl_SOURCE && ! steps.restore_openssl.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests openssl
-    - name: Build ninja
+    - name: Save openssl to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.openssl_SOURCE && ! steps.restore_openssl.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.openssl_INSTALL }}
+       key: ${{ steps.paths.outputs.openssl_CACHE_KEY }}-install
+    - name: Restore ninja from cache
+      id: restore_ninja
       if: ${{ steps.paths.outputs.ninja_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.ninja_INSTALL }}
+       key: ${{ steps.paths.outputs.ninja_CACHE_KEY }}-install
+    - name: Build ninja
+      if: ${{ steps.paths.outputs.ninja_SOURCE && ! steps.restore_ninja.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests ninja
-    - name: Build cmake
+    - name: Save ninja to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.ninja_SOURCE && ! steps.restore_ninja.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.ninja_INSTALL }}
+       key: ${{ steps.paths.outputs.ninja_CACHE_KEY }}-install
+    - name: Restore cmake from cache
+      id: restore_cmake
       if: ${{ steps.paths.outputs.cmake_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.cmake_INSTALL }}
+       key: ${{ steps.paths.outputs.cmake_CACHE_KEY }}-install
+    - name: Build cmake
+      if: ${{ steps.paths.outputs.cmake_SOURCE && ! steps.restore_cmake.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests cmake
-    - name: Build fmt
+    - name: Save cmake to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.cmake_SOURCE && ! steps.restore_cmake.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.cmake_INSTALL }}
+       key: ${{ steps.paths.outputs.cmake_CACHE_KEY }}-install
+    - name: Restore fmt from cache
+      id: restore_fmt
       if: ${{ steps.paths.outputs.fmt_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fmt_INSTALL }}
+       key: ${{ steps.paths.outputs.fmt_CACHE_KEY }}-install
+    - name: Build fmt
+      if: ${{ steps.paths.outputs.fmt_SOURCE && ! steps.restore_fmt.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fmt
-    - name: Build googletest
+    - name: Save fmt to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fmt_SOURCE && ! steps.restore_fmt.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fmt_INSTALL }}
+       key: ${{ steps.paths.outputs.fmt_CACHE_KEY }}-install
+    - name: Restore googletest from cache
+      id: restore_googletest
       if: ${{ steps.paths.outputs.googletest_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.googletest_INSTALL }}
+       key: ${{ steps.paths.outputs.googletest_CACHE_KEY }}-install
+    - name: Build googletest
+      if: ${{ steps.paths.outputs.googletest_SOURCE && ! steps.restore_googletest.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests googletest
-    - name: Build zstd
+    - name: Save googletest to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.googletest_SOURCE && ! steps.restore_googletest.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.googletest_INSTALL }}
+       key: ${{ steps.paths.outputs.googletest_CACHE_KEY }}-install
+    - name: Restore zstd from cache
+      id: restore_zstd
       if: ${{ steps.paths.outputs.zstd_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.zstd_INSTALL }}
+       key: ${{ steps.paths.outputs.zstd_CACHE_KEY }}-install
+    - name: Build zstd
+      if: ${{ steps.paths.outputs.zstd_SOURCE && ! steps.restore_zstd.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests zstd
-    - name: Build boost
+    - name: Save zstd to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.zstd_SOURCE && ! steps.restore_zstd.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.zstd_INSTALL }}
+       key: ${{ steps.paths.outputs.zstd_CACHE_KEY }}-install
+    - name: Restore boost from cache
+      id: restore_boost
       if: ${{ steps.paths.outputs.boost_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.boost_INSTALL }}
+       key: ${{ steps.paths.outputs.boost_CACHE_KEY }}-install
+    - name: Build boost
+      if: ${{ steps.paths.outputs.boost_SOURCE && ! steps.restore_boost.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests boost
-    - name: Build double-conversion
+    - name: Save boost to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.boost_SOURCE && ! steps.restore_boost.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.boost_INSTALL }}
+       key: ${{ steps.paths.outputs.boost_CACHE_KEY }}-install
+    - name: Restore double-conversion from cache
+      id: restore_double-conversion
       if: ${{ steps.paths.outputs.double-conversion_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.double-conversion_INSTALL }}
+       key: ${{ steps.paths.outputs.double-conversion_CACHE_KEY }}-install
+    - name: Build double-conversion
+      if: ${{ steps.paths.outputs.double-conversion_SOURCE && ! steps.restore_double-conversion.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests double-conversion
-    - name: Build fast_float
+    - name: Save double-conversion to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.double-conversion_SOURCE && ! steps.restore_double-conversion.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.double-conversion_INSTALL }}
+       key: ${{ steps.paths.outputs.double-conversion_CACHE_KEY }}-install
+    - name: Restore fast_float from cache
+      id: restore_fast_float
       if: ${{ steps.paths.outputs.fast_float_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fast_float_INSTALL }}
+       key: ${{ steps.paths.outputs.fast_float_CACHE_KEY }}-install
+    - name: Build fast_float
+      if: ${{ steps.paths.outputs.fast_float_SOURCE && ! steps.restore_fast_float.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fast_float
-    - name: Build gflags
+    - name: Save fast_float to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fast_float_SOURCE && ! steps.restore_fast_float.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fast_float_INSTALL }}
+       key: ${{ steps.paths.outputs.fast_float_CACHE_KEY }}-install
+    - name: Restore gflags from cache
+      id: restore_gflags
       if: ${{ steps.paths.outputs.gflags_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.gflags_INSTALL }}
+       key: ${{ steps.paths.outputs.gflags_CACHE_KEY }}-install
+    - name: Build gflags
+      if: ${{ steps.paths.outputs.gflags_SOURCE && ! steps.restore_gflags.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests gflags
-    - name: Build glog
+    - name: Save gflags to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.gflags_SOURCE && ! steps.restore_gflags.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.gflags_INSTALL }}
+       key: ${{ steps.paths.outputs.gflags_CACHE_KEY }}-install
+    - name: Restore glog from cache
+      id: restore_glog
       if: ${{ steps.paths.outputs.glog_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.glog_INSTALL }}
+       key: ${{ steps.paths.outputs.glog_CACHE_KEY }}-install
+    - name: Build glog
+      if: ${{ steps.paths.outputs.glog_SOURCE && ! steps.restore_glog.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests glog
-    - name: Build libdwarf
+    - name: Save glog to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.glog_SOURCE && ! steps.restore_glog.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.glog_INSTALL }}
+       key: ${{ steps.paths.outputs.glog_CACHE_KEY }}-install
+    - name: Restore libdwarf from cache
+      id: restore_libdwarf
       if: ${{ steps.paths.outputs.libdwarf_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libdwarf_INSTALL }}
+       key: ${{ steps.paths.outputs.libdwarf_CACHE_KEY }}-install
+    - name: Build libdwarf
+      if: ${{ steps.paths.outputs.libdwarf_SOURCE && ! steps.restore_libdwarf.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libdwarf
-    - name: Build libevent
+    - name: Save libdwarf to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libdwarf_SOURCE && ! steps.restore_libdwarf.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libdwarf_INSTALL }}
+       key: ${{ steps.paths.outputs.libdwarf_CACHE_KEY }}-install
+    - name: Restore libevent from cache
+      id: restore_libevent
       if: ${{ steps.paths.outputs.libevent_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libevent_INSTALL }}
+       key: ${{ steps.paths.outputs.libevent_CACHE_KEY }}-install
+    - name: Build libevent
+      if: ${{ steps.paths.outputs.libevent_SOURCE && ! steps.restore_libevent.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libevent
-    - name: Build lz4
+    - name: Save libevent to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libevent_SOURCE && ! steps.restore_libevent.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libevent_INSTALL }}
+       key: ${{ steps.paths.outputs.libevent_CACHE_KEY }}-install
+    - name: Restore lz4 from cache
+      id: restore_lz4
       if: ${{ steps.paths.outputs.lz4_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.lz4_INSTALL }}
+       key: ${{ steps.paths.outputs.lz4_CACHE_KEY }}-install
+    - name: Build lz4
+      if: ${{ steps.paths.outputs.lz4_SOURCE && ! steps.restore_lz4.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests lz4
-    - name: Build snappy
+    - name: Save lz4 to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.lz4_SOURCE && ! steps.restore_lz4.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.lz4_INSTALL }}
+       key: ${{ steps.paths.outputs.lz4_CACHE_KEY }}-install
+    - name: Restore snappy from cache
+      id: restore_snappy
       if: ${{ steps.paths.outputs.snappy_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.snappy_INSTALL }}
+       key: ${{ steps.paths.outputs.snappy_CACHE_KEY }}-install
+    - name: Build snappy
+      if: ${{ steps.paths.outputs.snappy_SOURCE && ! steps.restore_snappy.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests snappy
-    - name: Build liboqs
+    - name: Save snappy to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.snappy_SOURCE && ! steps.restore_snappy.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.snappy_INSTALL }}
+       key: ${{ steps.paths.outputs.snappy_CACHE_KEY }}-install
+    - name: Restore liboqs from cache
+      id: restore_liboqs
       if: ${{ steps.paths.outputs.liboqs_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.liboqs_INSTALL }}
+       key: ${{ steps.paths.outputs.liboqs_CACHE_KEY }}-install
+    - name: Build liboqs
+      if: ${{ steps.paths.outputs.liboqs_SOURCE && ! steps.restore_liboqs.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests liboqs
-    - name: Build zlib
+    - name: Save liboqs to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.liboqs_SOURCE && ! steps.restore_liboqs.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.liboqs_INSTALL }}
+       key: ${{ steps.paths.outputs.liboqs_CACHE_KEY }}-install
+    - name: Restore zlib from cache
+      id: restore_zlib
       if: ${{ steps.paths.outputs.zlib_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.zlib_INSTALL }}
+       key: ${{ steps.paths.outputs.zlib_CACHE_KEY }}-install
+    - name: Build zlib
+      if: ${{ steps.paths.outputs.zlib_SOURCE && ! steps.restore_zlib.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests zlib
-    - name: Build autoconf
+    - name: Save zlib to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.zlib_SOURCE && ! steps.restore_zlib.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.zlib_INSTALL }}
+       key: ${{ steps.paths.outputs.zlib_CACHE_KEY }}-install
+    - name: Restore autoconf from cache
+      id: restore_autoconf
       if: ${{ steps.paths.outputs.autoconf_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.autoconf_INSTALL }}
+       key: ${{ steps.paths.outputs.autoconf_CACHE_KEY }}-install
+    - name: Build autoconf
+      if: ${{ steps.paths.outputs.autoconf_SOURCE && ! steps.restore_autoconf.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests autoconf
-    - name: Build automake
+    - name: Save autoconf to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.autoconf_SOURCE && ! steps.restore_autoconf.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.autoconf_INSTALL }}
+       key: ${{ steps.paths.outputs.autoconf_CACHE_KEY }}-install
+    - name: Restore automake from cache
+      id: restore_automake
       if: ${{ steps.paths.outputs.automake_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.automake_INSTALL }}
+       key: ${{ steps.paths.outputs.automake_CACHE_KEY }}-install
+    - name: Build automake
+      if: ${{ steps.paths.outputs.automake_SOURCE && ! steps.restore_automake.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests automake
-    - name: Build libtool
+    - name: Save automake to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.automake_SOURCE && ! steps.restore_automake.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.automake_INSTALL }}
+       key: ${{ steps.paths.outputs.automake_CACHE_KEY }}-install
+    - name: Restore libtool from cache
+      id: restore_libtool
       if: ${{ steps.paths.outputs.libtool_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libtool_INSTALL }}
+       key: ${{ steps.paths.outputs.libtool_CACHE_KEY }}-install
+    - name: Build libtool
+      if: ${{ steps.paths.outputs.libtool_SOURCE && ! steps.restore_libtool.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libtool
-    - name: Build libsodium
+    - name: Save libtool to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libtool_SOURCE && ! steps.restore_libtool.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libtool_INSTALL }}
+       key: ${{ steps.paths.outputs.libtool_CACHE_KEY }}-install
+    - name: Restore libsodium from cache
+      id: restore_libsodium
       if: ${{ steps.paths.outputs.libsodium_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libsodium_INSTALL }}
+       key: ${{ steps.paths.outputs.libsodium_CACHE_KEY }}-install
+    - name: Build libsodium
+      if: ${{ steps.paths.outputs.libsodium_SOURCE && ! steps.restore_libsodium.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libsodium
-    - name: Build xz
+    - name: Save libsodium to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libsodium_SOURCE && ! steps.restore_libsodium.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libsodium_INSTALL }}
+       key: ${{ steps.paths.outputs.libsodium_CACHE_KEY }}-install
+    - name: Restore xz from cache
+      id: restore_xz
       if: ${{ steps.paths.outputs.xz_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.xz_INSTALL }}
+       key: ${{ steps.paths.outputs.xz_CACHE_KEY }}-install
+    - name: Build xz
+      if: ${{ steps.paths.outputs.xz_SOURCE && ! steps.restore_xz.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests xz
-    - name: Build folly
+    - name: Save xz to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.xz_SOURCE && ! steps.restore_xz.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.xz_INSTALL }}
+       key: ${{ steps.paths.outputs.xz_CACHE_KEY }}-install
+    - name: Restore folly from cache
+      id: restore_folly
       if: ${{ steps.paths.outputs.folly_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.folly_INSTALL }}
+       key: ${{ steps.paths.outputs.folly_CACHE_KEY }}-install
+    - name: Build folly
+      if: ${{ steps.paths.outputs.folly_SOURCE && ! steps.restore_folly.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests folly
-    - name: Build fizz
+    - name: Save folly to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.folly_SOURCE && ! steps.restore_folly.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.folly_INSTALL }}
+       key: ${{ steps.paths.outputs.folly_CACHE_KEY }}-install
+    - name: Restore fizz from cache
+      id: restore_fizz
       if: ${{ steps.paths.outputs.fizz_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fizz_INSTALL }}
+       key: ${{ steps.paths.outputs.fizz_CACHE_KEY }}-install
+    - name: Build fizz
+      if: ${{ steps.paths.outputs.fizz_SOURCE && ! steps.restore_fizz.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fizz
-    - name: Build mvfst
+    - name: Save fizz to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fizz_SOURCE && ! steps.restore_fizz.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fizz_INSTALL }}
+       key: ${{ steps.paths.outputs.fizz_CACHE_KEY }}-install
+    - name: Restore mvfst from cache
+      id: restore_mvfst
       if: ${{ steps.paths.outputs.mvfst_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.mvfst_INSTALL }}
+       key: ${{ steps.paths.outputs.mvfst_CACHE_KEY }}-install
+    - name: Build mvfst
+      if: ${{ steps.paths.outputs.mvfst_SOURCE && ! steps.restore_mvfst.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests mvfst
-    - name: Build wangle
+    - name: Save mvfst to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.mvfst_SOURCE && ! steps.restore_mvfst.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.mvfst_INSTALL }}
+       key: ${{ steps.paths.outputs.mvfst_CACHE_KEY }}-install
+    - name: Restore wangle from cache
+      id: restore_wangle
       if: ${{ steps.paths.outputs.wangle_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.wangle_INSTALL }}
+       key: ${{ steps.paths.outputs.wangle_CACHE_KEY }}-install
+    - name: Build wangle
+      if: ${{ steps.paths.outputs.wangle_SOURCE && ! steps.restore_wangle.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests wangle
-    - name: Build fbthrift
+    - name: Save wangle to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.wangle_SOURCE && ! steps.restore_wangle.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.wangle_INSTALL }}
+       key: ${{ steps.paths.outputs.wangle_CACHE_KEY }}-install
+    - name: Restore fbthrift from cache
+      id: restore_fbthrift
       if: ${{ steps.paths.outputs.fbthrift_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fbthrift_INSTALL }}
+       key: ${{ steps.paths.outputs.fbthrift_CACHE_KEY }}-install
+    - name: Build fbthrift
+      if: ${{ steps.paths.outputs.fbthrift_SOURCE && ! steps.restore_fbthrift.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fbthrift
-    - name: Build fb303
+    - name: Save fbthrift to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fbthrift_SOURCE && ! steps.restore_fbthrift.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fbthrift_INSTALL }}
+       key: ${{ steps.paths.outputs.fbthrift_CACHE_KEY }}-install
+    - name: Restore fb303 from cache
+      id: restore_fb303
       if: ${{ steps.paths.outputs.fb303_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fb303_INSTALL }}
+       key: ${{ steps.paths.outputs.fb303_CACHE_KEY }}-install
+    - name: Build fb303
+      if: ${{ steps.paths.outputs.fb303_SOURCE && ! steps.restore_fb303.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fb303
-    - name: Build rust-shed
+    - name: Save fb303 to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fb303_SOURCE && ! steps.restore_fb303.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fb303_INSTALL }}
+       key: ${{ steps.paths.outputs.fb303_CACHE_KEY }}-install
+    - name: Restore rust-shed from cache
+      id: restore_rust-shed
       if: ${{ steps.paths.outputs.rust-shed_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.rust-shed_INSTALL }}
+       key: ${{ steps.paths.outputs.rust-shed_CACHE_KEY }}-install
+    - name: Build rust-shed
+      if: ${{ steps.paths.outputs.rust-shed_SOURCE && ! steps.restore_rust-shed.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests rust-shed
+    - name: Save rust-shed to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.rust-shed_SOURCE && ! steps.restore_rust-shed.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.rust-shed_INSTALL }}
+       key: ${{ steps.paths.outputs.rust-shed_CACHE_KEY }}-install
     - name: Build mononoke
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. mononoke  --project-install-prefix mononoke:/usr/local
     - name: Copy artifacts

--- a/.github/workflows/sapling-cli-getdeps_linux.yml
+++ b/.github/workflows/sapling-cli-getdeps_linux.yml
@@ -151,120 +151,614 @@ jobs:
     - name: Fetch rust-shed
       if: ${{ steps.paths.outputs.rust-shed_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests rust-shed
-    - name: Build hexdump
+    - name: Restore hexdump from cache
+      id: restore_hexdump
       if: ${{ steps.paths.outputs.hexdump_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.hexdump_INSTALL }}
+       key: ${{ steps.paths.outputs.hexdump_CACHE_KEY }}-install
+    - name: Build hexdump
+      if: ${{ steps.paths.outputs.hexdump_SOURCE && ! steps.restore_hexdump.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests hexdump
-    - name: Build xxhash
+    - name: Save hexdump to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.hexdump_SOURCE && ! steps.restore_hexdump.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.hexdump_INSTALL }}
+       key: ${{ steps.paths.outputs.hexdump_CACHE_KEY }}-install
+    - name: Restore xxhash from cache
+      id: restore_xxhash
       if: ${{ steps.paths.outputs.xxhash_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.xxhash_INSTALL }}
+       key: ${{ steps.paths.outputs.xxhash_CACHE_KEY }}-install
+    - name: Build xxhash
+      if: ${{ steps.paths.outputs.xxhash_SOURCE && ! steps.restore_xxhash.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests xxhash
-    - name: Build bz2
+    - name: Save xxhash to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.xxhash_SOURCE && ! steps.restore_xxhash.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.xxhash_INSTALL }}
+       key: ${{ steps.paths.outputs.xxhash_CACHE_KEY }}-install
+    - name: Restore bz2 from cache
+      id: restore_bz2
       if: ${{ steps.paths.outputs.bz2_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.bz2_INSTALL }}
+       key: ${{ steps.paths.outputs.bz2_CACHE_KEY }}-install
+    - name: Build bz2
+      if: ${{ steps.paths.outputs.bz2_SOURCE && ! steps.restore_bz2.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests bz2
-    - name: Build ninja
+    - name: Save bz2 to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.bz2_SOURCE && ! steps.restore_bz2.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.bz2_INSTALL }}
+       key: ${{ steps.paths.outputs.bz2_CACHE_KEY }}-install
+    - name: Restore ninja from cache
+      id: restore_ninja
       if: ${{ steps.paths.outputs.ninja_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.ninja_INSTALL }}
+       key: ${{ steps.paths.outputs.ninja_CACHE_KEY }}-install
+    - name: Build ninja
+      if: ${{ steps.paths.outputs.ninja_SOURCE && ! steps.restore_ninja.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests ninja
-    - name: Build cmake
+    - name: Save ninja to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.ninja_SOURCE && ! steps.restore_ninja.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.ninja_INSTALL }}
+       key: ${{ steps.paths.outputs.ninja_CACHE_KEY }}-install
+    - name: Restore cmake from cache
+      id: restore_cmake
       if: ${{ steps.paths.outputs.cmake_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.cmake_INSTALL }}
+       key: ${{ steps.paths.outputs.cmake_CACHE_KEY }}-install
+    - name: Build cmake
+      if: ${{ steps.paths.outputs.cmake_SOURCE && ! steps.restore_cmake.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests cmake
-    - name: Build fmt
+    - name: Save cmake to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.cmake_SOURCE && ! steps.restore_cmake.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.cmake_INSTALL }}
+       key: ${{ steps.paths.outputs.cmake_CACHE_KEY }}-install
+    - name: Restore fmt from cache
+      id: restore_fmt
       if: ${{ steps.paths.outputs.fmt_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fmt_INSTALL }}
+       key: ${{ steps.paths.outputs.fmt_CACHE_KEY }}-install
+    - name: Build fmt
+      if: ${{ steps.paths.outputs.fmt_SOURCE && ! steps.restore_fmt.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fmt
-    - name: Build googletest
+    - name: Save fmt to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fmt_SOURCE && ! steps.restore_fmt.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fmt_INSTALL }}
+       key: ${{ steps.paths.outputs.fmt_CACHE_KEY }}-install
+    - name: Restore googletest from cache
+      id: restore_googletest
       if: ${{ steps.paths.outputs.googletest_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.googletest_INSTALL }}
+       key: ${{ steps.paths.outputs.googletest_CACHE_KEY }}-install
+    - name: Build googletest
+      if: ${{ steps.paths.outputs.googletest_SOURCE && ! steps.restore_googletest.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests googletest
-    - name: Build zstd
+    - name: Save googletest to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.googletest_SOURCE && ! steps.restore_googletest.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.googletest_INSTALL }}
+       key: ${{ steps.paths.outputs.googletest_CACHE_KEY }}-install
+    - name: Restore zstd from cache
+      id: restore_zstd
       if: ${{ steps.paths.outputs.zstd_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.zstd_INSTALL }}
+       key: ${{ steps.paths.outputs.zstd_CACHE_KEY }}-install
+    - name: Build zstd
+      if: ${{ steps.paths.outputs.zstd_SOURCE && ! steps.restore_zstd.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests zstd
-    - name: Build boost
+    - name: Save zstd to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.zstd_SOURCE && ! steps.restore_zstd.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.zstd_INSTALL }}
+       key: ${{ steps.paths.outputs.zstd_CACHE_KEY }}-install
+    - name: Restore boost from cache
+      id: restore_boost
       if: ${{ steps.paths.outputs.boost_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.boost_INSTALL }}
+       key: ${{ steps.paths.outputs.boost_CACHE_KEY }}-install
+    - name: Build boost
+      if: ${{ steps.paths.outputs.boost_SOURCE && ! steps.restore_boost.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests boost
-    - name: Build double-conversion
+    - name: Save boost to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.boost_SOURCE && ! steps.restore_boost.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.boost_INSTALL }}
+       key: ${{ steps.paths.outputs.boost_CACHE_KEY }}-install
+    - name: Restore double-conversion from cache
+      id: restore_double-conversion
       if: ${{ steps.paths.outputs.double-conversion_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.double-conversion_INSTALL }}
+       key: ${{ steps.paths.outputs.double-conversion_CACHE_KEY }}-install
+    - name: Build double-conversion
+      if: ${{ steps.paths.outputs.double-conversion_SOURCE && ! steps.restore_double-conversion.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests double-conversion
-    - name: Build fast_float
+    - name: Save double-conversion to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.double-conversion_SOURCE && ! steps.restore_double-conversion.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.double-conversion_INSTALL }}
+       key: ${{ steps.paths.outputs.double-conversion_CACHE_KEY }}-install
+    - name: Restore fast_float from cache
+      id: restore_fast_float
       if: ${{ steps.paths.outputs.fast_float_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fast_float_INSTALL }}
+       key: ${{ steps.paths.outputs.fast_float_CACHE_KEY }}-install
+    - name: Build fast_float
+      if: ${{ steps.paths.outputs.fast_float_SOURCE && ! steps.restore_fast_float.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fast_float
-    - name: Build gflags
+    - name: Save fast_float to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fast_float_SOURCE && ! steps.restore_fast_float.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fast_float_INSTALL }}
+       key: ${{ steps.paths.outputs.fast_float_CACHE_KEY }}-install
+    - name: Restore gflags from cache
+      id: restore_gflags
       if: ${{ steps.paths.outputs.gflags_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.gflags_INSTALL }}
+       key: ${{ steps.paths.outputs.gflags_CACHE_KEY }}-install
+    - name: Build gflags
+      if: ${{ steps.paths.outputs.gflags_SOURCE && ! steps.restore_gflags.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests gflags
-    - name: Build glog
+    - name: Save gflags to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.gflags_SOURCE && ! steps.restore_gflags.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.gflags_INSTALL }}
+       key: ${{ steps.paths.outputs.gflags_CACHE_KEY }}-install
+    - name: Restore glog from cache
+      id: restore_glog
       if: ${{ steps.paths.outputs.glog_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.glog_INSTALL }}
+       key: ${{ steps.paths.outputs.glog_CACHE_KEY }}-install
+    - name: Build glog
+      if: ${{ steps.paths.outputs.glog_SOURCE && ! steps.restore_glog.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests glog
-    - name: Build libdwarf
+    - name: Save glog to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.glog_SOURCE && ! steps.restore_glog.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.glog_INSTALL }}
+       key: ${{ steps.paths.outputs.glog_CACHE_KEY }}-install
+    - name: Restore libdwarf from cache
+      id: restore_libdwarf
       if: ${{ steps.paths.outputs.libdwarf_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libdwarf_INSTALL }}
+       key: ${{ steps.paths.outputs.libdwarf_CACHE_KEY }}-install
+    - name: Build libdwarf
+      if: ${{ steps.paths.outputs.libdwarf_SOURCE && ! steps.restore_libdwarf.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libdwarf
-    - name: Build libevent
+    - name: Save libdwarf to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libdwarf_SOURCE && ! steps.restore_libdwarf.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libdwarf_INSTALL }}
+       key: ${{ steps.paths.outputs.libdwarf_CACHE_KEY }}-install
+    - name: Restore libevent from cache
+      id: restore_libevent
       if: ${{ steps.paths.outputs.libevent_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libevent_INSTALL }}
+       key: ${{ steps.paths.outputs.libevent_CACHE_KEY }}-install
+    - name: Build libevent
+      if: ${{ steps.paths.outputs.libevent_SOURCE && ! steps.restore_libevent.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libevent
-    - name: Build lz4
+    - name: Save libevent to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libevent_SOURCE && ! steps.restore_libevent.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libevent_INSTALL }}
+       key: ${{ steps.paths.outputs.libevent_CACHE_KEY }}-install
+    - name: Restore lz4 from cache
+      id: restore_lz4
       if: ${{ steps.paths.outputs.lz4_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.lz4_INSTALL }}
+       key: ${{ steps.paths.outputs.lz4_CACHE_KEY }}-install
+    - name: Build lz4
+      if: ${{ steps.paths.outputs.lz4_SOURCE && ! steps.restore_lz4.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests lz4
-    - name: Build snappy
+    - name: Save lz4 to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.lz4_SOURCE && ! steps.restore_lz4.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.lz4_INSTALL }}
+       key: ${{ steps.paths.outputs.lz4_CACHE_KEY }}-install
+    - name: Restore snappy from cache
+      id: restore_snappy
       if: ${{ steps.paths.outputs.snappy_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.snappy_INSTALL }}
+       key: ${{ steps.paths.outputs.snappy_CACHE_KEY }}-install
+    - name: Build snappy
+      if: ${{ steps.paths.outputs.snappy_SOURCE && ! steps.restore_snappy.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests snappy
-    - name: Build zlib
+    - name: Save snappy to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.snappy_SOURCE && ! steps.restore_snappy.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.snappy_INSTALL }}
+       key: ${{ steps.paths.outputs.snappy_CACHE_KEY }}-install
+    - name: Restore zlib from cache
+      id: restore_zlib
       if: ${{ steps.paths.outputs.zlib_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.zlib_INSTALL }}
+       key: ${{ steps.paths.outputs.zlib_CACHE_KEY }}-install
+    - name: Build zlib
+      if: ${{ steps.paths.outputs.zlib_SOURCE && ! steps.restore_zlib.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests zlib
-    - name: Build python-setuptools
+    - name: Save zlib to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.zlib_SOURCE && ! steps.restore_zlib.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.zlib_INSTALL }}
+       key: ${{ steps.paths.outputs.zlib_CACHE_KEY }}-install
+    - name: Restore python-setuptools from cache
+      id: restore_python-setuptools
       if: ${{ steps.paths.outputs.python-setuptools_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.python-setuptools_INSTALL }}
+       key: ${{ steps.paths.outputs.python-setuptools_CACHE_KEY }}-install
+    - name: Build python-setuptools
+      if: ${{ steps.paths.outputs.python-setuptools_SOURCE && ! steps.restore_python-setuptools.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests python-setuptools
-    - name: Build openssl
+    - name: Save python-setuptools to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.python-setuptools_SOURCE && ! steps.restore_python-setuptools.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.python-setuptools_INSTALL }}
+       key: ${{ steps.paths.outputs.python-setuptools_CACHE_KEY }}-install
+    - name: Restore openssl from cache
+      id: restore_openssl
       if: ${{ steps.paths.outputs.openssl_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.openssl_INSTALL }}
+       key: ${{ steps.paths.outputs.openssl_CACHE_KEY }}-install
+    - name: Build openssl
+      if: ${{ steps.paths.outputs.openssl_SOURCE && ! steps.restore_openssl.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests openssl
-    - name: Build liboqs
+    - name: Save openssl to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.openssl_SOURCE && ! steps.restore_openssl.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.openssl_INSTALL }}
+       key: ${{ steps.paths.outputs.openssl_CACHE_KEY }}-install
+    - name: Restore liboqs from cache
+      id: restore_liboqs
       if: ${{ steps.paths.outputs.liboqs_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.liboqs_INSTALL }}
+       key: ${{ steps.paths.outputs.liboqs_CACHE_KEY }}-install
+    - name: Build liboqs
+      if: ${{ steps.paths.outputs.liboqs_SOURCE && ! steps.restore_liboqs.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests liboqs
-    - name: Build autoconf
+    - name: Save liboqs to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.liboqs_SOURCE && ! steps.restore_liboqs.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.liboqs_INSTALL }}
+       key: ${{ steps.paths.outputs.liboqs_CACHE_KEY }}-install
+    - name: Restore autoconf from cache
+      id: restore_autoconf
       if: ${{ steps.paths.outputs.autoconf_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.autoconf_INSTALL }}
+       key: ${{ steps.paths.outputs.autoconf_CACHE_KEY }}-install
+    - name: Build autoconf
+      if: ${{ steps.paths.outputs.autoconf_SOURCE && ! steps.restore_autoconf.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests autoconf
-    - name: Build automake
+    - name: Save autoconf to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.autoconf_SOURCE && ! steps.restore_autoconf.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.autoconf_INSTALL }}
+       key: ${{ steps.paths.outputs.autoconf_CACHE_KEY }}-install
+    - name: Restore automake from cache
+      id: restore_automake
       if: ${{ steps.paths.outputs.automake_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.automake_INSTALL }}
+       key: ${{ steps.paths.outputs.automake_CACHE_KEY }}-install
+    - name: Build automake
+      if: ${{ steps.paths.outputs.automake_SOURCE && ! steps.restore_automake.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests automake
-    - name: Build libtool
+    - name: Save automake to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.automake_SOURCE && ! steps.restore_automake.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.automake_INSTALL }}
+       key: ${{ steps.paths.outputs.automake_CACHE_KEY }}-install
+    - name: Restore libtool from cache
+      id: restore_libtool
       if: ${{ steps.paths.outputs.libtool_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libtool_INSTALL }}
+       key: ${{ steps.paths.outputs.libtool_CACHE_KEY }}-install
+    - name: Build libtool
+      if: ${{ steps.paths.outputs.libtool_SOURCE && ! steps.restore_libtool.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libtool
-    - name: Build libffi
+    - name: Save libtool to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libtool_SOURCE && ! steps.restore_libtool.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libtool_INSTALL }}
+       key: ${{ steps.paths.outputs.libtool_CACHE_KEY }}-install
+    - name: Restore libffi from cache
+      id: restore_libffi
       if: ${{ steps.paths.outputs.libffi_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libffi_INSTALL }}
+       key: ${{ steps.paths.outputs.libffi_CACHE_KEY }}-install
+    - name: Build libffi
+      if: ${{ steps.paths.outputs.libffi_SOURCE && ! steps.restore_libffi.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libffi
-    - name: Build ncurses
+    - name: Save libffi to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libffi_SOURCE && ! steps.restore_libffi.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libffi_INSTALL }}
+       key: ${{ steps.paths.outputs.libffi_CACHE_KEY }}-install
+    - name: Restore ncurses from cache
+      id: restore_ncurses
       if: ${{ steps.paths.outputs.ncurses_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.ncurses_INSTALL }}
+       key: ${{ steps.paths.outputs.ncurses_CACHE_KEY }}-install
+    - name: Build ncurses
+      if: ${{ steps.paths.outputs.ncurses_SOURCE && ! steps.restore_ncurses.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests ncurses
-    - name: Build python
+    - name: Save ncurses to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.ncurses_SOURCE && ! steps.restore_ncurses.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.ncurses_INSTALL }}
+       key: ${{ steps.paths.outputs.ncurses_CACHE_KEY }}-install
+    - name: Restore python from cache
+      id: restore_python
       if: ${{ steps.paths.outputs.python_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.python_INSTALL }}
+       key: ${{ steps.paths.outputs.python_CACHE_KEY }}-install
+    - name: Build python
+      if: ${{ steps.paths.outputs.python_SOURCE && ! steps.restore_python.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests python
-    - name: Build libsodium
+    - name: Save python to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.python_SOURCE && ! steps.restore_python.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.python_INSTALL }}
+       key: ${{ steps.paths.outputs.python_CACHE_KEY }}-install
+    - name: Restore libsodium from cache
+      id: restore_libsodium
       if: ${{ steps.paths.outputs.libsodium_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libsodium_INSTALL }}
+       key: ${{ steps.paths.outputs.libsodium_CACHE_KEY }}-install
+    - name: Build libsodium
+      if: ${{ steps.paths.outputs.libsodium_SOURCE && ! steps.restore_libsodium.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libsodium
-    - name: Build libiberty
+    - name: Save libsodium to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libsodium_SOURCE && ! steps.restore_libsodium.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libsodium_INSTALL }}
+       key: ${{ steps.paths.outputs.libsodium_CACHE_KEY }}-install
+    - name: Restore libiberty from cache
+      id: restore_libiberty
       if: ${{ steps.paths.outputs.libiberty_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libiberty_INSTALL }}
+       key: ${{ steps.paths.outputs.libiberty_CACHE_KEY }}-install
+    - name: Build libiberty
+      if: ${{ steps.paths.outputs.libiberty_SOURCE && ! steps.restore_libiberty.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libiberty
-    - name: Build libunwind
+    - name: Save libiberty to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libiberty_SOURCE && ! steps.restore_libiberty.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libiberty_INSTALL }}
+       key: ${{ steps.paths.outputs.libiberty_CACHE_KEY }}-install
+    - name: Restore libunwind from cache
+      id: restore_libunwind
       if: ${{ steps.paths.outputs.libunwind_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.libunwind_INSTALL }}
+       key: ${{ steps.paths.outputs.libunwind_CACHE_KEY }}-install
+    - name: Build libunwind
+      if: ${{ steps.paths.outputs.libunwind_SOURCE && ! steps.restore_libunwind.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libunwind
-    - name: Build xz
+    - name: Save libunwind to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.libunwind_SOURCE && ! steps.restore_libunwind.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.libunwind_INSTALL }}
+       key: ${{ steps.paths.outputs.libunwind_CACHE_KEY }}-install
+    - name: Restore xz from cache
+      id: restore_xz
       if: ${{ steps.paths.outputs.xz_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.xz_INSTALL }}
+       key: ${{ steps.paths.outputs.xz_CACHE_KEY }}-install
+    - name: Build xz
+      if: ${{ steps.paths.outputs.xz_SOURCE && ! steps.restore_xz.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests xz
-    - name: Build folly
+    - name: Save xz to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.xz_SOURCE && ! steps.restore_xz.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.xz_INSTALL }}
+       key: ${{ steps.paths.outputs.xz_CACHE_KEY }}-install
+    - name: Restore folly from cache
+      id: restore_folly
       if: ${{ steps.paths.outputs.folly_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.folly_INSTALL }}
+       key: ${{ steps.paths.outputs.folly_CACHE_KEY }}-install
+    - name: Build folly
+      if: ${{ steps.paths.outputs.folly_SOURCE && ! steps.restore_folly.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests folly
-    - name: Build fizz
+    - name: Save folly to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.folly_SOURCE && ! steps.restore_folly.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.folly_INSTALL }}
+       key: ${{ steps.paths.outputs.folly_CACHE_KEY }}-install
+    - name: Restore fizz from cache
+      id: restore_fizz
       if: ${{ steps.paths.outputs.fizz_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fizz_INSTALL }}
+       key: ${{ steps.paths.outputs.fizz_CACHE_KEY }}-install
+    - name: Build fizz
+      if: ${{ steps.paths.outputs.fizz_SOURCE && ! steps.restore_fizz.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fizz
-    - name: Build mvfst
+    - name: Save fizz to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fizz_SOURCE && ! steps.restore_fizz.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fizz_INSTALL }}
+       key: ${{ steps.paths.outputs.fizz_CACHE_KEY }}-install
+    - name: Restore mvfst from cache
+      id: restore_mvfst
       if: ${{ steps.paths.outputs.mvfst_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.mvfst_INSTALL }}
+       key: ${{ steps.paths.outputs.mvfst_CACHE_KEY }}-install
+    - name: Build mvfst
+      if: ${{ steps.paths.outputs.mvfst_SOURCE && ! steps.restore_mvfst.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests mvfst
-    - name: Build wangle
+    - name: Save mvfst to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.mvfst_SOURCE && ! steps.restore_mvfst.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.mvfst_INSTALL }}
+       key: ${{ steps.paths.outputs.mvfst_CACHE_KEY }}-install
+    - name: Restore wangle from cache
+      id: restore_wangle
       if: ${{ steps.paths.outputs.wangle_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.wangle_INSTALL }}
+       key: ${{ steps.paths.outputs.wangle_CACHE_KEY }}-install
+    - name: Build wangle
+      if: ${{ steps.paths.outputs.wangle_SOURCE && ! steps.restore_wangle.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests wangle
-    - name: Build fbthrift
+    - name: Save wangle to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.wangle_SOURCE && ! steps.restore_wangle.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.wangle_INSTALL }}
+       key: ${{ steps.paths.outputs.wangle_CACHE_KEY }}-install
+    - name: Restore fbthrift from cache
+      id: restore_fbthrift
       if: ${{ steps.paths.outputs.fbthrift_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fbthrift_INSTALL }}
+       key: ${{ steps.paths.outputs.fbthrift_CACHE_KEY }}-install
+    - name: Build fbthrift
+      if: ${{ steps.paths.outputs.fbthrift_SOURCE && ! steps.restore_fbthrift.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fbthrift
-    - name: Build fb303
+    - name: Save fbthrift to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fbthrift_SOURCE && ! steps.restore_fbthrift.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fbthrift_INSTALL }}
+       key: ${{ steps.paths.outputs.fbthrift_CACHE_KEY }}-install
+    - name: Restore fb303 from cache
+      id: restore_fb303
       if: ${{ steps.paths.outputs.fb303_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.fb303_INSTALL }}
+       key: ${{ steps.paths.outputs.fb303_CACHE_KEY }}-install
+    - name: Build fb303
+      if: ${{ steps.paths.outputs.fb303_SOURCE && ! steps.restore_fb303.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fb303
-    - name: Build rust-shed
+    - name: Save fb303 to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.fb303_SOURCE && ! steps.restore_fb303.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.fb303_INSTALL }}
+       key: ${{ steps.paths.outputs.fb303_CACHE_KEY }}-install
+    - name: Restore rust-shed from cache
+      id: restore_rust-shed
       if: ${{ steps.paths.outputs.rust-shed_SOURCE }}
+      uses: actions/cache/restore@v4
+      with:
+       path: ${{ steps.paths.outputs.rust-shed_INSTALL }}
+       key: ${{ steps.paths.outputs.rust-shed_CACHE_KEY }}-install
+    - name: Build rust-shed
+      if: ${{ steps.paths.outputs.rust-shed_SOURCE && ! steps.restore_rust-shed.outputs.cache-hit }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests rust-shed
+    - name: Save rust-shed to cache
+      uses: actions/cache/save@v4
+      if: ${{ steps.paths.outputs.rust-shed_SOURCE && ! steps.restore_rust-shed.outputs.cache-hit }}
+      with:
+       path: ${{ steps.paths.outputs.rust-shed_INSTALL }}
+       key: ${{ steps.paths.outputs.rust-shed_CACHE_KEY }}-install
     - name: Build sapling
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. sapling  --project-install-prefix sapling:/
     - name: Copy artifacts

--- a/.github/workflows/sapling-cli-getdeps_linux.yml
+++ b/.github/workflows/sapling-cli-getdeps_linux.yml
@@ -27,166 +27,243 @@ jobs:
     - name: Update system package info
       run: sudo apt-get update
     - name: Install system deps
-      run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive sapling
-    - name: Install packaging system deps
-      run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive patchelf
+      run: sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive sapling && sudo python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive patchelf
     - name: Install locale-gen
       run: sudo apt-get install locales
     - name: Ensure en_US.UTF-8 locale present
       run: sudo locale-gen en_US.UTF-8
+    - id: paths
+      name: Query paths
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages query-paths --recursive --src-dir=. sapling  >> "$GITHUB_OUTPUT"
     - name: Install Rust Stable
       uses: dtolnay/rust-toolchain@stable
     - name: Fetch hexdump
+      if: ${{ steps.paths.outputs.hexdump_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests hexdump
     - name: Fetch xxhash
+      if: ${{ steps.paths.outputs.xxhash_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests xxhash
     - name: Fetch bz2
+      if: ${{ steps.paths.outputs.bz2_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests bz2
     - name: Fetch ninja
+      if: ${{ steps.paths.outputs.ninja_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests ninja
     - name: Fetch cmake
+      if: ${{ steps.paths.outputs.cmake_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests cmake
     - name: Fetch fmt
+      if: ${{ steps.paths.outputs.fmt_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fmt
     - name: Fetch googletest
+      if: ${{ steps.paths.outputs.googletest_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests googletest
     - name: Fetch zstd
+      if: ${{ steps.paths.outputs.zstd_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zstd
     - name: Fetch boost
+      if: ${{ steps.paths.outputs.boost_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests boost
     - name: Fetch double-conversion
+      if: ${{ steps.paths.outputs.double-conversion_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests double-conversion
     - name: Fetch fast_float
+      if: ${{ steps.paths.outputs.fast_float_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fast_float
     - name: Fetch gflags
+      if: ${{ steps.paths.outputs.gflags_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests gflags
     - name: Fetch glog
+      if: ${{ steps.paths.outputs.glog_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests glog
     - name: Fetch libdwarf
+      if: ${{ steps.paths.outputs.libdwarf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libdwarf
     - name: Fetch libevent
+      if: ${{ steps.paths.outputs.libevent_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libevent
     - name: Fetch lz4
+      if: ${{ steps.paths.outputs.lz4_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests lz4
     - name: Fetch snappy
+      if: ${{ steps.paths.outputs.snappy_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests snappy
     - name: Fetch zlib
+      if: ${{ steps.paths.outputs.zlib_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests zlib
     - name: Fetch python-setuptools
+      if: ${{ steps.paths.outputs.python-setuptools_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests python-setuptools
     - name: Fetch openssl
+      if: ${{ steps.paths.outputs.openssl_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests openssl
     - name: Fetch liboqs
+      if: ${{ steps.paths.outputs.liboqs_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests liboqs
     - name: Fetch autoconf
+      if: ${{ steps.paths.outputs.autoconf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests autoconf
     - name: Fetch automake
+      if: ${{ steps.paths.outputs.automake_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests automake
     - name: Fetch libtool
+      if: ${{ steps.paths.outputs.libtool_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libtool
     - name: Fetch libffi
+      if: ${{ steps.paths.outputs.libffi_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libffi
     - name: Fetch ncurses
+      if: ${{ steps.paths.outputs.ncurses_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests ncurses
     - name: Fetch python
+      if: ${{ steps.paths.outputs.python_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests python
     - name: Fetch libsodium
+      if: ${{ steps.paths.outputs.libsodium_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libsodium
     - name: Fetch libiberty
+      if: ${{ steps.paths.outputs.libiberty_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libiberty
     - name: Fetch libunwind
+      if: ${{ steps.paths.outputs.libunwind_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests libunwind
     - name: Fetch xz
+      if: ${{ steps.paths.outputs.xz_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests xz
     - name: Fetch folly
+      if: ${{ steps.paths.outputs.folly_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests folly
     - name: Fetch fizz
+      if: ${{ steps.paths.outputs.fizz_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fizz
     - name: Fetch mvfst
+      if: ${{ steps.paths.outputs.mvfst_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests mvfst
     - name: Fetch wangle
+      if: ${{ steps.paths.outputs.wangle_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests wangle
     - name: Fetch fbthrift
+      if: ${{ steps.paths.outputs.fbthrift_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fbthrift
     - name: Fetch fb303
+      if: ${{ steps.paths.outputs.fb303_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fb303
     - name: Fetch rust-shed
+      if: ${{ steps.paths.outputs.rust-shed_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests rust-shed
     - name: Build hexdump
+      if: ${{ steps.paths.outputs.hexdump_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests hexdump
     - name: Build xxhash
+      if: ${{ steps.paths.outputs.xxhash_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests xxhash
     - name: Build bz2
+      if: ${{ steps.paths.outputs.bz2_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests bz2
     - name: Build ninja
+      if: ${{ steps.paths.outputs.ninja_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests ninja
     - name: Build cmake
+      if: ${{ steps.paths.outputs.cmake_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests cmake
     - name: Build fmt
+      if: ${{ steps.paths.outputs.fmt_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fmt
     - name: Build googletest
+      if: ${{ steps.paths.outputs.googletest_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests googletest
     - name: Build zstd
+      if: ${{ steps.paths.outputs.zstd_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests zstd
     - name: Build boost
+      if: ${{ steps.paths.outputs.boost_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests boost
     - name: Build double-conversion
+      if: ${{ steps.paths.outputs.double-conversion_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests double-conversion
     - name: Build fast_float
+      if: ${{ steps.paths.outputs.fast_float_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fast_float
     - name: Build gflags
+      if: ${{ steps.paths.outputs.gflags_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests gflags
     - name: Build glog
+      if: ${{ steps.paths.outputs.glog_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests glog
     - name: Build libdwarf
+      if: ${{ steps.paths.outputs.libdwarf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libdwarf
     - name: Build libevent
+      if: ${{ steps.paths.outputs.libevent_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libevent
     - name: Build lz4
+      if: ${{ steps.paths.outputs.lz4_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests lz4
     - name: Build snappy
+      if: ${{ steps.paths.outputs.snappy_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests snappy
     - name: Build zlib
+      if: ${{ steps.paths.outputs.zlib_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests zlib
     - name: Build python-setuptools
+      if: ${{ steps.paths.outputs.python-setuptools_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests python-setuptools
     - name: Build openssl
+      if: ${{ steps.paths.outputs.openssl_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests openssl
     - name: Build liboqs
+      if: ${{ steps.paths.outputs.liboqs_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests liboqs
     - name: Build autoconf
+      if: ${{ steps.paths.outputs.autoconf_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests autoconf
     - name: Build automake
+      if: ${{ steps.paths.outputs.automake_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests automake
     - name: Build libtool
+      if: ${{ steps.paths.outputs.libtool_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libtool
     - name: Build libffi
+      if: ${{ steps.paths.outputs.libffi_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libffi
     - name: Build ncurses
+      if: ${{ steps.paths.outputs.ncurses_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests ncurses
     - name: Build python
+      if: ${{ steps.paths.outputs.python_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests python
     - name: Build libsodium
+      if: ${{ steps.paths.outputs.libsodium_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libsodium
     - name: Build libiberty
+      if: ${{ steps.paths.outputs.libiberty_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libiberty
     - name: Build libunwind
+      if: ${{ steps.paths.outputs.libunwind_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests libunwind
     - name: Build xz
+      if: ${{ steps.paths.outputs.xz_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests xz
     - name: Build folly
+      if: ${{ steps.paths.outputs.folly_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests folly
     - name: Build fizz
+      if: ${{ steps.paths.outputs.fizz_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fizz
     - name: Build mvfst
+      if: ${{ steps.paths.outputs.mvfst_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests mvfst
     - name: Build wangle
+      if: ${{ steps.paths.outputs.wangle_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests wangle
     - name: Build fbthrift
+      if: ${{ steps.paths.outputs.fbthrift_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fbthrift
     - name: Build fb303
+      if: ${{ steps.paths.outputs.fb303_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fb303
     - name: Build rust-shed
+      if: ${{ steps.paths.outputs.rust-shed_SOURCE }}
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests rust-shed
     - name: Build sapling
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. sapling  --project-install-prefix sapling:/

--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -552,6 +552,33 @@ class ShowInstDirCmd(ProjectCmdBase):
         )
 
 
+@cmd("query-paths", "print the paths for tooling to use")
+class QueryPathsCmd(ProjectCmdBase):
+    def run_project_cmd(self, args, loader, manifest):
+        if args.recursive:
+            manifests = loader.manifests_in_dependency_order()
+        else:
+            manifests = [manifest]
+
+        for m in manifests:
+            fetcher = loader.create_fetcher(m)
+            if isinstance(fetcher, SystemPackageFetcher):
+                # We are guaranteed that if the fetcher is set to
+                # SystemPackageFetcher then this item is completely
+                # satisfied by the appropriate system packages
+                continue
+            src_dir = fetcher.get_src_dir()
+            print(f"{m.name}_SOURCE={src_dir}")
+
+    def setup_project_cmd_parser(self, parser):
+        parser.add_argument(
+            "--recursive",
+            help="print the transitive deps also",
+            action="store_true",
+            default=False,
+        )
+
+
 @cmd("show-source-dir", "print the source dir for a given project")
 class ShowSourceDirCmd(ProjectCmdBase):
     def run_project_cmd(self, args, loader, manifest):
@@ -1001,6 +1028,10 @@ class GenerateGitHubActionsCmd(ProjectCmdBase):
             manifest_ctx.set("test", "on")
         run_on = self.get_run_on(args)
 
+        tests_arg = "--no-tests "
+        if run_tests:
+            tests_arg = ""
+
         # Some projects don't do anything "useful" as a leaf project, only
         # as a dep for a leaf project. Check for those here; we don't want
         # to waste the effort scheduling them on CI.
@@ -1086,12 +1117,14 @@ jobs:
                 )
                 out.write("      shell: cmd\n")
 
-                # The git installation may not like long filenames, so tell it
-                # that we want it to use them!
                 out.write("    - name: Fix Git config\n")
-                out.write("      run: git config --system core.longpaths true\n")
-                out.write("    - name: Disable autocrlf\n")
-                out.write("      run: git config --system core.autocrlf false\n")
+                out.write("      run: >\n")
+                out.write("        git config --system core.longpaths true &&\n")
+                out.write("        git config --system core.autocrlf false &&\n")
+                # cxx crate needs symlinks enabled
+                out.write("        git config --system core.symlinks true\n")
+                # && is not supported on default windows powershell, so use cmd
+                out.write("      shell: cmd\n")
 
             out.write("    - uses: actions/checkout@v4\n")
 
@@ -1127,17 +1160,12 @@ jobs:
                 if build_opts.is_darwin():
                     # brew is installed as regular user
                     sudo_arg = ""
-                tests_arg = "--no-tests "
-                if run_tests:
-                    tests_arg = ""
-                out.write(
-                    f"      run: {sudo_arg}python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps {tests_arg}--recursive {manifest.name}\n"
-                )
+
+                system_deps_cmd = f"{sudo_arg}{getdepscmd}{allow_sys_arg} install-system-deps {tests_arg}--recursive {manifest.name}"
                 if build_opts.is_linux() or build_opts.is_freebsd():
-                    out.write("    - name: Install packaging system deps\n")
-                    out.write(
-                        f"      run: {sudo_arg}python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps {tests_arg}--recursive patchelf\n"
-                    )
+                    system_deps_cmd += f" && {sudo_arg}{getdepscmd}{allow_sys_arg} install-system-deps {tests_arg}--recursive patchelf"
+                out.write(f"      run: {system_deps_cmd}\n")
+
                 required_locales = manifest.get(
                     "github.actions", "required_locales", ctx=manifest_ctx
                 )
@@ -1151,6 +1179,18 @@ jobs:
                     for loc in required_locales.split():
                         out.write(f"    - name: Ensure {loc} locale present\n")
                         out.write(f"      run: {sudo_arg}locale-gen {loc}\n")
+
+            out.write("    - id: paths\n")
+            out.write("      name: Query paths\n")
+            if build_opts.is_windows():
+                out.write(
+                    f"      run: {getdepscmd}{allow_sys_arg} query-paths {tests_arg}--recursive --src-dir=. {manifest.name}  >> $env:GITHUB_OUTPUT\n"
+                )
+                out.write("      shell: pwsh\n")
+            else:
+                out.write(
+                    f'      run: {getdepscmd}{allow_sys_arg} query-paths {tests_arg}--recursive --src-dir=. {manifest.name}  >> "$GITHUB_OUTPUT"\n'
+                )
 
             projects = loader.manifests_in_dependency_order()
 
@@ -1179,24 +1219,31 @@ jobs:
                 if m.get_repo_url(ctx) != main_repo_url:
                     out.write("    - name: Fetch %s\n" % m.name)
                     out.write(
+                        f"      if: ${{{{ steps.paths.outputs.{m.name}_SOURCE }}}}\n"
+                    )
+                    out.write(
                         f"      run: {getdepscmd}{allow_sys_arg} fetch --no-tests {m.name}\n"
                     )
 
             for m in projects:
-                if m != manifest:
-                    if m.name == "rust":
-                        continue
-                    else:
-                        src_dir_arg = ""
-                        ctx = loader.ctx_gen.get_context(m.name)
-                        if main_repo_url and m.get_repo_url(ctx) == main_repo_url:
-                            # Its in the same repo, so src-dir is also .
-                            src_dir_arg = "--src-dir=. "
-                            has_same_repo_dep = True
-                        out.write("    - name: Build %s\n" % m.name)
-                        out.write(
-                            f"      run: {getdepscmd}{allow_sys_arg} build {build_type_arg}{src_dir_arg}{free_up_disk}--no-tests {m.name}\n"
-                        )
+                if m == manifest or m.name == "rust":
+                    continue
+                src_dir_arg = ""
+                ctx = loader.ctx_gen.get_context(m.name)
+                if main_repo_url and m.get_repo_url(ctx) == main_repo_url:
+                    # Its in the same repo, so src-dir is also .
+                    src_dir_arg = "--src-dir=. "
+                    has_same_repo_dep = True
+
+                out.write("    - name: Build %s\n" % m.name)
+                if not src_dir_arg:
+                    # only run the step if needed
+                    out.write(
+                        f"      if: ${{{{ steps.paths.outputs.{m.name}_SOURCE }}}}\n"
+                    )
+                out.write(
+                    f"      run: {getdepscmd}{allow_sys_arg} build {build_type_arg}{src_dir_arg}{free_up_disk}--no-tests {m.name}\n"
+                )
 
             out.write("    - name: Build %s\n" % manifest.name)
 
@@ -1213,12 +1260,8 @@ jobs:
             if has_same_repo_dep:
                 no_deps_arg = "--no-deps "
 
-            no_tests_arg = ""
-            if not run_tests:
-                no_tests_arg = "--no-tests "
-
             out.write(
-                f"      run: {getdepscmd}{allow_sys_arg} build {build_type_arg}{no_tests_arg}{no_deps_arg}--src-dir=. {manifest.name} {project_prefix}\n"
+                f"      run: {getdepscmd}{allow_sys_arg} build {build_type_arg}{tests_arg}{no_deps_arg}--src-dir=. {manifest.name} {project_prefix}\n"
             )
 
             out.write("    - name: Copy artifacts\n")

--- a/build/fbcode_builder/getdeps/cargo.py
+++ b/build/fbcode_builder/getdeps/cargo.py
@@ -82,6 +82,14 @@ class CargoBuilder(BuilderBase):
                 shutil.rmtree(dst)
         simple_copytree(src, dst)
 
+    def recreate_linked_dir(self, src, dst) -> None:
+        if os.path.isdir(dst):
+            if os.path.islink(dst):
+                os.remove(dst)
+            elif os.path.isdir(dst):
+                shutil.rmtree(dst)
+        os.symlink(src, dst)
+
     def cargo_config_file(self):
         build_source_dir = self.build_dir
         if self.cargo_config_file_subdir:
@@ -191,7 +199,9 @@ incremental = false
                     ],
                 )
 
-        self.recreate_dir(build_source_dir, os.path.join(self.inst_dir, "source"))
+        self.recreate_linked_dir(
+            build_source_dir, os.path.join(self.inst_dir, "source")
+        )
 
     def run_tests(self, schedule_type, owner, test_filter, retry, no_testpilot) -> None:
         if test_filter:

--- a/build/fbcode_builder/getdeps/fetcher.py
+++ b/build/fbcode_builder/getdeps/fetcher.py
@@ -244,7 +244,9 @@ class GitFetcher(Fetcher):
                     if not m:
                         raise Exception("Failed to parse rev from %s" % hash_file)
                     rev = m.group(1)
-                    print("Using pinned rev %s for %s" % (rev, repo_url))
+                    print(
+                        "Using pinned rev %s for %s" % (rev, repo_url), file=sys.stderr
+                    )
 
         self.rev = rev or "main"
         self.origin_repo = repo_url


### PR DESCRIPTION
Summary:
Speed up github builds with github actions CI caching based on the cache-key mechanism already present in getdeps. 

Cached fizz windows build completed in 22% of original time,  linux build in 54% of the original time,  and mac in 72% of original time.  This saves a lot of waiting around for PR builds on OSS changes as windows signal is usually the lagging one.  Speed ups will vary across the different Meta OSS projects.

Windows benefits most from caching dependencies as we don't use system packages there at all,  linux next as its default runner is slower than mac, and then finaly mac (the strongest hardware of the default github runners).

Github allows [up to 10GB cache per repo](https://github.blog/changelog/2021-11-23-github-actions-cache-size-is-now-increased-to-10gb-per-repository/), expiring data over capacity.  You can see the size of the caches generated in the [caches view of githhub actions UX](https://github.com/ahornby/fizz/actions/caches?query=sort%3Asize-desc),  looks like our usage is pretty small so far.

More background:
Github actions caching decides its own compression format (currently it prefers zstd), but they are free to change that in future, hence no .zstd suffix or similar on the cache keys.

Github actions caches from main are used from feature branches but not vice versa, hence a PR can't pollute cache for the trunk build.  This allows us to benefit from caching on main and PRs where dependency versions match.

The final item being built, and dependencies inside the same repo as the final are not cached.  A different mechanism would be necessary for those (e.g. using a tool like ccache/sccache or caching cargo/buck2 output).  This means that when building EdenFS, sapling could not be cached (its in the same repo), but folly could be as we have a key for it based on the folly-rev.txt file.

When there is a cache hit the build step is skipped using extension of the conditionals introduced in previous diff D67839708

Reviewed By: bigfootjon

Differential Revision: D67839730


