### PR TITLE
Do not require PYTHON_SYS_EXECUTABLE

### DIFF
--- a/eden/scm/lib/python-modules/build.rs
+++ b/eden/scm/lib/python-modules/build.rs
@@ -6,13 +6,19 @@
  */
 
 use std::env;
+use std::ffi::OsString;
 use std::path::Path;
 
 fn main() {
     println!("cargo:rerun-if-env-changed=PYTHON_SYS_EXECUTABLE");
 
-    let python = env::var_os("PYTHON_SYS_EXECUTABLE")
-        .expect("PYTHON_SYS_EXECUTABLE is required at build time");
+    let python = match env::var_os("PYTHON_SYS_EXECUTABLE") {
+        Some(python) => python,
+        None => {
+            println!("cargo:warning=PYTHON_SYS_EXECUTABLE is recommended at build time");
+            OsString::from("python3")
+        }
+    };
     let manifest_dir = env::var_os("CARGO_MANIFEST_DIR").unwrap();
     let manifest_dir = Path::new(&manifest_dir);
     let sys_path = manifest_dir.parent().unwrap().parent().unwrap();

--- a/eden/scm/saplingnative/bindings/modules/pycext/build.rs
+++ b/eden/scm/saplingnative/bindings/modules/pycext/build.rs
@@ -4,7 +4,8 @@
  * This software may be used and distributed according to the terms of the
  * GNU General Public License version 2.
  */
-
+use std::env;
+use std::ffi::OsString;
 use std::path::Path;
 use std::process::Command;
 
@@ -17,8 +18,13 @@ struct PythonSysConfig {
 impl PythonSysConfig {
     fn load() -> Self {
         println!("cargo:rerun-if-env-changed=PYTHON_SYS_EXECUTABLE");
-        let python = std::env::var("PYTHON_SYS_EXECUTABLE")
-            .expect("Building bindings.cext requires PYTHON_SYS_EXECUTABLE");
+        let python = match env::var_os("PYTHON_SYS_EXECUTABLE") {
+            Some(python) => python,
+            None => {
+                println!("cargo:warning=PYTHON_SYS_EXECUTABLE is recommended at build time");
+                OsString::from("python3")
+            }
+        };
         let script = concat!(
             "import sysconfig;",
             "print((sysconfig.get_config_var('CFLAGS') or '').strip());",


### PR DESCRIPTION
Add sensible default so the project could be opened in RustRover.