### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/edenfs_linux.yml
+++ b/.github/workflows/edenfs_linux.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Show disk space at start
       run: df -h
     - name: Free up disk space
@@ -982,7 +982,7 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests --src-dir=. eden --project-install-prefix eden:/usr/local
     - name: Copy artifacts
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --strip --src-dir=. eden _artifacts/linux --project-install-prefix eden:/usr/local --final-install-prefix /usr/local
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: eden
         path: _artifacts

--- a/.github/workflows/edenscm-libs.yml
+++ b/.github/workflows/edenscm-libs.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Run auth tests
       run: cargo test --verbose --target-dir target --manifest-path eden/scm/lib/auth/Cargo.toml
     - name: Run backingstore tests

--- a/.github/workflows/manylinux_2_34.yml
+++ b/.github/workflows/manylinux_2_34.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx

--- a/.github/workflows/mononoke-integration_linux.yml
+++ b/.github/workflows/mononoke-integration_linux.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Update system package info
       run: sudo --preserve-env=http_proxy apt-get update
     - name: Install system deps
@@ -866,7 +866,7 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --no-deps --src-dir=. mononoke_integration --project-install-prefix mononoke_integration:/usr/local
     - name: Copy artifacts
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --strip --src-dir=. mononoke_integration _artifacts/linux --project-install-prefix mononoke_integration:/usr/local --final-install-prefix /usr/local
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: mononoke_integration
         path: _artifacts

--- a/.github/workflows/mononoke_linux.yml
+++ b/.github/workflows/mononoke_linux.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Show disk space at start
       run: df -h
     - name: Free up disk space
@@ -645,7 +645,7 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --build-type MinSizeRel --src-dir=. mononoke --project-install-prefix mononoke:/
     - name: Copy artifacts
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --strip --src-dir=. mononoke _artifacts/linux --project-install-prefix mononoke:/ --final-install-prefix /usr/local
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: mononoke
         path: _artifacts

--- a/.github/workflows/mononoke_mac.yml
+++ b/.github/workflows/mononoke_mac.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Show disk space at start
       run: df -h
     - name: Free up disk space
@@ -600,7 +600,7 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --build-type MinSizeRel --src-dir=. mononoke --project-install-prefix mononoke:/usr/local
     - name: Copy artifacts
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --src-dir=. mononoke _artifacts/mac --project-install-prefix mononoke:/usr/local --final-install-prefix /usr/local
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: mononoke
         path: _artifacts

--- a/.github/workflows/reviewstack.dev-deploy.yml
+++ b/.github/workflows/reviewstack.dev-deploy.yml
@@ -15,7 +15,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Grant Access
         run: git config --global --add safe.directory "$PWD"
       - name: Install dependencies

--- a/.github/workflows/sapling-addons.yml
+++ b/.github/workflows/sapling-addons.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install fb-watchman
         run: curl -fsSL https://github.com/facebook/watchman/releases/download/v2023.09.18.00/watchman_ubuntu20.04_v2023.09.18.00.deb -o watchman.deb && apt -y -f install ./watchman.deb
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Grant Access
         run: git config --global --add safe.directory "$PWD"
       - name: yarn install

--- a/.github/workflows/sapling-cli-getdeps_linux.yml
+++ b/.github/workflows/sapling-cli-getdeps_linux.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Show disk space at start
       run: df -h
     - name: Free up disk space
@@ -763,7 +763,7 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. sapling --project-install-prefix sapling:/
     - name: Copy artifacts
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --strip --src-dir=. sapling _artifacts/linux --project-install-prefix sapling:/ --final-install-prefix /usr/local
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: sapling
         path: _artifacts

--- a/.github/workflows/sapling-cli-homebrew-macos-arm64-release.yml
+++ b/.github/workflows/sapling-cli-homebrew-macos-arm64-release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macos-13-xlarge
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
     - name: Grant Access
       run: git config --global --add safe.directory "$PWD"
     - name: set-env SAPLING_VERSION
@@ -33,7 +33,7 @@ jobs:
     - name: Rename bottle to some platform specific name
       run: mv sapling*ventura.bottle*.tar.gz sapling-${{ env.SAPLING_VERSION }}.arm64_ventura.bottle.tar.gz
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: macos-homebrew-arm64-bottle
         path: sapling*ventura.bottle*.tar.gz
@@ -42,11 +42,11 @@ jobs:
     needs: build
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
     - name: Grant Access
       run: git config --global --add safe.directory "$PWD"
     - name: Download Artifact
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v7
       with:
         name: macos-homebrew-arm64-bottle
     - name: Create pre-release

--- a/.github/workflows/sapling-cli-manylinux-release.yml
+++ b/.github/workflows/sapling-cli-manylinux-release.yml
@@ -19,7 +19,7 @@ jobs:
       image: ${{ format('ghcr.io/{0}/manylinux_2_34:latest', github.repository) }}
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Configure Git
       run: git config --global --add safe.directory "$PWD"
     - name: rustup
@@ -34,7 +34,7 @@ jobs:
       working-directory: ./eden/scm
       run: ${{ format('mv sl-manylinux.tar.xz sapling-{0}-linux-{1}.tar.xz', env.SAPLING_VERSION, matrix.arch) }}
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: sapling-linux-${{ matrix.arch }}
         path: ./eden/scm/sapling*.tar.xz
@@ -43,11 +43,11 @@ jobs:
     needs: build
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
     - name: Grant Access
       run: git config --global --add safe.directory "$PWD"
     - name: Download Artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         pattern: sapling-linux-*
         merge-multiple: true

--- a/.github/workflows/sapling-cli-windows-amd64-release.yml
+++ b/.github/workflows/sapling-cli-windows-amd64-release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
     - name: Grant Access
       run: git config --global --add safe.directory "$PWD"
     - name: rustup
@@ -39,7 +39,7 @@ jobs:
       working-directory: ./eden/scm/artifacts
       run: ${{ format('Rename-Item sapling_windows_amd64.zip -NewName sapling-{0}-windows-x64.zip', env.SAPLING_VERSION) }}
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: windows-amd64
         path: ./eden/scm/artifacts/sapling*.zip
@@ -48,11 +48,11 @@ jobs:
     needs: build
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
     - name: Grant Access
       run: git config --global --add safe.directory "$PWD"
     - name: Download Artifact
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v7
       with:
         name: windows-amd64
     - name: Create pre-release

--- a/.github/workflows/sapling-website-deploy.yml
+++ b/.github/workflows/sapling-website-deploy.yml
@@ -16,10 +16,10 @@ jobs:
       run:
         working-directory: website
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 18
           cache: yarn


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [``](https://github.com/actions/checkout/releases/tag/) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) |  |
| `actions/download-artifact` | [``](https://github.com/actions/download-artifact/releases/tag/) | [`v7`](https://github.com/actions/download-artifact/releases/tag/v7) | [Release](https://github.com/actions/download-artifact/releases/tag/v7) |  |
| `actions/setup-node` | [``](https://github.com/actions/setup-node/releases/tag/) | [`v6`](https://github.com/actions/setup-node/releases/tag/v6) | [Release](https://github.com/actions/setup-node/releases/tag/v6) |  |
| `actions/upload-artifact` | [``](https://github.com/actions/upload-artifact/releases/tag/) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) |  |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
