### PR TITLE
docs: use triple backticks instead of `@theme/CodeBlock` component

### DIFF
--- a/website/docs/introduction/installation.md
+++ b/website/docs/introduction/installation.md
@@ -24,9 +24,9 @@ First, make sure that [Homebrew](https://brew.sh/) is installed on your system. 
 
 Just run:
 
-<CodeBlock>
+```
 brew install sapling
-</CodeBlock>
+```
 
 #### Installing from our prebuilt bottles
 
@@ -58,10 +58,10 @@ xattr -r -d com.apple.quarantine ~/Downloads/{macArmAsset.name}
 
 Note that to clone larger repositories, you need to change the open files limit. We recommend doing it now so it doesn't bite you in the future:
 
-<CodeBlock>
+```
 echo "ulimit -n 1048576" >> ~/.bash_profile{'\n'}
 echo "ulimit -n 1048576" >> ~/.zshrc
-</CodeBlock>
+```
 
 ### Windows
 
@@ -73,9 +73,9 @@ Expand-Archive ~/Downloads/{windowsAsset.name} 'C:\Program Files'{'\n'}
 
 This will create `C:\Program Files\Sapling`, which you likely want to add to your `%PATH%` environment variable using:
 
-<CodeBlock>
+```
 setx PATH "$env:PATH;C:\Program Files\Sapling" -m
-</CodeBlock>
+```
 
 Note the following tools must be installed to leverage Sapling's full feature set:
 
@@ -108,17 +108,17 @@ sudo apt install -y ./{ubuntu22.name}
 
 #### Arch Linux (AUR)
 
-<CodeBlock>
+```
 yay -S sapling-scm-bin
-</CodeBlock>
+```
 
 #### Other Linux distros
 
 Sapling can be installed from Homebrew on Linux. First install Homebrew on your machine, then run
 
-<CodeBlock>
+```
 brew install sapling
-</CodeBlock>
+```
 
 ## Building from source
 


### PR DESCRIPTION
## Description

The code blocks in [Installation docs](https://sapling-scm.com/docs/introduction/installation) is different from the others.
Installation code blocks are surrounded by [`@theme/CodeBlock` component](https://docusaurus.io/docs/markdown-features/code-blocks#usage-in-jsx).
This is useful to use variables.
However, this makes the unnecessary new line.
Moreover, copy and paste button doesn't show.

---

### Image1: `@theme/CodeBlock` component

![theme_codeblock](https://github.com/user-attachments/assets/673c9d9f-b1b9-4aa0-9d6d-abf9a87505eb)

---

### Image2: triple backticks

![other_codeblock](https://github.com/user-attachments/assets/82a6f8d4-f13c-4ec5-acb8-9e81956ed433)

---

Therefore, we should use triple backticks instead of `@theme/CodeBlock` if variables don't exist.