### PR TITLE
fix(oss): fix LOG/fmt issues for "stock" fmt

### DIFF
--- a/eden/fs/fuse/FuseChannel.cpp
+++ b/eden/fs/fuse/FuseChannel.cpp
@@ -9,7 +9,7 @@
 
 #include "eden/fs/fuse/FuseChannel.h"
 #include <boost/cast.hpp>
-#include <fmt/core.h>
+#include <fmt/base.h>
 #include <folly/futures/Future.h>
 #include <folly/logging/xlog.h>
 #include <folly/system/ThreadName.h>

--- a/eden/fs/fuse/FuseChannel.h
+++ b/eden/fs/fuse/FuseChannel.h
@@ -1004,7 +1004,7 @@ struct formatter<facebook::eden::FuseChannel::InvalidationEntry>
   template <typename FormatContext>
   auto format(
       const facebook::eden::FuseChannel::InvalidationEntry& entry,
-      FormatContext& ctx) {
+      FormatContext& ctx) const {
     auto out = ctx.out();
     switch (entry.type) {
       case facebook::eden::FuseChannel::InvalidationType::INODE:

--- a/eden/fs/inodes/EdenMount.cpp
+++ b/eden/fs/inodes/EdenMount.cpp
@@ -2529,13 +2529,13 @@ folly::Future<folly::Unit> EdenMount::startFsChannel(bool readOnly) {
                XLOGF(
                    ERR,
                    "Failed to create mount point (hanging mount): {}: {}",
-                   e.code(),
+                   e.code().value(),
                    e.what());
              } else {
                XLOGF(
                    ERR,
                    "Failed to create mount point: {}: {}",
-                   e.code(),
+                   e.code().value(),
                    e.what());
                throw;
              }

--- a/eden/fs/inodes/FileInode.h
+++ b/eden/fs/inodes/FileInode.h
@@ -60,6 +60,19 @@ struct FileInodeState {
     MATERIALIZED_IN_OVERLAY,
   };
 
+  friend inline auto format_as(Tag t) {
+    switch (t) {
+      case BLOB_NOT_LOADING:
+        return "BLOB_NOT_LOADING";
+      case BLOB_LOADING:
+        return "BLOB_LOADING";
+      case MATERIALIZED_IN_OVERLAY:
+        return "MATERIALIZED_IN_OVERLAY";
+      default:
+        return "UNKNOWN";
+    }
+  }
+
   explicit FileInodeState(const ObjectId* id);
   explicit FileInodeState();
   ~FileInodeState();

--- a/eden/fs/inodes/test/CheckoutTest.cpp
+++ b/eden/fs/inodes/test/CheckoutTest.cpp
@@ -691,7 +691,7 @@ void runModifyConflictTests(CheckoutMode checkoutMode) {
   for (StringPiece path : {"a/b/aaa.txt", "a/b/mmm.txt", "a/b/zzz.tzt"}) {
     for (auto loadType : kAllLoadTypes) {
       SCOPED_TRACE(fmt::format(
-          "path {} load type {} force={}", path, loadType, checkoutMode));
+          "path {} load type {} force={}", path, loadType, static_cast<int>(checkoutMode)));
       testModifyConflict(
           path,
           loadType,

--- a/eden/fs/takeover/TakeoverData.cpp
+++ b/eden/fs/takeover/TakeoverData.cpp
@@ -279,12 +279,12 @@ void TakeoverData::serializeFd(
           "Unexpected FileDescriptorType {}", fmt::underlying(type));
   }
 
-  XLOGF(DBG7, "serializing file type: {} fd: {}", type, fileToSerialize->fd());
+  XLOGF(DBG7, "serializing file type: {} fd: {}", fmt::underlying(type), fileToSerialize->fd());
   files.push_back(std::move(*fileToSerialize));
 }
 
 void TakeoverData::deserializeFd(FileDescriptorType type, folly::File& file) {
-  XLOGF(DBG7, "deserializing file type: {} fd: {}", type, file.fd());
+  XLOGF(DBG7, "deserializing file type: {} fd: {}", fmt::underlying(type), file.fd());
   switch (type) {
     case FileDescriptorType::LOCK_FILE:
       lockFile = std::move(file);

--- a/eden/fs/utils/GlobNodeImpl.cpp
+++ b/eden/fs/utils/GlobNodeImpl.cpp
@@ -28,7 +28,7 @@ struct fmt::formatter<facebook::eden::detail::Indentation> {
   template <typename FormatContext>
   auto format(
       const facebook::eden::detail::Indentation& indentation,
-      FormatContext& ctx) {
+      FormatContext& ctx) const {
     return std::fill_n(ctx.out(), indentation.width, ' ');
   }
 };


### PR DESCRIPTION
Summary:
Several build issues because sapling currently depends on the custom behavior of an internal fork of the C++ fmt library.

Test Plan:

Confirm the following gets past the compilation step without formatter issues
```
act --container-architecture linux/x86_64 -W ".github/workflows/edenfs_linux.yml"
```