### PR TITLE
[ReviewStack] Display # of lines modified

### DIFF
--- a/eden/contrib/reviewstack/src/PullRequest.tsx
+++ b/eden/contrib/reviewstack/src/PullRequest.tsx
@@ -7,15 +7,16 @@
 
 import './PullRequest.css';
 
-import type {GitHubPullRequestParams} from './recoil';
+import type { GitHubPullRequestParams } from './recoil';
 
 import CenteredSpinner from './CenteredSpinner';
 import DiffView from './DiffView';
+import PullRequestChangeCount from './PullRequestChangeCount';
 import PullRequestLabels from './PullRequestLabels';
 import PullRequestReviewers from './PullRequestReviewers';
 import PullRequestSignals from './PullRequestSignals';
 import TrustedRenderedMarkdown from './TrustedRenderedMarkdown';
-import {stripStackInfoFromBodyHTML} from './ghstackUtils';
+import { stripStackInfoFromBodyHTML } from './ghstackUtils';
 import {
   gitHubPullRequest,
   gitHubOrgAndRepo,
@@ -24,10 +25,10 @@ import {
   gitHubPullRequestComparableVersions,
   gitHubPullRequestVersionDiff,
 } from './recoil';
-import {stripStackInfoFromSaplingBodyHTML} from './saplingStack';
-import {stackedPullRequest} from './stackState';
-import {Box, Text} from '@primer/react';
-import {Suspense, useEffect} from 'react';
+import { stripStackInfoFromSaplingBodyHTML } from './saplingStack';
+import { stackedPullRequest } from './stackState';
+import { Box, Text } from '@primer/react';
+import { Suspense, useEffect } from 'react';
 import {
   useRecoilValue,
   useRecoilValueLoadable,
@@ -55,13 +56,13 @@ function PullRequestBootstrap() {
   const number = useRecoilValue(gitHubPullRequestID);
   const orgAndRepo = useRecoilValue(gitHubOrgAndRepo);
   if (number != null && orgAndRepo != null) {
-    return <PullRequestWithParams params={{orgAndRepo, number}} />;
+    return <PullRequestWithParams params={{ orgAndRepo, number }} />;
   } else {
     return <Text>This is not a URL for a pull request.</Text>;
   }
 }
 
-function PullRequestWithParams({params}: {params: GitHubPullRequestParams}) {
+function PullRequestWithParams({ params }: { params: GitHubPullRequestParams }) {
   // When useRefreshPullRequest() is used to update gitHubPullRequestForParams,
   // we expect *most* of the data that comes back to be the same as before.
   // As such, we would prefer to avoid triggering <Suspense>, as the user would
@@ -104,7 +105,7 @@ function PullRequestDetails() {
   }
 
   const stack = pullRequestStack.contents;
-  const {bodyHTML} = pullRequest;
+  const { bodyHTML } = pullRequest;
   let pullRequestBodyHTML;
   switch (stack.type) {
     case 'no-stack':
@@ -133,9 +134,22 @@ function PullRequestDetails() {
       </Box>
       <PullRequestSignals />
       <Suspense fallback={<CenteredSpinner />}>
-        <PullRequestVersionDiff />
+        <div>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "row",
+              gap: ".5rem",
+              paddingBottom: ".5rem"
+            }}
+          >
+            <PullRequestChangeCount />
+          </div>
+          <PullRequestVersionDiff />
+        </div>
       </Suspense>
     </Box>
+
   );
 }
 
@@ -147,6 +161,8 @@ function PullRequestVersionDiff() {
     return (
       <Suspense
         fallback={<CenteredSpinner message={'Loading ' + diff.diff.length + ' changes...'} />}>
+        <div className="line-count">
+        </div>
         <DiffView diff={diff.diff} isPullRequest={true} />
       </Suspense>
     );

--- a/eden/contrib/reviewstack/src/PullRequestChangeCount.tsx
+++ b/eden/contrib/reviewstack/src/PullRequestChangeCount.tsx
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {gitHubPullRequest} from './recoil';
+import {CounterLabel} from '@primer/react';
+import {useRecoilValue} from 'recoil';
+
+export default function PullRequestChangeCount(): React.ReactElement | null {
+  const pullRequest = useRecoilValue(gitHubPullRequest);
+
+  if (pullRequest == null) {
+    return null;
+  }
+
+  const {additions, deletions} = pullRequest;
+
+  return (
+    <>
+    <CounterLabel sx={{ backgroundColor: "success.muted" }}>+{additions}</CounterLabel>
+    <CounterLabel scheme="primary" sx={{ backgroundColor: "danger.muted", color: "black" }}>-{deletions}</CounterLabel>
+    </>
+  );
+}

--- a/eden/contrib/reviewstack/src/queries/PullRequestQuery.graphql
+++ b/eden/contrib/reviewstack/src/queries/PullRequestQuery.graphql
@@ -7,6 +7,8 @@ query PullRequestQuery(
 ) {
   repository(name: $name, owner: $owner) {
     pullRequest(number: $pr) {
+      additions
+      deletions
       id
       number
       url


### PR DESCRIPTION

Currently ReviewStack doesn't show the number of lines modified like github, so this diff adds a simple display of it. Requires adding 2 additional fields to the graphQL query
