### PR TITLE
website: add Hideable sidebar

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -79,6 +79,11 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     {
+      docs: {
+        sidebar: {
+          hideable: true,
+        },
+      },
       navbar: {
         title: 'Sapling',
         logo: {


### PR DESCRIPTION
## Description

By enabling the [`themeConfig.docs.sidebar.hideable`](https://docusaurus.io/docs/sidebar#hideable-sidebar) option, you can make the entire sidebar hideable, allowing users to better focus on the content.
This is especially useful when content is consumed on medium-sized screens (e.g. tablets).

![sidebar](https://github.com/user-attachments/assets/d4fa46ad-6ee0-4f17-a635-aabc3660d32a)
