### PR TITLE
[RFC] Fix reviewstack.dev deploy by removing broken Docker container dependency take 2

### DIFF
--- a/.github/workflows/reviewstack.dev-deploy.yml
+++ b/.github/workflows/reviewstack.dev-deploy.yml
@@ -8,19 +8,22 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-22.04
-    # Our build container already has Node, Yarn, and Python installed.
-    container:
-      image: ${{ format('ghcr.io/{0}/build_ubuntu_22_04:latest', github.repository) }}
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Install Yarn
+        run: npm install -g yarn
       - name: Grant Access
         run: git config --global --add safe.directory "$PWD"
       - name: Install dependencies
         working-directory: ./eden/contrib/
-        run: yarn install --prefer-offline
+        run: yarn install
 
       # Build codegen and then do some sanity checks so we don't push the site
       # when the tests are broken.


### PR DESCRIPTION
# Summary

The repo used to have a CI workflow that built an Ubuntu 22.04 Docker image (generated by `ci/gen_workflows.py` as `sapling-cli-ubuntu-22.04-image.yml`) and pushed it to GitHub Container Registry as `ghcr.io/facebook/sapling/build_ubuntu_22_04:latest`. At some point, that workflow and its Dockerfile were removed from the repo, but two workflows that depend on that image were never updated:

- `reviewstack.dev-deploy.yml`
- `sapling-addons.yml`

So every time either of those workflows runs, it tries to pull an image that no longer exists, and fails immediately at container initialization.

Example failure on `main`: https://github.com/facebook/sapling/actions/runs/21693937235/job/62559938248


# Test Plan
Not 100% sure how to test this tbh.  I tried to add a trigger to get GHA to pick up the change and see if the deploy action would succeed but it looks like I don't have permissions to do that.

ubuntu-22.04 should already have node and yarn so the build deployment should work without any custom dependencies.


Redo of #1208