### PR TITLE
Support uuid "rng-getrandom" feature

### DIFF
--- a/eden/fs/cli_rs/edenfs-client/Cargo.toml
+++ b/eden/fs/cli_rs/edenfs-client/Cargo.toml
@@ -42,7 +42,7 @@ thrift_streaming_clients = { version = "0.1.0", path = "../../service/thrift_str
 tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 toml = { version = "0.9.8", features = ["preserve_order"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
-uuid = { version = "1.17", features = ["serde", "v4", "v5", "v6", "v7", "v8"] }
+uuid = { version = "1.17", features = ["rng-getrandom", "serde", "v4", "v5", "v6", "v7", "v8"] }
 whoami = "1.5"
 
 [dev-dependencies]

--- a/eden/mononoke/blobrepo/blobrepo_hg/Cargo.toml
+++ b/eden/mononoke/blobrepo/blobrepo_hg/Cargo.toml
@@ -32,7 +32,7 @@ repo_derived_data = { version = "0.1.0", path = "../../repo_attributes/repo_deri
 scuba_ext = { version = "0.1.0", path = "../../common/scuba_ext" }
 sorted_vector_map = { version = "0.2.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-uuid = { version = "1.17", features = ["serde", "v4", "v5", "v6", "v7", "v8"] }
+uuid = { version = "1.17", features = ["rng-getrandom", "serde", "v4", "v5", "v6", "v7", "v8"] }
 
 [dev-dependencies]
 fbinit = { version = "0.2.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }

--- a/eden/mononoke/blobstore_sync_queue/Cargo.toml
+++ b/eden/mononoke/blobstore_sync_queue/Cargo.toml
@@ -27,7 +27,7 @@ sql = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-s
 sql_common = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 sql_construct = { version = "0.1.0", path = "../common/sql_construct" }
 sql_ext = { version = "0.1.0", path = "../common/rust/sql_ext" }
-uuid = { version = "1.17", features = ["serde", "v4", "v5", "v6", "v7", "v8"] }
+uuid = { version = "1.17", features = ["rng-getrandom", "serde", "v4", "v5", "v6", "v7", "v8"] }
 vec1 = { version = "1", features = ["serde"] }
 
 [dev-dependencies]

--- a/eden/mononoke/modern_sync/Cargo.toml
+++ b/eden/mononoke/modern_sync/Cargo.toml
@@ -53,4 +53,4 @@ stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust
 tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 url = "2.5.4"
-uuid = { version = "1.17", features = ["serde", "v4", "v5", "v6", "v7", "v8"] }
+uuid = { version = "1.17", features = ["rng-getrandom", "serde", "v4", "v5", "v6", "v7", "v8"] }

--- a/eden/scm/lib/treestate/Cargo.toml
+++ b/eden/scm/lib/treestate/Cargo.toml
@@ -28,7 +28,7 @@ sha2 = "0.10.6"
 thiserror = "2.0.12"
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 twox-hash = "1.6.1"
-uuid = { version = "1.17", features = ["serde", "v4", "v5", "v6", "v7", "v8"] }
+uuid = { version = "1.17", features = ["rng-getrandom", "serde", "v4", "v5", "v6", "v7", "v8"] }
 
 [dev-dependencies]
 itertools = "0.14.0"


### PR DESCRIPTION
Summary:
Required in D85438479, which contains a handwritten Cargo.toml (fbcode/pyrefly/pyrefly_wasm/Cargo.toml) that gets incorporated into an Autocargo-generated Cargo.lock (fbcode/pyrefly/Cargo.lock).

In order for the handwritten Cargo.toml to be able to use uuid with "rng-getrandom", the Cargo.lock generation needs to have offline access to all the transitive dependencies pulled by this feature.

https://www.internalfb.com/code/fbsource/[0cc72b95913a155b4ae4b660196a25e4c23cd6b1]/fbcode/pyrefly/pyrefly_wasm/Cargo.toml?lines=17%2C26

Reviewed By: diliop

Differential Revision: D85680730


