### PR TITLE
fix: generate-command-markdown.py doesn't work --commands option

### DIFF
--- a/website/scripts/generate-command-markdown.py
+++ b/website/scripts/generate-command-markdown.py
@@ -400,7 +400,7 @@ def main(args):
 
     command_list = DEFAULT_COMMAND_LIST
     if args.commands is not None:
-        command_list = args.commands.split(",")
+        command_list = args.commands
 
     extract_docs_from_sapling = True
     rst_to_md = True


### PR DESCRIPTION
## Description

I ran the `./scripts/generate-command-markdown.py --commands pull` to update [my another PR](https://github.com/facebook/sapling/pull/1017).
However, it shows the below error.

```bash
Traceback (most recent call last):
  File "/home/jam/workspace/sapling/website/./scripts/generate-command-markdown.py", line 462, in <module>
    main(args)
    ~~~~^^^^^^
  File "/home/jam/workspace/sapling/website/./scripts/generate-command-markdown.py", line 403, in main
    command_list = args.commands.split(",")
                   ^^^^^^^^^^^^^^^^^^^
AttributeError: 'list' object has no attribute 'split'
```

To fix this error, I removed [the `split(",")`](https://github.com/facebook/sapling/blob/d129c4b0b143e82e5ef2eaae28f3337defa206fa/website/scripts/generate-command-markdown.py#L403) and ran again.
Finally I could regenerate the `pull.md` with the SUCCESS message.

```bash
extracting documentation from Sapling ...
translating rst to markdown ...
Regenerating documentation ...
Signing files ...
SUCCESS
```

In conclusion, I fixed [generate-command-markdown.py](https://github.com/facebook/sapling/blob/main/website/scripts/generate-command-markdown.py) --commands option.