### PR TITLE
sl push: more helpful message

### DIFF
--- a/eden/scm/sapling/ext/remotenames.py
+++ b/eden/scm/sapling/ext/remotenames.py
@@ -858,6 +858,19 @@ def expushcmd(orig, ui, repo, dest=None, **opts):
             remotename = ui.config("remotenames", "rename.%s" % dest) or dest
             to = opts.get("to") or _guesspushtobookmark(repo, pushnode, remotename)
             if not to:
+                prefix = "%s/" % remotename
+                at_bookmarks = [
+                    name
+                    for name, nodes in repo._remotenames["bookmarks"].items()
+                    if name.startswith(prefix)
+                    and len(nodes) == 1
+                    and nodes[0] == pushnode
+                ]
+                if at_bookmarks:
+                    raise error.Abort(
+                        _("nothing to push - current commit is already at %s")
+                        % ", ".join(at_bookmarks)
+                    )
                 raise error.Abort(_("use '--to' to specify destination bookmark"))
         return git.push(repo, dest, [(pushnode, to)], force=force)
 

--- a/eden/scm/tests/test-git.t
+++ b/eden/scm/tests/test-git.t
@@ -425,6 +425,11 @@ Test push:
      0de3093..a9d5bd6  a9d5bd6ac8bcf89de9cd99fd215cca243e8aeed9 -> main
   $ sl push -q --to stable
 
+ (nothing to push - already at a remote bookmark)
+  $ sl push
+  abort: nothing to push - current commit is already at remote/main, remote/stable
+  [255]
+
  (cannot pick with multiple candidates)
   $ sl commit -m D
   $ sl push


### PR DESCRIPTION
```
sl push   # no args
```

```
abort: nothing to push - current commit is already at origin/master
```

instead of

```
abort: use '--to' to specify destination bookmark
```