### PR TITLE
Fix serde dependency not actually being optional in `renderdag`

### DIFF
--- a/eden/scm/lib/renderdag/Cargo.toml
+++ b/eden/scm/lib/renderdag/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT"
 name = "renderdag"
 
 [dependencies]
-bitflags = { version = "2.6", features = ["serde"] }
+bitflags = "2.6"
 serde = { version = "1.0.185", features = ["derive", "rc"], optional = true }
 
 [dev-dependencies]
@@ -23,4 +23,4 @@ unicode-width = "=0.1.12"
 
 [features]
 default = []
-serialize = ["serde"]
+serialize = ["dep:serde", "bitflags/serde"]


### PR DESCRIPTION
The `serde` feature of `bitflags` was unconditionally enabling `serde`.

Fixing this cuts a potentially critical chain in the compilation of jujutsu:
```
syn -> serde_derive -> serde -> bitflags -> rustix -> tempfile -> termwiz -> sapling-streampager
->
bitflags -> rustix -> ...
```