### PR TITLE
streampager: allow running Streampager without reading its config files

### DIFF
--- a/eden/scm/lib/third-party/streampager/src/config.rs
+++ b/eden/scm/lib/third-party/streampager/src/config.rs
@@ -233,6 +233,10 @@ impl Config {
         }
         self
     }
+
+    pub(crate) fn from_user_config() -> Self {
+        Self::from_config_file().with_env()
+    }
 }
 
 fn parse_bool(value: &str) -> Option<bool> {


### PR DESCRIPTION
This could be considered as a bug report/feature request instead of a PR.

Currently, there is no way for a calling program (like `sl` or `jj`) to start streampager without it trying to read
`$CONFIG/streampager/streampager.toml` and the environment variables `SP_INTERFACE_MODE`, `SP_SCROLL_PAST_EOF`, and `SP_READ_AHEAD_LINES`. This is undesireable if we'd like to control Streampager's behavior fully from `jj` config (or `sl` config). Sapling currently overrides the most important Streampager config from its own config anyway.

I'd like there to be a way to invoke Streampager with a given config. I carefully implemented it so that no changes to Sapling are required, though I think it'd also benefit from using the API I introduce here (and the old UI could be deprecated).

If there's a better way to achieve that than my approach here, I'd be happy to do that. Another, less invasive, possibility would be to simply make `Pager::config` public. However, this would mean that Streampager would uselessly read `$CONFIG/streampager/streampager.toml` even if the config is later fully overriden by `jj`.

As an aside, the docs for the config from
https://github.com/markbt/streampager#example-configuration do not seem to be fully correct, setting `interface_mode = "delayed"` as described there did not work for me. However, I'd rather not use that configuration method at all for my purposes with `jj`.

Cc: https://github.com/jj-vcs/jj/pull/4203#discussion_r1914281540, @yuja.

As ever, thanks for making it convenient for us to use Streampager in `jj`! :) 