### PR TITLE
(docs): Add pr to "other commands" in sl help outputs

### DIFF
--- a/eden/scm/sapling/help.py
+++ b/eden/scm/sapling/help.py
@@ -373,7 +373,7 @@ helphomecommands = [
         ["previous", "next", "split", "fold", "histedit", "absorb"],
     ),
     ("Undo changes", ["uncommit", "unamend", "undo", "redo"]),
-    ("Other commands", ["config", "doctor", "grep", "journal", "rage", "web"]),
+    ("Other commands", ["config", "doctor", "grep", "journal", "rage", "web", "pr"]),
 ]
 
 helphometopics = {"revisions", "filesets", "glossary", "patterns", "templating"}


### PR DESCRIPTION
- Fixes #1000
- "pr" is at the back, grouped with "Other commands"