### PR TITLE
docs: update Docusaurus README.md

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -1,16 +1,16 @@
 # Website
 
-This website is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator.
+This website is built using [Docusaurus](https://docusaurus.io/), a modern static website generator.
 
 ### Installation
 
-```
+```bash
 $ yarn
 ```
 
 ### Local Development
 
-```
+```bash
 $ yarn start
 ```
 
@@ -18,7 +18,7 @@ This command starts a local development server and opens up a browser window. Mo
 
 ### Build
 
-```
+```bash
 $ yarn build
 ```
 
@@ -28,13 +28,13 @@ This command generates static content into the `build` directory and can be serv
 
 Using SSH:
 
-```
+```bash
 $ USE_SSH=true yarn deploy
 ```
 
 Not using SSH:
 
-```
+```bash
 $ GIT_USER=<Your GitHub username> yarn deploy
 ```
 
@@ -44,6 +44,6 @@ If you are using GitHub pages for hosting, this command is a convenient way to b
 
 Some common defaults for linting/formatting have been set for you. If you integrate your project with an open source Continuous Integration system (e.g. Travis CI, CircleCI), you may check for issues using the following command.
 
-```
+```bash
 $ yarn ci
 ```


### PR DESCRIPTION
## Summary

Remove [version 2 ref](https://github.com/facebook/docusaurus/pull/9487) from Docusaurus [README.md](https://github.com/facebook/sapling/blob/main/website/README.md).

```diff
- This website is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator.
+ This website is built using [Docusaurus](https://docusaurus.io/), a modern static website generator.
```

[Add `bash`](https://github.com/facebook/docusaurus/pull/10952) to code block. 