### PR TITLE
feat(oss): include thrift/lib/(cpp,cpp2,java,py,python) from fbthrift

### DIFF
--- a/build/fbcode_builder/manifests/eden
+++ b/build/fbcode_builder/manifests/eden
@@ -63,6 +63,11 @@ sapling
 # for internal builds that use getdeps
 fbcode/fb303 = fb303
 fbcode/common/rust/shed = common/rust/shed
+fbcode/thrift/lib/cpp = thrift/lib/cpp
+fbcode/thrift/lib/cpp2 = thrift/lib/cpp2
+fbcode/thrift/lib/java = thrift/lib/java
+fbcode/thrift/lib/py = thrift/lib/py
+fbcode/thrift/lib/python = thrift/lib/python
 fbcode/thrift/lib/rust = thrift/lib/rust
 
 [shipit.pathmap]


### PR DESCRIPTION
Map `fbcode/thrift/lib/cpp` into sapling so it is available to satisfy the error shown below. (As well as `cpp2`, `java`, `py` and `python`.)

This may not be the correct mapping (fbthrift uses a copy in `xplat/thrift`), but it is necessary to unblock OSS buck development as fbthrift does prune all `BUCK` files from its OSS repo.


The error in the OSS buck build:
```
$ buck2 build //eden/fs/service:edenfs-oss

...

Error running analysis for `gh_facebook_sapling//eden/fs/service:edenfs-oss (prelude//platforms:default#2c621926a02f7469)`

Caused by:
    0: Error in configured node dependency, dependency chain follows (-> indicates depends on, ^ indicates same configuration as previous):
              gh_facebook_sapling//eden/fs/service:edenfs-oss (prelude//platforms:default#2c621926a02f7469)
           -> gh_facebook_sapling//eden/fs/service:server (^)
           -> gh_facebook_sapling//thrift/lib/cpp:event_handler_base (^)

    1: looking up unconfigured target node `gh_facebook_sapling//thrift/lib/cpp:event_handler_base`
    2: Error loading targets in package `gh_facebook_sapling//thrift/lib/cpp` for target `gh_facebook_sapling//thrift/lib/cpp:event_handler_base`
    3: package `gh_facebook_sapling//thrift/lib/cpp:` does not exist
           missing `BUCK` file (also missing alternatives `BUCK.v2`, `BUCK`)
```