### PR TITLE
upgrading which to 8.0.2 (#1286)

### DIFF
--- a/common/rust/shed/thrift_compiler/Cargo.toml
+++ b/common/rust/shed/thrift_compiler/Cargo.toml
@@ -19,4 +19,4 @@ anyhow = "1.0.102"
 clap = { version = "4.6.0", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 dunce = "1.0.5"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
-which = "4.2.4"
+which = "8.0.2"


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexperimental/rust-shed/pull/72

X-link: https://github.com/meta-pytorch/monarch/pull/3476


Upgrading `which` from `4.2.4` to `8.0.2`.
- Major version jump (4→8). Key changes: `Sys` trait for filesystem abstraction, `tracing` support, removed `either`/`rustix`/`winsafe` deps. Basic `which::which()` API is unchanged.
- All downstream consumers checked with arc rust-check — 0 errors.

Reviewed By: dtolnay

Differential Revision: D101291181
