### PR TITLE
fix(oss): Stubs that get edenfsctl to run (at least as far as help)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,7 @@ set_property(
 )
 add_subdirectory(eden/fs)
 add_subdirectory(eden/integration)
+add_subdirectory(eden/scm)
 add_subdirectory(eden/scm/lib)
 add_subdirectory(eden/test_support)
 add_subdirectory(eden/scm/exec/eden_apfs_mount_helper)

--- a/eden/fs/cli/CMakeLists.txt
+++ b/eden/fs/cli/CMakeLists.txt
@@ -18,6 +18,7 @@ add_fb_python_executable(
   DEPENDS
     eden_py
     eden_overlay_thrift_py
+    eden_scm_redact
     eden_service_thrift_py
     FBThrift::thrift_py_inspect
     python-toml::python-toml

--- a/eden/fs/cli/main.py
+++ b/eden/fs/cli/main.py
@@ -74,7 +74,19 @@ except ImportError:
 
 from eden.fs.cli.buck import get_buck_command, run_buck_command
 from eden.fs.cli.config import HG_REPO_TYPES
-from eden.fs.cli.doctor.facebook import check_x509
+try:
+    from eden.fs.cli.doctor.facebook import check_x509
+except ImportError:
+    # in OSS define a stub
+    class check_x509:
+        @staticmethod
+        def find_x509_path() -> Optional[str]:
+            return ""
+        @staticmethod
+        def validate_x509(cert: str) -> str:
+            return ""
+    
+
 from eden.fs.cli.telemetry import TelemetrySample
 from eden.fs.cli.util import (
     check_health_using_lockfile,

--- a/eden/scm/CMakeLists.txt
+++ b/eden/scm/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This software may be used and distributed according to the terms of the
+# GNU General Public License version 2.
+
+add_fb_python_library(
+  eden_scm_redact
+  NAMESPACE eden.scm
+  SOURCES
+    sapling/redact.py
+)
+install_fb_python_library(eden_scm_redact)


### PR DESCRIPTION
Fix a couple minor issues in the python part of edenfsctl, allowing it to run far enough to show the help messages.

*eden.fs.cli.doctor.facebook.check_x509*
This module was missing and is stubbed

*eden.scm.redact*
Was part of a tree (`eden.scm.**`) that isn't linked from the `eden.fs.cli` cmake config. This fix introduces a small cmake stub -- perhaps consider moving it to a common directory in the future.

# Test
This PR along with a stack of other fixes. Prior to this change, we'd get import failures at runtime.

Run a build, then run the internal edenfsctl:
```bash
$ act --bind --container-architecture linux/x86_64 -W .github/workflows/edenfs_linux.yml --reuse
# ... build run successfully

$ docker exec -it act-EdenFS-Linux-build-5e66d7aa5639830b3524c93df91d82566f20249f6246702098bb4f70f553fdd6 /bin/bash
root@docker-desktop:/Users/ben/oss/sapling# /tmp/fbcode_builder_getdeps-ZUsersZbenZossZsaplingZbuildZfbcode_builder-root/installed/eden/usr/local/bin/edenfsctl
usage: edenfsctl [-h] [--config-dir CONFIG_DIR] [--etc-eden-dir ETC_EDEN_DIR] [--home-dir HOME_DIR] [--version] [--debug] COMMAND ...

Manage EdenFS checkouts.

positional arguments:
  COMMAND
    chown               Chown an entire EdenFS repository
    clone               Create a clone of a specific repo and check it out
    config              Query EdenFS CLI configuration
    debug               Internal commands for examining EdenFS state
    doctor              Debug and fix issues with EdenFS
    du                  Show disk space usage for a checkout
    fsck                Perform a filesystem check for EdenFS
    fsconfig            Query EdenFS daemon configuration
    gc                  Minimize disk and memory usage by freeing caches
    glob                Print matching filenames
    health-report       Notify critical eden issues
    help                Display command line usage information
    info                Get details about a checkout
    list                List available checkouts
    minitop             Simple monitoring of EdenFS accesses by process.
    mount               Remount an existing checkout (for instance, after it was manually unmounted)
    notify              Provides a list of filesystem changes since the specified position
    pid                 Print the daemon's process ID if running
    prefetch            Prefetch content for matching file patterns
    prefetch-profile (pp)
                        Create, manage, and use Prefetch Profiles. Use `eden prefetch-profile help` to see more detailed help text.
    rage                Gather diagnostic information about EdenFS
    redirect (redir)    List and manipulate redirected paths
    reloadconfig        Reload EdenFS dynamic configs. This invokes edenfs_config_manager under the hood
    remove (rm)         Remove an EdenFS checkout
    restart             Restart the EdenFS service
    socket              Print the daemon's socket path if it exists
    start (daemon)      Start the EdenFS service
    stats               Prints statistics information for EdenFS
    status (health)     Check the health of the EdenFS service
    stop (shutdown)     Shutdown the EdenFS service
    strace              Monitor FUSE requests.
    top                 Monitor EdenFS accesses by process.
    trace               Commands for managing EdenFS tracing
    unmount             Temporarily unmount a specific checkout
    uptime              Determine uptime of the EdenFS service
    version             Print EdenFS's version information.

options:
  -h, --help            show this help message and exit

global options:
  --config-dir CONFIG_DIR
                        Path to directory where EdenFS stores its internal state
  --etc-eden-dir ETC_EDEN_DIR
                        Path to directory that holds the system configuration files
  --home-dir HOME_DIR   Path to directory where .edenrc config file is stored
  --version, -v         Print EdenFS version
  --debug               Enable debug mode (more verbose logging, traceback, etc..)
```