### PR TITLE
Builder fixes

### DIFF
--- a/build/fbcode_builder/CMake/FBPythonBinary.cmake
+++ b/build/fbcode_builder/CMake/FBPythonBinary.cmake
@@ -235,7 +235,6 @@ function(add_fb_python_unittest TARGET)
   set(multi_value_args SOURCES DEPENDS ENV PROPERTIES)
   set(
     one_value_args
-    WORKING_DIRECTORY BASE_DIR NAMESPACE TEST_LIST DISCOVERY_TIMEOUT
     WORKING_DIRECTORY BASE_DIR NAMESPACE TEST_LIST DISCOVERY_TIMEOUT TYPE
   )
   fb_cmake_parse_args(

--- a/build/fbcode_builder/CMake/RustStaticLibrary.cmake
+++ b/build/fbcode_builder/CMake/RustStaticLibrary.cmake
@@ -124,9 +124,9 @@ function(rust_static_library TARGET)
   set(rust_staticlib "${CMAKE_CURRENT_BINARY_DIR}/${target_dir}/${staticlib_name}")
 
   if(DEFINED ARG_FEATURES)
-    set(cargo_flags build $<IF:$<CONFIG:Debug>,,--release> -p ${crate_name} --features ${ARG_FEATURES})
+    set(cargo_flags build $<IF:$<CONFIG:Debug>,,--release> -p ${crate_name} --features ${ARG_FEATURES} --config fbcode_build=false)
   else()
-    set(cargo_flags build $<IF:$<CONFIG:Debug>,,--release> -p ${crate_name})
+    set(cargo_flags build $<IF:$<CONFIG:Debug>,,--release> -p ${crate_name} --config fbcode_build=false)
   endif()
   if(USE_CARGO_VENDOR)
     set(extra_cargo_env "CARGO_HOME=${RUST_CARGO_HOME}")
@@ -515,9 +515,12 @@ function(rust_cxx_bridge TARGET CXX_BRIDGE_FILE)
       "${CMAKE_CURRENT_BINARY_DIR}/${cxx_source}"
     COMMAND
       ${cxxbridge} ${rust_source_path}
-        --header --output "${CMAKE_CURRENT_BINARY_DIR}/${cxx_header}"
+        --cfg fbcode_build=false
+        --header
+        --output "${CMAKE_CURRENT_BINARY_DIR}/${cxx_header}"
     COMMAND
       ${cxxbridge} ${rust_source_path}
+        --cfg fbcode_build=false
         --output "${CMAKE_CURRENT_BINARY_DIR}/${cxx_source}"
         --include "${cxx_header}"
     DEPENDS "cxxbridge_v${cxx_required_version}" "${rust_source_path}"

--- a/build/fbcode_builder/manifests/zstd
+++ b/build/fbcode_builder/manifests/zstd
@@ -6,6 +6,7 @@ zstd
 
 # 18.04 zstd is too old
 [debs.not(all(distro=ubuntu,distro_vers="18.04"))]
+libclang-dev
 libzstd-dev
 zstd
 


### PR DESCRIPTION
Three independent changes:

1. Fix merge damage in FBPythonBinary.cmake
2. Define `fbcode_build=False` in rust builds to eliminate errors/warnings
3. Add a missing dependency to zstd

Tested by building sapling using the GitHub action (won't run fully until other PRs land):
```
act --container-architecture linux/x86_64 -W .github/workflows/edenfs_linux.yml
```