### PR TITLE
streampager: upgrade dependencies

### DIFF
--- a/eden/scm/lib/third-party/streampager/Cargo.toml
+++ b/eden/scm/lib/third-party/streampager/Cargo.toml
@@ -14,26 +14,26 @@ categories = ["command-line-utilities", "text-processing"]
 name = "streampager"
 
 [dependencies]
-bit-set = "0.5"
-dirs = "2.0"
+bit-set = "0.8.0"
+dirs = "6.0.0"
 enum_dispatch = "0.3.13"
-indexmap = "2.2.6"
-lazy_static = "1.4"
-lru = "0.12.3"
-memmap2 = "0.5.10"
-notify = { version = "5", optional = true }
-regex = "1.9.2"
+indexmap = "2.7.0"
+lazy_static = "1.5.0"
+lru = "0.12.5"
+memmap2 = "0.9.5"
+notify = { version = "8.0.0", optional = true }
+regex = "1.11.1"
 scopeguard = "1.2.0"
-serde = { version = "1.0.185", features = ["derive"] }
-smallvec = { version = "1.6.1", default-features = false }
-tempfile = "3.8"
-terminfo = "0.8"
-termwiz = "0.22"
-thiserror = "2"
-toml = "0.8.4"
-unicode-segmentation = "1.6.0"
-unicode-width = "=0.1.12"
-vec_map = "0.8"
+serde = { version = "1.0.217", features = ["derive"] }
+smallvec = { version = "1.13.2", default-features = false }
+tempfile = "3.15.0"
+terminfo = "0.8.0"
+termwiz = "0.22.0"
+thiserror = "2.0.11"
+toml = "0.8.19"
+unicode-segmentation = "1.12.0"
+unicode-width = "=0.2.0"
+vec_map = "0.8.2"
 
 [features]
 keymap-file = []


### PR DESCRIPTION
Many of streampager's dependencies were very old. The `dirs` version, for example was 5 years old. It seems it's about time to to upgrade.