### PR TITLE
enable OSS CI now build is fixed

### DIFF
--- a/.github/workflows/sapling-cli-getdeps_linux.yml
+++ b/.github/workflows/sapling-cli-getdeps_linux.yml
@@ -3,7 +3,12 @@
 name: Sapling CLI Getdeps Linux
 
 on:
-  workflow_dispatch
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
 
 permissions:
   contents: read  #  to fetch code (actions/checkout)


### PR DESCRIPTION
Summary:
enable CI now that the build and tests are fixed.

Enabling for linux only to limit noise for the teams

Differential Revision: D88010549
