### PR TITLE
Use GitHub PR template file when creating pull requests

### DIFF
--- a/eden/scm/tests/github/mock_create_one_pr_placeholder_issue.py
+++ b/eden/scm/tests/github/mock_create_one_pr_placeholder_issue.py
@@ -23,15 +23,18 @@ def setup_mock_github_server() -> MockGitHubServer:
         start_number=pr_number, num_times=1
     )
 
-    body = "addfile\n"
+    # Body is empty because "addfile" is just the title (no body after first line)
+    initial_body = ""
     github_server.expect_create_pr_using_placeholder_request(
-        body=body, issue=pr_number
+        body=initial_body, issue=pr_number
     ).and_respond()
 
     pr_id = f"PR_id_{pr_number}"
     github_server.expect_get_pr_details_request(pr_number).and_respond(pr_id)
 
-    github_server.expect_update_pr_request(pr_id, pr_number, body).and_respond()
+    # The update request uses the full commit message for title/body extraction
+    commit_msg = "addfile\n"
+    github_server.expect_update_pr_request(pr_id, pr_number, commit_msg).and_respond()
     github_server.expect_get_username_request().and_respond()
 
     head = "3a120a3a153f7d2960967ce6f1d52698a4d3a436"


### PR DESCRIPTION
## Use GitHub PR template file when creating pull requests

### Summary

This PR makes `sl pr submit` respect the standard GitHub pull request template file (`.github/pull_request_template.md`) when creating pull requests, matching GitHub's native behavior.

Previously, Sapling would ignore the PR template and use the commit message body (or append the template to it), which was inconsistent with how GitHub's web UI works.

### Changes

- Read PR template from working directory instead of the commit context, so the template is found regardless of which commits are being submitted
- Use template as the PR body instead of appending it to the commit message
- Add config option `github.pull-request-template` to customize the template path or disable the feature
- Fix placeholder strategy which previously ignored templates entirely

### Config Options
```
[github]
# Use a custom template path
pull-request-template = my/custom/template.md

# Disable PR templates entirely  
pull-request-template = 
```

When not configured, checks standard GitHub locations:
- .github/pull_request_template.md
- docs/pull_request_template.md
- pull_request_template.md

This is consistent with the GitHub documentation https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository

### Test Plan
1. Create a repo with .github/pull_request_template.md
1. Make a commit and run sl pr submit
1. Verify the PR body contains the template content (not the commit message body)
