### PR TITLE
OSS edenfs_linux build fixes

### DIFF
--- a/CMake/EdenConfigChecks.cmake
+++ b/CMake/EdenConfigChecks.cmake
@@ -110,6 +110,7 @@ endif()
 
 find_package(python-toml REQUIRED)
 find_package(python-filelock REQUIRED)
+find_package(python-psutil REQUIRED)
 
 # pexpect is used by some of the integration tests.
 # If we don't find it we simply won't run those tests.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ else()
 endif()
 
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD 20)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
   message(STATUS "setting C++ standard to C++${CMAKE_CXX_STANDARD}")
 endif()

--- a/build/fbcode_builder/CMake/FBPythonBinary.cmake
+++ b/build/fbcode_builder/CMake/FBPythonBinary.cmake
@@ -236,6 +236,7 @@ function(add_fb_python_unittest TARGET)
   set(
     one_value_args
     WORKING_DIRECTORY BASE_DIR NAMESPACE TEST_LIST DISCOVERY_TIMEOUT
+    WORKING_DIRECTORY BASE_DIR NAMESPACE TEST_LIST DISCOVERY_TIMEOUT TYPE
   )
   fb_cmake_parse_args(
     ARG "" "${one_value_args}" "${multi_value_args}" "${ARGN}"
@@ -286,8 +287,13 @@ function(add_fb_python_unittest TARGET)
   list(APPEND ARG_SOURCES "${FB_PY_TEST_MAIN}=__main__.py")
   list(APPEND ARG_SOURCES "${test_modules_path}=__test_modules__.py")
 
+  if(NOT DEFINED ARG_TYPE)
+    set(ARG_TYPE "zipapp")
+  endif()
+
   add_fb_python_executable(
     "${TARGET}"
+    TYPE "${ARG_TYPE}"
     NAMESPACE "${ARG_NAMESPACE}"
     BASE_DIR "${ARG_BASE_DIR}"
     SOURCES ${ARG_SOURCES}

--- a/build/fbcode_builder/CMake/make_fbpy_archive.py
+++ b/build/fbcode_builder/CMake/make_fbpy_archive.py
@@ -7,6 +7,7 @@ import collections
 import errno
 import os
 import shutil
+import subprocess
 import sys
 import tempfile
 import zipapp
@@ -121,6 +122,36 @@ def populate_install_tree(inst_dir, path_map):
         init_path = os.path.join(inst_dir, dir_path, "__init__.py")
         with open(init_path, "w"):
             pass
+
+
+def build_pex(args, path_map):
+    """Create a self executing python binary using the PEX tool
+
+    This type of Python binary is more complex as it requires a third-party tool,
+    but it does support native language extensions (.so/.dll files).
+    """
+    dest_dir = os.path.dirname(args.output)
+    with tempfile.TemporaryDirectory(prefix="make_fbpy.", dir=dest_dir) as tmpdir:
+        inst_dir = os.path.join(tmpdir, "tree")
+        populate_install_tree(inst_dir, path_map)
+
+        if os.path.exists(os.path.join(inst_dir, "__main__.py")):
+            os.rename(
+                os.path.join(inst_dir, "__main__.py"),
+                os.path.join(inst_dir, "main.py"),
+            )
+            args.main = "main"
+
+        tmp_output = os.path.abspath(os.path.join(tmpdir, "output.exe"))
+        subprocess.check_call(
+            ["pex"] +
+            ["--output-file", tmp_output]+
+            ["--python", args.python] +
+            ["--sources-directory", inst_dir] +
+            ["-e", args.main]
+            )
+
+        os.replace(tmp_output, args.output)
 
 
 def build_zipapp(args, path_map):
@@ -262,6 +293,7 @@ def check_main_module(args, path_map):
 
 
 BUILD_TYPES = {
+    "pex": build_pex,
     "zipapp": build_zipapp,
     "dir": build_install_dir,
     "lib-install": install_library,

--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -432,29 +432,30 @@ class InstallSysDepsCmd(ProjectCmdBase):
                 merged += v
                 all_packages[k] = merged
 
-        cmd_args = None
+        cmd_argss = []
         if manager == "rpm":
             packages = sorted(set(all_packages["rpm"]))
             if packages:
-                cmd_args = ["sudo", "dnf", "install", "-y", "--skip-broken"] + packages
+                cmd_argss.append(["sudo", "dnf", "install", "-y", "--skip-broken"] + packages)
         elif manager == "deb":
             packages = sorted(set(all_packages["deb"]))
             if packages:
-                cmd_args = [
+                cmd_argss.append([
                     "sudo",
                     "--preserve-env=http_proxy",
                     "apt-get",
                     "install",
                     "-y",
-                ] + packages
+                ] + packages)
+                cmd_argss.append(["pip", "install", "pex"])
         elif manager == "homebrew":
             packages = sorted(set(all_packages["homebrew"]))
             if packages:
-                cmd_args = ["brew", "install"] + packages
+                cmd_argss.append(["brew", "install"] + packages)
         elif manager == "pacman-package":
             packages = sorted(list(set(all_packages["pacman-package"])))
             if packages:
-                cmd_args = ["pacman", "-S"] + packages
+                cmd_argss.append(["pacman", "-S"] + packages)
         else:
             host_tuple = loader.build_opts.host_type.as_tuple_string()
             print(
@@ -462,7 +463,7 @@ class InstallSysDepsCmd(ProjectCmdBase):
             )
             return
 
-        if cmd_args:
+        for cmd_args in cmd_argss:
             if args.dry_run:
                 print(" ".join(cmd_args))
             else:

--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -440,12 +440,22 @@ class InstallSysDepsCmd(ProjectCmdBase):
         elif manager == "deb":
             packages = sorted(set(all_packages["deb"]))
             if packages:
+                cmd_argss.append(["sed", "-i", "-e", "s/http:/https:/g", "/etc/apt/sources.list"])
+                cmd_argss.append([
+                    "sudo",
+                    "--preserve-env=http_proxy",
+                    "apt-get",
+                    "update",
+                ])
                 cmd_argss.append([
                     "sudo",
                     "--preserve-env=http_proxy",
                     "apt-get",
                     "install",
                     "-y",
+                    "--no-install-recommends",
+                    "-o",
+                    "Acquire::Retries=3",
                 ] + packages)
                 cmd_argss.append(["pip", "install", "pex"])
         elif manager == "homebrew":

--- a/build/fbcode_builder/manifests/eden
+++ b/build/fbcode_builder/manifests/eden
@@ -27,6 +27,7 @@ rocksdb
 re2
 libgit2
 pexpect
+python-psutil
 python-toml
 python-filelock
 edencommon

--- a/build/fbcode_builder/manifests/python-psutil
+++ b/build/fbcode_builder/manifests/python-psutil
@@ -1,0 +1,10 @@
+[manifest]
+name = python-psutil
+
+[download]
+url = https://files.pythonhosted.org/packages/bf/b9/b0eb3f3cbcb734d930fdf839431606844a825b23eaf9a6ab371edac8162c/psutil-7.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+sha256 = 4b1388a4f6875d7e2aff5c4ca1cc16c545ed41dd8bb596cefea80111db353a34
+
+[build]
+builder = python-wheel
+

--- a/build/fbcode_builder/manifests/zstd
+++ b/build/fbcode_builder/manifests/zstd
@@ -6,6 +6,7 @@ zstd
 
 # 18.04 zstd is too old
 [debs.not(all(distro=ubuntu,distro_vers="18.04"))]
+libclang-dev
 libzstd-dev
 zstd
 

--- a/eden/fs/cli_rs/edenfs-client/BUCK
+++ b/eden/fs/cli_rs/edenfs-client/BUCK
@@ -5,9 +5,6 @@ oncall("scm_client_infra")
 rust_library(
     name = "edenfs-client",
     srcs = glob(["src/**/*.rs"]),
-    named_deps = {
-        "hg_util": "//eden/scm/lib/util:util",
-    },
     os_deps = [
         (
             "windows",

--- a/eden/fs/cli_rs/edenfs-client/Cargo.toml
+++ b/eden/fs/cli_rs/edenfs-client/Cargo.toml
@@ -21,7 +21,6 @@ fbinit = { version = "0.2.0", git = "https://github.com/facebookexperimental/rus
 futures = { version = "0.3.30", features = ["async-await", "compat"] }
 futures_stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 hex = { version = "0.4.3", features = ["alloc"] }
-hg_util = { package = "sapling-util", version = "0.1.0", path = "../../../scm/lib/util" }
 lazy_static = { version = "1.5", features = ["spin_no_std"], default-features = false }
 libc = "0.2.139"
 parking_lot = { version = "0.12.1", features = ["send_guard"] }

--- a/eden/fs/privhelper/CMakeLists.txt
+++ b/eden/fs/privhelper/CMakeLists.txt
@@ -3,7 +3,7 @@
 # This software may be used and distributed according to the terms of the
 # GNU General Public License version 2.
 
-file(GLOB PRIVHELPER_SRCS "*.cpp")
+file(GLOB PRIVHELPER_SRCS "*.cpp" "priority/*.cpp")
 
 add_library(
   eden_fuse_privhelper STATIC

--- a/eden/fs/takeover/TakeoverData.cpp
+++ b/eden/fs/takeover/TakeoverData.cpp
@@ -279,12 +279,12 @@ void TakeoverData::serializeFd(
           "Unexpected FileDescriptorType {}", fmt::underlying(type));
   }
 
-  XLOGF(DBG7, "serializing file type: {} fd: {}", type, fileToSerialize->fd());
+  XLOGF(DBG7, "serializing file type: {} fd: {}", fmt::underlying(type), fileToSerialize->fd());
   files.push_back(std::move(*fileToSerialize));
 }
 
 void TakeoverData::deserializeFd(FileDescriptorType type, folly::File& file) {
-  XLOGF(DBG7, "deserializing file type: {} fd: {}", type, file.fd());
+  XLOGF(DBG7, "deserializing file type: {} fd: {}", fmt::underlying(type), file.fd());
   switch (type) {
     case FileDescriptorType::LOCK_FILE:
       lockFile = std::move(file);

--- a/eden/integration/CMakeLists.txt
+++ b/eden/integration/CMakeLists.txt
@@ -44,6 +44,7 @@ endif()
 
 add_fb_python_unittest(
   integration_tests
+  TYPE "pex"
   SOURCES ${INTEGRATION_SRCS}
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
   DEPENDS

--- a/eden/integration/CMakeLists.txt
+++ b/eden/integration/CMakeLists.txt
@@ -51,6 +51,7 @@ add_fb_python_unittest(
     edenfsctl.real.main_lib
     eden_integration_lib
     eden_hg_integration_lib
+    python-psutil::python-psutil
   ENV
     "CMAKE_SOURCE_DIR=${CMAKE_SOURCE_DIR}"
 )

--- a/eden/scm/lib/backingstore/BUCK
+++ b/eden/scm/lib/backingstore/BUCK
@@ -52,6 +52,14 @@ rust_library(
             }},
             "features": {"fb": ["sapling-configloader/fb"]},
             "lib": {"name": "backingstore"},
+            "lints": {
+                "rust": {
+                    "unexpected_cfgs": {
+                        "check-cfg": ["cfg(fbcode_build)"],
+                        "level": "warn",
+                    },
+                },
+            },
             "package": {
                 "authors": ["Meta Source Control Team <sourcecontrol-dev@meta.com>"],
                 "homepage": "https://sapling-scm.com/",

--- a/eden/scm/lib/backingstore/CMakeLists.txt
+++ b/eden/scm/lib/backingstore/CMakeLists.txt
@@ -10,7 +10,7 @@ if (IS_FB_BUILD)
     USE_CXX_INCLUDE
     FEATURES fb)
 else()
-  rust_static_library(rust_backingstore CRATE backingstore USE_CXX_INCLUDE)
+  rust_static_library(rust_backingstore CRATE sapling-backingstore USE_CXX_INCLUDE)
 endif()
 
 install_rust_static_library(

--- a/eden/scm/lib/backingstore/src/ffi.rs
+++ b/eden/scm/lib/backingstore/src/ffi.rs
@@ -15,6 +15,7 @@ use anyhow::Result;
 use anyhow::anyhow;
 use cxx::SharedPtr;
 use cxx::UniquePtr;
+#[cfg(fbcode_build)]
 use iobuf::IOBuf;
 use storemodel::FileAuxData as ScmStoreFileAuxData;
 use types::FetchContext;
@@ -118,6 +119,7 @@ pub(crate) mod ffi {
     unsafe extern "C++" {
         include!("eden/scm/lib/backingstore/include/ffi.h");
 
+        #[cfg(fbcode_build)]
         #[namespace = "folly"]
         type IOBuf = iobuf::IOBuf;
 
@@ -140,6 +142,7 @@ pub(crate) mod ffi {
             tree: SharedPtr<TreeAuxData>,
         );
 
+        #[cfg(fbcode_build)]
         unsafe fn sapling_backingstore_get_blob_batch_handler(
             resolve_state: SharedPtr<GetBlobBatchResolver>,
             index: usize,
@@ -193,12 +196,14 @@ pub(crate) mod ffi {
             resolver: SharedPtr<GetTreeAuxBatchResolver>,
         );
 
+        #[cfg(fbcode_build)]
         pub fn sapling_backingstore_get_blob(
             store: &BackingStore,
             node: &[u8],
             fetch_mode: FetchMode,
         ) -> Result<UniquePtr<IOBuf>>;
 
+        #[cfg(fbcode_build)]
         pub fn sapling_backingstore_get_blob_batch(
             store: &BackingStore,
             requests: &[Request],
@@ -430,6 +435,7 @@ pub fn sapling_backingstore_get_tree_aux_batch(
     );
 }
 
+#[cfg(fbcode_build)]
 pub fn sapling_backingstore_get_blob(
     store: &BackingStore,
     node: &[u8],
@@ -445,6 +451,7 @@ pub fn sapling_backingstore_get_blob(
     }
 }
 
+#[cfg(fbcode_build)]
 pub fn sapling_backingstore_get_blob_batch(
     store: &BackingStore,
     requests: &[ffi::Request],


### PR DESCRIPTION
This change should be landed after or instead of #1100 (it includes that as the first commit)

This PR fixes a number of build issues in the OSS build. Each individual fix can be verified by running:

```
act --container-architecture linux/x86_64 -W ".github/workflows/edenfs_linux.yml"
```

on the prior commit. (Though, due to job prioritization, sometimes you may find a different issue first.)

The above build still does not complete due to a lack of thrift file generation, but that modification will be largely independent of this "stack".