### PR TITLE
Back out "Enable using python3.12 at build time (#957)"

### DIFF
--- a/eden/scm/contrib/pick_python.py
+++ b/eden/scm/contrib/pick_python.py
@@ -38,7 +38,8 @@ def main(args):
         + [
             p + EXE
             for p in [
-                "python3.12",
+                # Cannot use python3.12+ because distutils was removed in python3.12.
+                # https://github.com/facebook/sapling/issues/1032
                 "python3.11",
                 "python3.10",
                 "python3.9",


### PR DESCRIPTION
Revert https://github.com/facebook/sapling/pull/957 CC @bigfootjon 
To work around https://github.com/facebook/sapling/issues/1032

P.S. Can you please set up CI for Sapling to prevent regressions like this?