### PR TITLE
Add extra newline to horizontal header

### DIFF
--- a/eden/scm/sapling/ext/github/pull_request_body.py
+++ b/eden/scm/sapling/ext/github/pull_request_body.py
@@ -8,7 +8,7 @@ from typing import List, Tuple, Union
 
 from .gh_submit import Repository
 
-_HORIZONTAL_RULE = "---"
+_HORIZONTAL_RULE = "\n---"
 _SAPLING_FOOTER_MARKER = "[//]: # (BEGIN SAPLING FOOTER)"
 
 


### PR DESCRIPTION

Currently there is no newline in the horizontal header, so when the extra new line is added to the body on line 118 the body comes in the form

```
<body>
<last line of body>
---
<sapling footer>
```

However, this causes the `<last line of body>` to be treated as a title in markdown causing the body to not be formatted quite correctly
