### PR TITLE
upgrading tokio to 1.52.1

### DIFF
--- a/common/rust/shed/fbinit/fbinit-tokio/Cargo.toml
+++ b/common/rust/shed/fbinit/fbinit-tokio/Cargo.toml
@@ -14,4 +14,4 @@ path = "lib.rs"
 
 [dependencies]
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/common/rust/shed/futures_ext/Cargo.toml
+++ b/common/rust/shed/futures_ext/Cargo.toml
@@ -16,7 +16,7 @@ futures = { version = "0.3.31", features = ["async-await", "compat"] }
 pin-project = "1.1.11"
 shared_error = { version = "0.1.0", path = "../shared_error" }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 
 [dev-dependencies]
 assert_matches = "1.5"

--- a/common/rust/shed/futures_stats/Cargo.toml
+++ b/common/rust/shed/futures_stats/Cargo.toml
@@ -17,4 +17,4 @@ path = "test/main.rs"
 [dependencies]
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
 futures_ext = { version = "0.1.0", path = "../futures_ext" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/common/rust/shed/stats/Cargo.toml
+++ b/common/rust/shed/stats/Cargo.toml
@@ -15,7 +15,7 @@ fbinit = { version = "0.2.0", path = "../fbinit" }
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
 perthread = { version = "0.1.0", path = "../perthread" }
 stats_traits = { version = "0.1.0", path = "traits" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tokio-stream = { version = "0.1.18", features = ["fs", "io-util", "net", "signal", "sync", "time"] }
 
 [lints]

--- a/common/rust/shed/tokio-uds-compat/Cargo.toml
+++ b/common/rust/shed/tokio-uds-compat/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/facebookexperimental/rust-shed"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 
 [dev-dependencies]
 futures = { version = "0.3.31", features = ["async-await", "compat"] }

--- a/eden/fs/cli_rs/edenfs-client/Cargo.toml
+++ b/eden/fs/cli_rs/edenfs-client/Cargo.toml
@@ -53,7 +53,7 @@ mockall = "0.13.1"
 rand = "0.10"
 serde_test = "1.0.167"
 tempfile = "3.22"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 psutil = "3.2.2"

--- a/eden/fs/cli_rs/edenfs-error/Cargo.toml
+++ b/eden/fs/cli_rs/edenfs-error/Cargo.toml
@@ -12,4 +12,4 @@ anyhow = "1.0.102"
 sapling-thrift-types = { version = "0.1.0", path = "../../../scm/lib/thrift-types" }
 thiserror = "2.0.18"
 thrift_streaming_clients = { version = "0.1.0", path = "../../service/thrift_streaming/clients" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/fs/cli_rs/sapling-client/Cargo.toml
+++ b/eden/fs/cli_rs/sapling-client/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = "1.0.102"
 async_process_traits = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 lru-cache = "0.1.2"
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 
 [dev-dependencies]
 edenfs-client = { version = "0.1.0", path = "../edenfs-client" }

--- a/eden/fs/rust/edenfs-asserted-states/Cargo.toml
+++ b/eden/fs/rust/edenfs-asserted-states/Cargo.toml
@@ -20,6 +20,6 @@ sapling-spawn-ext = { version = "0.1.0", path = "../../../scm/lib/spawn-ext" }
 sapling-util = { version = "0.1.0", path = "../../../scm/lib/util" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 whoami = "1.5"

--- a/eden/fs/rust/redirect_ffi/Cargo.toml
+++ b/eden/fs/rust/redirect_ffi/Cargo.toml
@@ -12,4 +12,4 @@ anyhow = "1.0.102"
 cxx = "1.0.119"
 cxxerror = { version = "0.1.0", path = "../../../scm/lib/edenfs_ffi/cxxerror" }
 edenfs-client = { version = "0.1.0", path = "../../cli_rs/edenfs-client" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/mononoke/benchmarks/filestore/Cargo.toml
+++ b/eden/mononoke/benchmarks/filestore/Cargo.toml
@@ -33,5 +33,5 @@ mononoke_types = { version = "0.1.0", path = "../../mononoke_types" }
 prefixblob = { version = "0.1.0", path = "../../blobstore/prefixblob" }
 rand = "0.10"
 throttledblob = { version = "0.1.0", path = "../../blobstore/throttledblob" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tokio-util = { version = "0.7.18", features = ["full"] }

--- a/eden/mononoke/benchmarks/storage_config/Cargo.toml
+++ b/eden/mononoke/benchmarks/storage_config/Cargo.toml
@@ -25,4 +25,4 @@ futures = { version = "0.3.31", features = ["async-await", "compat"] }
 mononoke_app = { version = "0.1.0", path = "../../cmdlib/mononoke_app" }
 rand = "0.10"
 repo_factory = { version = "0.1.0", path = "../../repo_factory" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/mononoke/blobimport_lib/Cargo.toml
+++ b/eden/mononoke/blobimport_lib/Cargo.toml
@@ -40,5 +40,5 @@ repo_blobstore = { version = "0.1.0", path = "../repo_attributes/repo_blobstore"
 repo_derived_data = { version = "0.1.0", path = "../repo_attributes/repo_derived_data" }
 repo_identity = { version = "0.1.0", path = "../repo_attributes/repo_identity" }
 synced_commit_mapping = { version = "0.1.0", path = "../features/commit_rewriting/synced_commit_mapping" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/eden/mononoke/blobrepo_utils/Cargo.toml
+++ b/eden/mononoke/blobrepo_utils/Cargo.toml
@@ -33,7 +33,7 @@ repo_blobstore = { version = "0.1.0", path = "../repo_attributes/repo_blobstore"
 repo_derived_data = { version = "0.1.0", path = "../repo_attributes/repo_derived_data" }
 restricted_paths = { version = "0.1.0", path = "../repo_attributes/restricted_paths" }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tokio-stream = { version = "0.1.18", features = ["fs", "io-util", "net", "signal", "sync", "time"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 

--- a/eden/mononoke/blobstore/cacheblob/Cargo.toml
+++ b/eden/mononoke/blobstore/cacheblob/Cargo.toml
@@ -29,7 +29,7 @@ mononoke_types = { version = "0.1.0", path = "../../mononoke_types" }
 prefixblob = { version = "0.1.0", path = "../prefixblob" }
 redactedblobstore = { version = "0.1.0", path = "../redactedblobstore" }
 stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [dev-dependencies]

--- a/eden/mononoke/blobstore/delayblob/Cargo.toml
+++ b/eden/mononoke/blobstore/delayblob/Cargo.toml
@@ -15,4 +15,4 @@ context = { version = "0.1.0", path = "../../servers/slapi/slapi_server/context"
 mononoke_types = { version = "0.1.0", path = "../../mononoke_types" }
 rand = "0.10"
 rand_distr = "0.6"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/mononoke/blobstore/ephemeral_blobstore/Cargo.toml
+++ b/eden/mononoke/blobstore/ephemeral_blobstore/Cargo.toml
@@ -37,7 +37,7 @@ sql_construct = { version = "0.1.0", path = "../../common/sql_construct" }
 sql_ext = { version = "0.1.0", path = "../../common/rust/sql_ext" }
 sql_query_config = { version = "0.1.0", path = "../../repo_attributes/sql_query_config" }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 vec1 = { version = "1.12.1", features = ["serde"] }
 
 [dev-dependencies]

--- a/eden/mononoke/blobstore/factory/Cargo.toml
+++ b/eden/mononoke/blobstore/factory/Cargo.toml
@@ -39,4 +39,4 @@ sql_construct = { version = "0.1.0", path = "../../common/sql_construct" }
 sql_ext = { version = "0.1.0", path = "../../common/rust/sql_ext" }
 sqlblob = { version = "0.1.0", path = "../sqlblob" }
 throttledblob = { version = "0.1.0", path = "../throttledblob" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/mononoke/blobstore/fileblob/Cargo.toml
+++ b/eden/mononoke/blobstore/fileblob/Cargo.toml
@@ -16,7 +16,7 @@ mononoke_macros = { version = "0.1.0", path = "../../common/mononoke_macros" }
 mononoke_types = { version = "0.1.0", path = "../../mononoke_types" }
 percent-encoding = "2.1"
 tempfile = "3.27.0"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 walkdir = "2.3"
 
 [dev-dependencies]

--- a/eden/mononoke/blobstore/multiplexedblob/Cargo.toml
+++ b/eden/mononoke/blobstore/multiplexedblob/Cargo.toml
@@ -23,6 +23,6 @@ once_cell = "1.21.4"
 scuba_ext = { version = "0.1.0", path = "../../common/scuba_ext" }
 strum = { version = "0.27.1", features = ["derive"] }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 twox-hash = "1.6.1"

--- a/eden/mononoke/blobstore/multiplexedblob_wal/Cargo.toml
+++ b/eden/mononoke/blobstore/multiplexedblob_wal/Cargo.toml
@@ -26,7 +26,7 @@ multiplexedblob = { version = "0.1.0", path = "../multiplexedblob" }
 scuba_ext = { version = "0.1.0", path = "../../common/scuba_ext" }
 thiserror = "2.0.18"
 time_ext = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 
 [dev-dependencies]
 blobstore_test_utils = { version = "0.1.0", path = "../test_utils" }

--- a/eden/mononoke/blobstore/s3blob/Cargo.toml
+++ b/eden/mononoke/blobstore/s3blob/Cargo.toml
@@ -25,4 +25,4 @@ rusoto_credential = "0.48.0"
 rusoto_s3 = "0.48.0"
 rusoto_sts = "0.48.0"
 time_ext = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/mononoke/blobstore/sqlblob/Cargo.toml
+++ b/eden/mononoke/blobstore/sqlblob/Cargo.toml
@@ -26,7 +26,7 @@ serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw
 sql = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 sql_ext = { version = "0.1.0", path = "../../common/rust/sql_ext" }
 stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tokio-stream = { version = "0.1.18", features = ["fs", "io-util", "net", "signal", "sync", "time"] }
 twox-hash = "1.6.1"
 vec1 = { version = "1.12.1", features = ["serde"] }

--- a/eden/mononoke/blobstore/test_utils/Cargo.toml
+++ b/eden/mononoke/blobstore/test_utils/Cargo.toml
@@ -20,4 +20,4 @@ futures = { version = "0.3.31", features = ["async-await", "compat"] }
 lock_ext = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 metaconfig_types = { version = "0.1.0", path = "../../metaconfig/types" }
 mononoke_types = { version = "0.1.0", path = "../../mononoke_types" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/mononoke/blobstore/virtually_sharded_blobstore/Cargo.toml
+++ b/eden/mononoke/blobstore/virtually_sharded_blobstore/Cargo.toml
@@ -26,7 +26,7 @@ scopeguard = "1.2.0"
 shared_error = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 time_ext = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 twox-hash = "1.6.1"
 
 [dev-dependencies]

--- a/eden/mononoke/cmdlib/config_args/Cargo.toml
+++ b/eden/mononoke/cmdlib/config_args/Cargo.toml
@@ -14,4 +14,4 @@ clap = { version = "4.6.0", features = ["derive", "env", "string", "unicode", "w
 fbinit = { version = "0.2.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 justknobs = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 mononoke_configs = { version = "0.1.0", path = "../../common/mononoke_configs" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/mononoke/cmdlib/environment/Cargo.toml
+++ b/eden/mononoke/cmdlib/environment/Cargo.toml
@@ -27,4 +27,4 @@ sapling-clientinfo = { version = "0.1.0", path = "../../../scm/lib/clientinfo" }
 scuba_ext = { version = "0.1.0", path = "../../common/scuba_ext" }
 sql_ext = { version = "0.1.0", path = "../../common/rust/sql_ext" }
 strum = { version = "0.27.1", features = ["derive"] }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/mononoke/cmdlib/mononoke_app/Cargo.toml
+++ b/eden/mononoke/cmdlib/mononoke_app/Cargo.toml
@@ -61,5 +61,5 @@ sql_ext = { version = "0.1.0", path = "../../common/rust/sql_ext" }
 stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 strum = { version = "0.27.1", features = ["derive"] }
 tls = { version = "0.1.0", path = "tls" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/eden/mononoke/cmdlib/sharding/Cargo.toml
+++ b/eden/mononoke/cmdlib/sharding/Cargo.toml
@@ -15,5 +15,5 @@ fbinit = { version = "0.2.0", git = "https://github.com/facebookexperimental/rus
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
 sharding_ext = { version = "0.1.0", path = "../sharding_ext" }
 stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/eden/mononoke/common/assembly_line/Cargo.toml
+++ b/eden/mononoke/common/assembly_line/Cargo.toml
@@ -12,4 +12,4 @@ futures = { version = "0.3.31", features = ["async-await", "compat"] }
 pin-project = "1.1.11"
 
 [dev-dependencies]
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/mononoke/common/async_limiter/Cargo.toml
+++ b/eden/mononoke/common/async_limiter/Cargo.toml
@@ -17,4 +17,4 @@ thiserror = "2.0.18"
 
 [dev-dependencies]
 nonzero_ext = "0.2"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/mononoke/common/async_limiter/examples/tokio_v2/Cargo.toml
+++ b/eden/mononoke/common/async_limiter/examples/tokio_v2/Cargo.toml
@@ -18,4 +18,4 @@ chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-fea
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
 governor = "0.10.4"
 nonzero_ext = "0.2"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/mononoke/common/cas_client/client/Cargo.toml
+++ b/eden/mononoke/common/cas_client/client/Cargo.toml
@@ -22,5 +22,5 @@ futures = { version = "0.3.31", features = ["async-await", "compat"] }
 futures_ext = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 mononoke_types = { version = "0.1.0", path = "../../../mononoke_types" }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/eden/mononoke/common/gotham_ext/Cargo.toml
+++ b/eden/mononoke/common/gotham_ext/Cargo.toml
@@ -47,7 +47,7 @@ scopeguard = "1.2.0"
 scuba_ext = { version = "0.1.0", path = "../scuba_ext" }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 time_ext = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tokio-openssl = "0.6.5"
 tokio-util = { version = "0.7.18", features = ["full"] }
 tower-service = "0.3.3"

--- a/eden/mononoke/common/hgproto/Cargo.toml
+++ b/eden/mononoke/common/hgproto/Cargo.toml
@@ -21,7 +21,7 @@ nom = "8"
 pin-project = "1.1.11"
 qps = { version = "0.1.0", path = "../../servers/slapi/slapi_server/qps" }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tokio-util = { version = "0.7.18", features = ["full"] }
 
 [dev-dependencies]

--- a/eden/mononoke/common/metadata/Cargo.toml
+++ b/eden/mononoke/common/metadata/Cargo.toml
@@ -12,5 +12,5 @@ anyhow = "1.0.102"
 permission_checker = { version = "0.1.0", path = "../permission_checker" }
 sapling-clientinfo = { version = "0.1.0", path = "../../../scm/lib/clientinfo" }
 session_id = { version = "0.1.0", path = "../session_id" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 trust-dns-resolver = "0.20.4"

--- a/eden/mononoke/common/mononoke_configs/Cargo.toml
+++ b/eden/mononoke/common/mononoke_configs/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 sha2 = "0.10.6"
 stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [dev-dependencies]

--- a/eden/mononoke/common/mononoke_macros/Cargo.toml
+++ b/eden/mononoke/common/mononoke_macros/Cargo.toml
@@ -10,5 +10,5 @@ license = "GPLv2+"
 [dependencies]
 justknobs = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 mononoke_proc_macros = { version = "0.1.0", path = "proc_macros" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/eden/mononoke/common/ods_counters/Cargo.toml
+++ b/eden/mononoke/common/ods_counters/Cargo.toml
@@ -13,7 +13,7 @@ chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-fea
 fbinit = { version = "0.2.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 maplit = "1.0"
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 
 [dev-dependencies]
 anyhow = "1.0.102"

--- a/eden/mononoke/common/permission_checker/Cargo.toml
+++ b/eden/mononoke/common/permission_checker/Cargo.toml
@@ -17,7 +17,7 @@ maplit = "1.0"
 openssl = "0.10.72"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 
 [dev-dependencies]
 fbinit-tokio = { version = "0.1.2", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }

--- a/eden/mononoke/common/quiet_stream/Cargo.toml
+++ b/eden/mononoke/common/quiet_stream/Cargo.toml
@@ -10,4 +10,4 @@ license = "GPLv2+"
 [dependencies]
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
 pin-project = "1.1.11"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/mononoke/common/rate_limiting/Cargo.toml
+++ b/eden/mononoke/common/rate_limiting/Cargo.toml
@@ -22,4 +22,4 @@ serde = { version = "1.0.219", features = ["derive", "rc"] }
 stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 strum = { version = "0.27.1", features = ["derive"] }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/mononoke/common/reloader/Cargo.toml
+++ b/eden/mononoke/common/reloader/Cargo.toml
@@ -16,7 +16,7 @@ context = { version = "0.1.0", path = "../../servers/slapi/slapi_server/context"
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
 futures_ext = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 rand = "0.10"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [dev-dependencies]

--- a/eden/mononoke/common/rendezvous/Cargo.toml
+++ b/eden/mononoke/common/rendezvous/Cargo.toml
@@ -20,7 +20,7 @@ mononoke_macros = { version = "0.1.0", path = "../mononoke_macros" }
 shared_error = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 time_ext = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 
 [dev-dependencies]
 fbinit-tokio = { version = "0.1.2", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }

--- a/eden/mononoke/common/running/Cargo.toml
+++ b/eden/mononoke/common/running/Cargo.toml
@@ -12,5 +12,5 @@ anyhow = "1.0.102"
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
 libc = "0.2.183"
 mononoke_macros = { version = "0.1.0", path = "../mononoke_macros" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/eden/mononoke/common/rust/caching_ext/Cargo.toml
+++ b/eden/mononoke/common/rust/caching_ext/Cargo.toml
@@ -24,4 +24,4 @@ stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust
 [dev-dependencies]
 maplit = "1.0"
 quickcheck = "1.0"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/mononoke/common/rust/sql_ext/Cargo.toml
+++ b/eden/mononoke/common/rust/sql_ext/Cargo.toml
@@ -46,7 +46,7 @@ stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust
 strum = { version = "0.27.1", features = ["derive"] }
 thiserror = "2.0.18"
 time_measuring = { version = "0.1.0", path = "../../time_measuring" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 twox-hash = "1.6.1"
 vec1 = { version = "1.12.1", features = ["serde"] }

--- a/eden/mononoke/common/wait_for_replication/Cargo.toml
+++ b/eden/mononoke/common/wait_for_replication/Cargo.toml
@@ -15,5 +15,5 @@ futures = { version = "0.3.31", features = ["async-await", "compat"] }
 metaconfig_types = { version = "0.1.0", path = "../../metaconfig/types" }
 replication_lag_config = { version = "0.1.0", path = "../../../../configerator/structs/scm/mononoke/mysql/replication_lag" }
 sql_ext = { version = "0.1.0", path = "../rust/sql_ext" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/eden/mononoke/common/yield_stream/Cargo.toml
+++ b/eden/mononoke/common/yield_stream/Cargo.toml
@@ -13,4 +13,4 @@ pin-project = "1.1.11"
 
 [dev-dependencies]
 bytes = { version = "1.11.1", features = ["serde"] }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/mononoke/derived_data/deleted_manifest/Cargo.toml
+++ b/eden/mononoke/derived_data/deleted_manifest/Cargo.toml
@@ -35,7 +35,7 @@ mononoke_types = { version = "0.1.0", path = "../../mononoke_types" }
 multimap = "0.8.3"
 repo_blobstore = { version = "0.1.0", path = "../../repo_attributes/repo_blobstore" }
 repo_derived_data = { version = "0.1.0", path = "../../repo_attributes/repo_derived_data" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 unodes = { version = "0.1.0", path = "../unodes" }
 

--- a/eden/mononoke/derived_data/inferred_copy_from/Cargo.toml
+++ b/eden/mononoke/derived_data/inferred_copy_from/Cargo.toml
@@ -26,7 +26,7 @@ itertools = "0.14.0"
 manifest = { version = "0.1.0", path = "../../manifest" }
 mononoke_types = { version = "0.1.0", path = "../../mononoke_types" }
 similar = { version = "2.2.0", features = ["bytes", "inline"] }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 vec1 = { version = "1.12.1", features = ["serde"] }
 
 [dev-dependencies]

--- a/eden/mononoke/derived_data/manager/Cargo.toml
+++ b/eden/mononoke/derived_data/manager/Cargo.toml
@@ -42,5 +42,5 @@ restricted_paths_common = { version = "0.1.0", path = "../../repo_attributes/res
 scuba_ext = { version = "0.1.0", path = "../../common/scuba_ext" }
 shared_error = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/eden/mononoke/derived_data/mercurial_derivation/Cargo.toml
+++ b/eden/mononoke/derived_data/mercurial_derivation/Cargo.toml
@@ -68,4 +68,4 @@ scuba_ext = { version = "0.1.0", path = "../../common/scuba_ext" }
 sql = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 test_repo_factory = { version = "0.1.0", path = "../../repo_factory/test_repo_factory" }
 tests_utils = { version = "0.1.0", path = "../../tests/utils" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/mononoke/features/async_requests/Cargo.toml
+++ b/eden/mononoke/features/async_requests/Cargo.toml
@@ -29,7 +29,7 @@ source_control = { version = "0.1.0", path = "../../scs/if" }
 sql_construct = { version = "0.1.0", path = "../../common/sql_construct" }
 stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 
 [dev-dependencies]
 fbinit = { version = "0.2.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }

--- a/eden/mononoke/features/async_requests/requests_table/Cargo.toml
+++ b/eden/mononoke/features/async_requests/requests_table/Cargo.toml
@@ -23,4 +23,4 @@ sql_ext = { version = "0.1.0", path = "../../../common/rust/sql_ext" }
 fbinit = { version = "0.2.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 fbinit-tokio = { version = "0.1.2", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 mononoke_macros = { version = "0.1.0", path = "../../../common/mononoke_macros" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/mononoke/features/async_requests/worker/Cargo.toml
+++ b/eden/mononoke/features/async_requests/worker/Cargo.toml
@@ -27,6 +27,6 @@ mononoke_app = { version = "0.1.0", path = "../../../cmdlib/mononoke_app" }
 mononoke_types = { version = "0.1.0", path = "../../../mononoke_types" }
 requests_table = { version = "0.1.0", path = "../requests_table" }
 sharding_ext = { version = "0.1.0", path = "../../../cmdlib/sharding_ext" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 worker_lib = { version = "0.1.0", path = "../worker_lib" }

--- a/eden/mononoke/features/async_requests/worker_lib/Cargo.toml
+++ b/eden/mononoke/features/async_requests/worker_lib/Cargo.toml
@@ -40,7 +40,7 @@ scs_methods = { version = "0.1.0", path = "../../../servers/scs/scs_methods" }
 source_control = { version = "0.1.0", path = "../../../scs/if" }
 stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 throttledblob = { version = "0.1.0", path = "../../../blobstore/throttledblob" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [dev-dependencies]

--- a/eden/mononoke/features/commit_rewriting/backsyncer/Cargo.toml
+++ b/eden/mononoke/features/commit_rewriting/backsyncer/Cargo.toml
@@ -42,7 +42,7 @@ scuba_ext = { version = "0.1.0", path = "../../../common/scuba_ext" }
 sql_ext = { version = "0.1.0", path = "../../../common/rust/sql_ext" }
 sql_query_config = { version = "0.1.0", path = "../../../repo_attributes/sql_query_config" }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 wireproto_handler = { version = "0.1.0", path = "../../../servers/slapi/wireproto_handler" }
 

--- a/eden/mononoke/features/commit_rewriting/backsyncer/features/commit_rewriting/backsyncer_cmd/Cargo.toml
+++ b/eden/mononoke/features/commit_rewriting/backsyncer/features/commit_rewriting/backsyncer_cmd/Cargo.toml
@@ -37,6 +37,6 @@ repo_identity = { version = "0.1.0", path = "../../../../../../repo_attributes/r
 sapling-clientinfo = { version = "0.1.0", path = "../../../../../../../scm/lib/clientinfo" }
 sharding_ext = { version = "0.1.0", path = "../../../../../../cmdlib/sharding_ext" }
 stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 wireproto_handler = { version = "0.1.0", path = "../../../../../../servers/slapi/wireproto_handler" }

--- a/eden/mononoke/features/commit_rewriting/bookmarks_validator/Cargo.toml
+++ b/eden/mononoke/features/commit_rewriting/bookmarks_validator/Cargo.toml
@@ -29,7 +29,7 @@ repo_identity = { version = "0.1.0", path = "../../../repo_attributes/repo_ident
 sapling-clientinfo = { version = "0.1.0", path = "../../../../scm/lib/clientinfo" }
 sharding_ext = { version = "0.1.0", path = "../../../cmdlib/sharding_ext" }
 stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [dev-dependencies]

--- a/eden/mononoke/features/commit_rewriting/commit_validator/Cargo.toml
+++ b/eden/mononoke/features/commit_rewriting/commit_validator/Cargo.toml
@@ -45,7 +45,7 @@ sql_ext = { version = "0.1.0", path = "../../../common/rust/sql_ext" }
 sql_query_config = { version = "0.1.0", path = "../../../repo_attributes/sql_query_config" }
 stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 synced_commit_mapping = { version = "0.1.0", path = "../synced_commit_mapping" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [dev-dependencies]

--- a/eden/mononoke/features/commit_rewriting/mononoke_x_repo_sync_job/Cargo.toml
+++ b/eden/mononoke/features/commit_rewriting/mononoke_x_repo_sync_job/Cargo.toml
@@ -45,7 +45,7 @@ sapling-clientinfo = { version = "0.1.0", path = "../../../../scm/lib/clientinfo
 scuba_ext = { version = "0.1.0", path = "../../../common/scuba_ext" }
 sharding_ext = { version = "0.1.0", path = "../../../cmdlib/sharding_ext" }
 sql_query_config = { version = "0.1.0", path = "../../../repo_attributes/sql_query_config" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 zk_leader_election = { version = "0.1.0", path = "../../../cmdlib/zk_leader_election" }
 

--- a/eden/mononoke/features/cross_repo_sync/Cargo.toml
+++ b/eden/mononoke/features/cross_repo_sync/Cargo.toml
@@ -69,7 +69,7 @@ synced_commit_mapping_pushrebase_hook = { version = "0.1.0", path = "../commit_r
 test_repo_factory = { version = "0.1.0", path = "../../repo_factory/test_repo_factory" }
 tests_utils = { version = "0.1.0", path = "../../tests/utils" }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 topo_sort = { version = "0.1.0", path = "../../common/topo_sort" }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 

--- a/eden/mononoke/features/diff/Cargo.toml
+++ b/eden/mononoke/features/diff/Cargo.toml
@@ -29,7 +29,7 @@ repo_derived_data = { version = "0.1.0", path = "../../repo_attributes/repo_deri
 repo_identity = { version = "0.1.0", path = "../../repo_attributes/repo_identity" }
 sapling-xdiff = { version = "0.1.0", path = "../../../scm/lib/xdiff" }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 unodes = { version = "0.1.0", path = "../../derived_data/unodes" }
 
 [dev-dependencies]

--- a/eden/mononoke/features/history_traversal/Cargo.toml
+++ b/eden/mononoke/features/history_traversal/Cargo.toml
@@ -37,7 +37,7 @@ scuba_ext = { version = "0.1.0", path = "../../common/scuba_ext" }
 stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 thiserror = "2.0.18"
 time_ext = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 unodes = { version = "0.1.0", path = "../../derived_data/unodes" }
 
 [dev-dependencies]

--- a/eden/mononoke/features/hooks/Cargo.toml
+++ b/eden/mononoke/features/hooks/Cargo.toml
@@ -61,7 +61,7 @@ source_control = { version = "0.1.0", path = "../../scs/if" }
 source_control_clients = { version = "0.1.0", path = "../../scs/if/clients" }
 stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [dev-dependencies]

--- a/eden/mononoke/features/microwave/features/microwave/Cargo.toml
+++ b/eden/mononoke/features/microwave/features/microwave/Cargo.toml
@@ -22,5 +22,5 @@ microwave_if = { version = "0.1.0", path = "../../if" }
 mononoke_types = { version = "0.1.0", path = "../../../../mononoke_types" }
 mutable_blobstore = { version = "0.1.0", path = "../../../../repo_attributes/mutable_blobstore" }
 repo_identity = { version = "0.1.0", path = "../../../../repo_attributes/repo_identity" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/eden/mononoke/features/pushrebase/Cargo.toml
+++ b/eden/mononoke/features/pushrebase/Cargo.toml
@@ -37,7 +37,7 @@ shared_error = { version = "0.1.0", git = "https://github.com/facebookexperiment
 stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 thiserror = "2.0.18"
 three_way_merge = { version = "0.1.0", path = "../../common/three_way_merge" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [dev-dependencies]

--- a/eden/mononoke/features/repo_stats_logger/Cargo.toml
+++ b/eden/mononoke/features/repo_stats_logger/Cargo.toml
@@ -26,7 +26,7 @@ repo_blobstore = { version = "0.1.0", path = "../../repo_attributes/repo_blobsto
 repo_derived_data = { version = "0.1.0", path = "../../repo_attributes/repo_derived_data" }
 sharding_ext = { version = "0.1.0", path = "../../cmdlib/sharding_ext" }
 stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [dev-dependencies]

--- a/eden/mononoke/git/check_git_wc/Cargo.toml
+++ b/eden/mononoke/git/check_git_wc/Cargo.toml
@@ -27,5 +27,5 @@ repo_derived_data = { version = "0.1.0", path = "../../repo_attributes/repo_deri
 repo_identity = { version = "0.1.0", path = "../../repo_attributes/repo_identity" }
 sha2 = "0.10.6"
 sorted_vector_map = { version = "0.2.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tokio-stream = { version = "0.1.18", features = ["fs", "io-util", "net", "signal", "sync", "time"] }

--- a/eden/mononoke/git/git-pool/Cargo.toml
+++ b/eden/mononoke/git/git-pool/Cargo.toml
@@ -13,4 +13,4 @@ git2 = "0.20.4"
 mononoke_macros = { version = "0.1.0", path = "../../common/mononoke_macros" }
 num_cpus = "1.16"
 r2d2 = "0.8.10"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/mononoke/git/git_types/Cargo.toml
+++ b/eden/mononoke/git/git_types/Cargo.toml
@@ -49,7 +49,7 @@ sha1 = "0.10.5"
 smallvec = { version = "1.15", features = ["impl_bincode", "serde", "specialization", "union"] }
 sorted_vector_map = { version = "0.2.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [dev-dependencies]

--- a/eden/mononoke/git/gitexport/Cargo.toml
+++ b/eden/mononoke/git/gitexport/Cargo.toml
@@ -58,7 +58,7 @@ serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 sql = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 test_repo_factory = { version = "0.1.0", path = "../../repo_factory/test_repo_factory" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 unodes = { version = "0.1.0", path = "../../derived_data/unodes" }
 warm_bookmarks_cache = { version = "0.1.0", path = "../../repo_attributes/bookmarks/warm_bookmarks_cache" }

--- a/eden/mononoke/git/import_tools/Cargo.toml
+++ b/eden/mononoke/git/import_tools/Cargo.toml
@@ -52,5 +52,5 @@ scuba_ext = { version = "0.1.0", path = "../../common/scuba_ext" }
 smallvec = { version = "1.15", features = ["impl_bincode", "serde", "specialization", "union"] }
 sorted_vector_map = { version = "0.2.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 tls = { version = "0.1.0", path = "../../cmdlib/mononoke_app/tls" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/eden/mononoke/git/packetline/Cargo.toml
+++ b/eden/mononoke/git/packetline/Cargo.toml
@@ -15,7 +15,7 @@ path = "test/packetline_test.rs"
 faster-hex = "0.6.1"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 
 [dev-dependencies]
 anyhow = "1.0.102"

--- a/eden/mononoke/git/packfile/Cargo.toml
+++ b/eden/mononoke/git/packfile/Cargo.toml
@@ -22,7 +22,7 @@ rustc-hash = "2.1.2"
 sha1 = "0.10.5"
 sha1-checked = "0.10.0"
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 
 [dev-dependencies]
 bytes = { version = "1.11.1", features = ["serde"] }

--- a/eden/mononoke/git/protocol/Cargo.toml
+++ b/eden/mononoke/git/protocol/Cargo.toml
@@ -49,7 +49,7 @@ rustc-hash = "2.1.2"
 scuba_ext = { version = "0.1.0", path = "../../common/scuba_ext" }
 sha1 = "0.10.5"
 tempfile = "3.27.0"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tokio-stream = { version = "0.1.18", features = ["fs", "io-util", "net", "signal", "sync", "time"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 weight_observer = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }

--- a/eden/mononoke/jobs/blobstore_healer/Cargo.toml
+++ b/eden/mononoke/jobs/blobstore_healer/Cargo.toml
@@ -29,7 +29,7 @@ mononoke_types = { version = "0.1.0", path = "../../mononoke_types" }
 rand = "0.10"
 sql_construct = { version = "0.1.0", path = "../../common/sql_construct" }
 sql_ext = { version = "0.1.0", path = "../../common/rust/sql_ext" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 wait_for_replication = { version = "0.1.0", path = "../../common/wait_for_replication" }
 

--- a/eden/mononoke/jobs/cas_sync/Cargo.toml
+++ b/eden/mononoke/jobs/cas_sync/Cargo.toml
@@ -42,6 +42,6 @@ sapling-repourl = { version = "0.1.0", path = "../../../scm/lib/repo/url" }
 scuba_ext = { version = "0.1.0", path = "../../common/scuba_ext" }
 sharding_ext = { version = "0.1.0", path = "../../cmdlib/sharding_ext" }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 zk_leader_election = { version = "0.1.0", path = "../../cmdlib/zk_leader_election" }

--- a/eden/mononoke/jobs/modern_sync/Cargo.toml
+++ b/eden/mononoke/jobs/modern_sync/Cargo.toml
@@ -51,7 +51,7 @@ sharding_ext = { version = "0.1.0", path = "../../cmdlib/sharding_ext" }
 slapi_service = { version = "0.1.0", path = "../../servers/slapi/slapi_service" }
 sorted_vector_map = { version = "0.2.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 url = "2.5.8"
 uuid = { version = "1.23.0", features = ["rng-getrandom", "serde", "v4", "v5", "v6", "v7", "v8"] }

--- a/eden/mononoke/jobs/statistics_collector/Cargo.toml
+++ b/eden/mononoke/jobs/statistics_collector/Cargo.toml
@@ -36,7 +36,7 @@ scuba_ext = { version = "0.1.0", path = "../../common/scuba_ext" }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 sharding_ext = { version = "0.1.0", path = "../../cmdlib/sharding_ext" }
 stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [dev-dependencies]

--- a/eden/mononoke/jobs/walker/Cargo.toml
+++ b/eden/mononoke/jobs/walker/Cargo.toml
@@ -79,7 +79,7 @@ sql_ext = { version = "0.1.0", path = "../../common/rust/sql_ext" }
 stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 strum = { version = "0.27.1", features = ["derive"] }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 unodes = { version = "0.1.0", path = "../../derived_data/unodes" }
 yield_stream = { version = "0.1.0", path = "../../common/yield_stream" }

--- a/eden/mononoke/lfs_import_lib/Cargo.toml
+++ b/eden/mononoke/lfs_import_lib/Cargo.toml
@@ -16,6 +16,6 @@ futures = { version = "0.3.31", features = ["async-await", "compat"] }
 mercurial_types = { version = "0.1.0", path = "../mercurial/types" }
 mononoke_types = { version = "0.1.0", path = "../mononoke_types" }
 repo_blobstore = { version = "0.1.0", path = "../repo_attributes/repo_blobstore" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tokio-util = { version = "0.7.18", features = ["full"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/eden/mononoke/manifest/Cargo.toml
+++ b/eden/mononoke/manifest/Cargo.toml
@@ -28,7 +28,7 @@ serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_derive = "1.0.185"
 smallvec = { version = "1.15", features = ["impl_bincode", "serde", "specialization", "union"] }
 sorted_vector_map = { version = "0.2.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 
 [dev-dependencies]
 fbinit = { version = "0.2.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }

--- a/eden/mononoke/mercurial/bundles/Cargo.toml
+++ b/eden/mononoke/mercurial/bundles/Cargo.toml
@@ -34,7 +34,7 @@ sapling-revisionstore_types = { version = "0.1.0", path = "../../../scm/lib/revi
 sapling-types = { version = "0.1.0", path = "../../../scm/lib/types" }
 sapling-vlqencoding = { version = "0.1.0", path = "../../../scm/lib/vlqencoding" }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tokio-util = { version = "0.7.18", features = ["full"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 

--- a/eden/mononoke/mercurial/types/Cargo.toml
+++ b/eden/mononoke/mercurial/types/Cargo.toml
@@ -44,7 +44,7 @@ sorted_vector_map = { version = "0.2.0", git = "https://github.com/facebookexper
 sql = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [dev-dependencies]

--- a/eden/mononoke/mononoke_api/Cargo.toml
+++ b/eden/mononoke/mononoke_api/Cargo.toml
@@ -122,7 +122,7 @@ stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust
 streaming_clone = { version = "0.1.0", path = "../repo_client/streaming_clone" }
 synced_commit_mapping = { version = "0.1.0", path = "../features/commit_rewriting/synced_commit_mapping" }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 unbundle = { version = "0.1.0", path = "../repo_client/unbundle" }
 unodes = { version = "0.1.0", path = "../derived_data/unodes" }

--- a/eden/mononoke/mononoke_api_hg/Cargo.toml
+++ b/eden/mononoke/mononoke_api_hg/Cargo.toml
@@ -60,4 +60,4 @@ sql_construct = { version = "0.1.0", path = "../common/sql_construct" }
 tempfile = "3.27.0"
 test_repo_factory = { version = "0.1.0", path = "../repo_factory/test_repo_factory" }
 tests_utils = { version = "0.1.0", path = "../tests/utils" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/mononoke/mononoke_types/Cargo.toml
+++ b/eden/mononoke/mononoke_types/Cargo.toml
@@ -54,7 +54,7 @@ sql = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-s
 strum = { version = "0.27.1", features = ["derive"] }
 thiserror = "2.0.18"
 thrift_convert = { version = "0.1.0", path = "../common/thrift_convert" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 vec_map = "0.8"
 

--- a/eden/mononoke/repo_attributes/bonsai_globalrev_mapping/globalrev_pushrebase_hook/Cargo.toml
+++ b/eden/mononoke/repo_attributes/bonsai_globalrev_mapping/globalrev_pushrebase_hook/Cargo.toml
@@ -39,4 +39,4 @@ repo_derived_data = { version = "0.1.0", path = "../../repo_derived_data" }
 repo_identity = { version = "0.1.0", path = "../../repo_identity" }
 test_repo_factory = { version = "0.1.0", path = "../../../repo_factory/test_repo_factory" }
 tests_utils = { version = "0.1.0", path = "../../../tests/utils" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/mononoke/repo_attributes/bonsai_tag_mapping/Cargo.toml
+++ b/eden/mononoke/repo_attributes/bonsai_tag_mapping/Cargo.toml
@@ -27,7 +27,7 @@ repo_update_logger = { version = "0.1.0", path = "../../features/repo_update_log
 sql_construct = { version = "0.1.0", path = "../../common/sql_construct" }
 sql_ext = { version = "0.1.0", path = "../../common/rust/sql_ext" }
 stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [dev-dependencies]

--- a/eden/mononoke/repo_attributes/bookmarks/Cargo.toml
+++ b/eden/mononoke/repo_attributes/bookmarks/Cargo.toml
@@ -32,4 +32,4 @@ maplit = "1.0"
 mononoke_macros = { version = "0.1.0", path = "../../common/mononoke_macros" }
 mononoke_types-mocks = { version = "0.1.0", path = "../../mononoke_types/mocks" }
 quickcheck = "1.0"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/mononoke/repo_attributes/bookmarks/dbbookmarks/Cargo.toml
+++ b/eden/mononoke/repo_attributes/bookmarks/dbbookmarks/Cargo.toml
@@ -40,4 +40,4 @@ mononoke_types-mocks = { version = "0.1.0", path = "../../../mononoke_types/mock
 quickcheck = "1.0"
 quickcheck_arbitrary_derive = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 sql = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/mononoke/repo_attributes/bookmarks/warm_bookmarks_cache/Cargo.toml
+++ b/eden/mononoke/repo_attributes/bookmarks/warm_bookmarks_cache/Cargo.toml
@@ -48,7 +48,7 @@ repo_identity = { version = "0.1.0", path = "../../repo_identity" }
 skeleton_manifest = { version = "0.1.0", path = "../../../derived_data/skeleton_manifest" }
 skeleton_manifest_v2 = { version = "0.1.0", path = "../../../derived_data/skeleton_manifest_v2" }
 stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 unodes = { version = "0.1.0", path = "../../../derived_data/unodes" }
 

--- a/eden/mononoke/repo_attributes/commit_graph/commit_graph/Cargo.toml
+++ b/eden/mononoke/repo_attributes/commit_graph/commit_graph/Cargo.toml
@@ -26,6 +26,6 @@ mononoke_macros = { version = "0.1.0", path = "../../../common/mononoke_macros" 
 mononoke_types = { version = "0.1.0", path = "../../../mononoke_types" }
 scuba_ext = { version = "0.1.0", path = "../../../common/scuba_ext" }
 smallvec = { version = "1.15", features = ["impl_bincode", "serde", "specialization", "union"] }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 vec1 = { version = "1.12.1", features = ["serde"] }

--- a/eden/mononoke/repo_attributes/commit_graph/preloaded_commit_graph_storage/Cargo.toml
+++ b/eden/mononoke/repo_attributes/commit_graph/preloaded_commit_graph_storage/Cargo.toml
@@ -22,7 +22,7 @@ mononoke_macros = { version = "0.1.0", path = "../../../common/mononoke_macros" 
 mononoke_types = { version = "0.1.0", path = "../../../mononoke_types" }
 reloader = { version = "0.1.0", path = "../../../common/reloader" }
 repo_identity = { version = "0.1.0", path = "../../repo_identity" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 vec1 = { version = "1.12.1", features = ["serde"] }
 

--- a/eden/mononoke/repo_attributes/filestore/Cargo.toml
+++ b/eden/mononoke/repo_attributes/filestore/Cargo.toml
@@ -28,7 +28,7 @@ sha1 = "0.10.5"
 sha2 = "0.10.6"
 strum = { version = "0.27.1", features = ["derive"] }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [dev-dependencies]

--- a/eden/mononoke/repo_attributes/git_ref_content_mapping/Cargo.toml
+++ b/eden/mononoke/repo_attributes/git_ref_content_mapping/Cargo.toml
@@ -25,7 +25,7 @@ repo_update_logger = { version = "0.1.0", path = "../../features/repo_update_log
 sql_construct = { version = "0.1.0", path = "../../common/sql_construct" }
 sql_ext = { version = "0.1.0", path = "../../common/rust/sql_ext" }
 stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [dev-dependencies]

--- a/eden/mononoke/repo_attributes/newfilenodes/Cargo.toml
+++ b/eden/mononoke/repo_attributes/newfilenodes/Cargo.toml
@@ -33,7 +33,7 @@ sql_ext = { version = "0.1.0", path = "../../common/rust/sql_ext" }
 stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 thiserror = "2.0.18"
 time_ext = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 vec1 = { version = "1.12.1", features = ["serde"] }
 
 [dev-dependencies]

--- a/eden/mononoke/repo_attributes/repo_derivation_queues/Cargo.toml
+++ b/eden/mononoke/repo_attributes/repo_derivation_queues/Cargo.toml
@@ -30,5 +30,5 @@ parking_lot = { version = "0.12.1", features = ["send_guard"] }
 sapling-clientinfo = { version = "0.1.0", path = "../../../scm/lib/clientinfo" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/eden/mononoke/repo_attributes/repo_event_publisher/Cargo.toml
+++ b/eden/mononoke/repo_attributes/repo_event_publisher/Cargo.toml
@@ -24,7 +24,7 @@ mononoke_macros = { version = "0.1.0", path = "../../common/mononoke_macros" }
 repo_update_logger = { version = "0.1.0", path = "../../features/repo_update_logger" }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 
 [dev-dependencies]
 fbinit-tokio = { version = "0.1.2", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }

--- a/eden/mononoke/repo_attributes/repo_permission_checker/Cargo.toml
+++ b/eden/mononoke/repo_attributes/repo_permission_checker/Cargo.toml
@@ -16,5 +16,5 @@ justknobs = { version = "0.1.0", git = "https://github.com/facebookexperimental/
 metaconfig_types = { version = "0.1.0", path = "../../metaconfig/types" }
 mockall = "0.13.1"
 permission_checker = { version = "0.1.0", path = "../../common/permission_checker" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/eden/mononoke/repo_attributes/restricted_paths/Cargo.toml
+++ b/eden/mononoke/repo_attributes/restricted_paths/Cargo.toml
@@ -30,7 +30,7 @@ restricted_paths_common = { version = "0.1.0", path = "../restricted_paths_commo
 sapling-clientinfo = { version = "0.1.0", path = "../../../scm/lib/clientinfo" }
 scuba_ext = { version = "0.1.0", path = "../../common/scuba_ext" }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [dev-dependencies]

--- a/eden/mononoke/repo_attributes/restricted_paths_common/Cargo.toml
+++ b/eden/mononoke/repo_attributes/restricted_paths_common/Cargo.toml
@@ -25,5 +25,5 @@ sql = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-s
 sql_construct = { version = "0.1.0", path = "../../common/sql_construct" }
 sql_ext = { version = "0.1.0", path = "../../common/rust/sql_ext" }
 strum = { version = "0.27.1", features = ["derive"] }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/eden/mononoke/repo_client/unbundle/Cargo.toml
+++ b/eden/mononoke/repo_client/unbundle/Cargo.toml
@@ -70,4 +70,4 @@ mercurial_types-mocks = { version = "0.1.0", path = "../../mercurial/types/mocks
 mononoke_macros = { version = "0.1.0", path = "../../common/mononoke_macros" }
 quickcheck_macros = "1.2.0"
 test_repo_factory = { version = "0.1.0", path = "../../repo_factory/test_repo_factory" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/mononoke/repo_client/wirepack/Cargo.toml
+++ b/eden/mononoke/repo_client/wirepack/Cargo.toml
@@ -19,4 +19,4 @@ thiserror = "2.0.18"
 [dev-dependencies]
 maplit = "1.0"
 mercurial_types-mocks = { version = "0.1.0", path = "../../mercurial/types/mocks" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/mononoke/repo_factory/Cargo.toml
+++ b/eden/mononoke/repo_factory/Cargo.toml
@@ -90,7 +90,7 @@ stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust
 streaming_clone = { version = "0.1.0", path = "../repo_client/streaming_clone" }
 synced_commit_mapping = { version = "0.1.0", path = "../features/commit_rewriting/synced_commit_mapping" }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 virtually_sharded_blobstore = { version = "0.1.0", path = "../blobstore/virtually_sharded_blobstore" }
 warm_bookmarks_cache = { version = "0.1.0", path = "../repo_attributes/bookmarks/warm_bookmarks_cache" }

--- a/eden/mononoke/servers/git/git_server/Cargo.toml
+++ b/eden/mononoke/servers/git/git_server/Cargo.toml
@@ -79,7 +79,7 @@ slapi_service = { version = "0.1.0", path = "../../slapi/slapi_service" }
 stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 strum = { version = "0.27.1", features = ["derive"] }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tokio-stream = { version = "0.1.18", features = ["fs", "io-util", "net", "signal", "sync", "time"] }
 topo_sort = { version = "0.1.0", path = "../../../common/topo_sort" }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/eden/mononoke/servers/lfs/lfs_server/Cargo.toml
+++ b/eden/mononoke/servers/lfs/lfs_server/Cargo.toml
@@ -66,7 +66,7 @@ stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust
 thiserror = "2.0.18"
 time_ext = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 time_window_counter = { version = "0.1.0", path = "../../../common/time_window_counter" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [dev-dependencies]

--- a/eden/mononoke/servers/scs/scs_methods/Cargo.toml
+++ b/eden/mononoke/servers/scs/scs_methods/Cargo.toml
@@ -78,7 +78,7 @@ source_control_services = { version = "0.1.0", path = "../../../scs/if/services"
 stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 synced_commit_mapping = { version = "0.1.0", path = "../../../features/commit_rewriting/synced_commit_mapping" }
 time_ext = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [dev-dependencies]

--- a/eden/mononoke/servers/slapi/slapi_server/Cargo.toml
+++ b/eden/mononoke/servers/slapi/slapi_server/Cargo.toml
@@ -29,5 +29,5 @@ sapling-clientinfo = { version = "0.1.0", path = "../../../../scm/lib/clientinfo
 scuba_ext = { version = "0.1.0", path = "../../../common/scuba_ext" }
 secure_utils = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 sharding_ext = { version = "0.1.0", path = "../../../cmdlib/sharding_ext" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/eden/mononoke/servers/slapi/slapi_server/repo_listener/Cargo.toml
+++ b/eden/mononoke/servers/slapi/slapi_server/repo_listener/Cargo.toml
@@ -62,7 +62,7 @@ stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust
 textwrap = { version = "0.16.0", features = ["terminal_size"] }
 thiserror = "2.0.18"
 time_ext = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tokio-openssl = "0.6.5"
 tokio-util = { version = "0.7.18", features = ["full"] }
 tower-service = "0.3.3"

--- a/eden/mononoke/servers/slapi/slapi_service/Cargo.toml
+++ b/eden/mononoke/servers/slapi/slapi_service/Cargo.toml
@@ -77,7 +77,7 @@ streaming_clone = { version = "0.1.0", path = "../../../repo_client/streaming_cl
 thiserror = "2.0.18"
 time_ext = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 time_window_counter = { version = "0.1.0", path = "../../../common/time_window_counter" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tokio-util = { version = "0.7.18", features = ["full"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 vec1 = { version = "1.12.1", features = ["serde"] }

--- a/eden/mononoke/tools/admin/Cargo.toml
+++ b/eden/mononoke/tools/admin/Cargo.toml
@@ -136,7 +136,7 @@ strum = { version = "0.27.1", features = ["derive"] }
 synced_commit_mapping = { version = "0.1.0", path = "../../features/commit_rewriting/synced_commit_mapping" }
 thiserror = "2.0.18"
 time_measuring = { version = "0.1.0", path = "../../common/time_measuring" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tokio-stream = { version = "0.1.18", features = ["fs", "io-util", "net", "signal", "sync", "time"] }
 tokio-util = { version = "0.7.18", features = ["full"] }
 topo_sort = { version = "0.1.0", path = "../../common/topo_sort" }

--- a/eden/mononoke/tools/aliasverify/tools/aliasverify/Cargo.toml
+++ b/eden/mononoke/tools/aliasverify/tools/aliasverify/Cargo.toml
@@ -33,5 +33,5 @@ repo_blobstore = { version = "0.1.0", path = "../../../../repo_attributes/repo_b
 repo_identity = { version = "0.1.0", path = "../../../../repo_attributes/repo_identity" }
 sharding_ext = { version = "0.1.0", path = "../../../../cmdlib/sharding_ext" }
 sql_commit_graph_storage = { version = "0.1.0", path = "../../../../repo_attributes/commit_graph/sql_commit_graph_storage" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/eden/mononoke/tools/bonsai_verify/Cargo.toml
+++ b/eden/mononoke/tools/bonsai_verify/Cargo.toml
@@ -34,6 +34,6 @@ repo_derived_data = { version = "0.1.0", path = "../../repo_attributes/repo_deri
 restricted_paths = { version = "0.1.0", path = "../../repo_attributes/restricted_paths" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_derive = "1.0.185"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 toml = { version = "0.9.12", features = ["preserve_order"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/eden/mononoke/tools/executor/Cargo.toml
+++ b/eden/mononoke/tools/executor/Cargo.toml
@@ -15,5 +15,5 @@ executor_lib = { version = "0.1.0", path = "../../cmdlib/sharding" }
 fbinit = { version = "0.2.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 mononoke_app = { version = "0.1.0", path = "../../cmdlib/mononoke_app" }
 sharding_ext = { version = "0.1.0", path = "../../cmdlib/sharding_ext" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/eden/mononoke/tools/packer/Cargo.toml
+++ b/eden/mononoke/tools/packer/Cargo.toml
@@ -23,7 +23,7 @@ packblob = { version = "0.1.0", path = "../../blobstore/packblob" }
 rand = "0.10"
 regex = "1.12.3"
 scuba_ext = { version = "0.1.0", path = "../../common/scuba_ext" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [dev-dependencies]

--- a/eden/mononoke/tools/repo_import/Cargo.toml
+++ b/eden/mononoke/tools/repo_import/Cargo.toml
@@ -62,7 +62,7 @@ serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 sql_query_config = { version = "0.1.0", path = "../../repo_attributes/sql_query_config" }
 synced_commit_mapping = { version = "0.1.0", path = "../../features/commit_rewriting/synced_commit_mapping" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 topo_sort = { version = "0.1.0", path = "../../common/topo_sort" }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 wireproto_handler = { version = "0.1.0", path = "../../servers/slapi/wireproto_handler" }

--- a/eden/mononoke/tools/streaming_clone/Cargo.toml
+++ b/eden/mononoke/tools/streaming_clone/Cargo.toml
@@ -23,5 +23,5 @@ mutable_blobstore = { version = "0.1.0", path = "../../repo_attributes/mutable_b
 repo_identity = { version = "0.1.0", path = "../../repo_attributes/repo_identity" }
 sapling-clientinfo = { version = "0.1.0", path = "../../../scm/lib/clientinfo" }
 streaming_clone = { version = "0.1.0", path = "../../repo_client/streaming_clone" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/eden/mononoke/tools/tail-to-cloudwatch/Cargo.toml
+++ b/eden/mononoke/tools/tail-to-cloudwatch/Cargo.toml
@@ -14,7 +14,7 @@ aws-sdk-cloudwatchlogs = "1.71.0"
 clap = { version = "4.6.0", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"

--- a/eden/mononoke/tools/testtool/Cargo.toml
+++ b/eden/mononoke/tools/testtool/Cargo.toml
@@ -37,7 +37,7 @@ smallvec = { version = "1.15", features = ["impl_bincode", "serde", "specializat
 sorted_vector_map = { version = "0.2.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 sql_construct = { version = "0.1.0", path = "../../common/sql_construct" }
 tests_utils = { version = "0.1.0", path = "../../tests/utils" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 topo_sort = { version = "0.1.0", path = "../../common/topo_sort" }
 
 [dev-dependencies]

--- a/eden/scm/exec/scm_daemon/Cargo.toml
+++ b/eden/scm/exec/scm_daemon/Cargo.toml
@@ -13,7 +13,7 @@ log = { version = "0.4.29", features = ["kv_unstable", "kv_unstable_std"] }
 sapling-commitcloudsubscriber = { version = "0.1.0", path = "../../lib/commitcloudsubscriber" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 toml = { version = "0.9.12", features = ["preserve_order"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/eden/scm/lib/async-runtime/Cargo.toml
+++ b/eden/scm/lib/async-runtime/Cargo.toml
@@ -16,4 +16,4 @@ name = "async_runtime"
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
 num_cpus = "1.16"
 once_cell = "1.21.4"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/scm/lib/commitcloudsubscriber/Cargo.toml
+++ b/eden/scm/lib/commitcloudsubscriber/Cargo.toml
@@ -39,7 +39,7 @@ sapling-identity = { version = "0.1.0", path = "../identity" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/eden/scm/lib/copytrace/Cargo.toml
+++ b/eden/scm/lib/copytrace/Cargo.toml
@@ -35,5 +35,5 @@ tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [dev-dependencies]
 sapling-manifest-tree = { version = "0.1.0", path = "../manifest-tree", features = ["for-tests"] }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing-test = { version = "0.2.6", features = ["no-env-filter"] }

--- a/eden/scm/lib/cpython-async/Cargo.toml
+++ b/eden/scm/lib/cpython-async/Cargo.toml
@@ -16,4 +16,4 @@ sapling-async-runtime = { version = "0.1.0", path = "../async-runtime" }
 sapling-cpython-ext = { version = "0.1.0", path = "../cpython-ext" }
 
 [dev-dependencies]
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/scm/lib/dag/Cargo.toml
+++ b/eden/scm/lib/dag/Cargo.toml
@@ -41,7 +41,7 @@ quickcheck = "1.0"
 sapling-dev-logger = { version = "0.1.0", path = "../dev-logger" }
 sapling-renderdag = { version = "0.1.0", path = "../renderdag" }
 tempfile = "3.27.0"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 
 [features]
 default = ["indexedlog-backend", "render"]

--- a/eden/scm/lib/eagerepo/Cargo.toml
+++ b/eden/scm/lib/eagerepo/Cargo.toml
@@ -45,4 +45,4 @@ tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [dev-dependencies]
 tempfile = "3.27.0"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/scm/lib/edenapi/Cargo.toml
+++ b/eden/scm/lib/edenapi/Cargo.toml
@@ -38,6 +38,6 @@ sapling-version = { version = "0.1.0", path = "../version" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_cbor = "0.11.2"
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 url = "2.5.8"

--- a/eden/scm/lib/edenapi/ext/Cargo.toml
+++ b/eden/scm/lib/edenapi/ext/Cargo.toml
@@ -30,7 +30,7 @@ sapling-types = { version = "0.1.0", path = "../../types" }
 sapling-util = { version = "0.1.0", path = "../../util" }
 sapling-vfs = { version = "0.1.0", path = "../../vfs" }
 serde_cbor = "0.11.2"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [dev-dependencies]

--- a/eden/scm/lib/http-client/Cargo.toml
+++ b/eden/scm/lib/http-client/Cargo.toml
@@ -36,7 +36,7 @@ serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_cbor = "0.11.2"
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tokio-util = { version = "0.7.18", features = ["full"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 url = "2.5.8"

--- a/eden/scm/lib/minibench/examples/Cargo.toml
+++ b/eden/scm/lib/minibench/examples/Cargo.toml
@@ -13,4 +13,4 @@ path = "fs_read.rs"
 crossbeam = "0.8"
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
 sapling-minibench = { version = "0.1.0", path = ".." }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/scm/lib/pathhistory/Cargo.toml
+++ b/eden/scm/lib/pathhistory/Cargo.toml
@@ -28,4 +28,4 @@ blob = { version = "0.1.0", path = "../blob" }
 sapling-dev-logger = { version = "0.1.0", path = "../dev-logger" }
 sapling-manifest = { version = "0.1.0", path = "../manifest" }
 sha1 = "0.10.5"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/scm/lib/progress/model/Cargo.toml
+++ b/eden/scm/lib/progress/model/Cargo.toml
@@ -18,5 +18,5 @@ once_cell = "1.21.4"
 parking_lot = { version = "0.12.1", features = ["send_guard"] }
 paste = "1.0.14"
 thread_local = "1.1.4"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/eden/scm/lib/revisionstore/Cargo.toml
+++ b/eden/scm/lib/revisionstore/Cargo.toml
@@ -60,7 +60,7 @@ serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw
 sha1 = "0.10.5"
 sha2 = "0.10.6"
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tokio-stream = { version = "0.1.18", features = ["fs", "io-util", "net", "signal", "sync", "time"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 url = "2.5.8"

--- a/eden/scm/lib/sparse/Cargo.toml
+++ b/eden/scm/lib/sparse/Cargo.toml
@@ -22,11 +22,11 @@ sapling-pathmatcher = { version = "0.1.0", path = "../pathmatcher" }
 sapling-rewrite-macros = { version = "0.1.0", path = "../util/rewrite-macros" }
 sapling-types = { version = "0.1.0", path = "../types" }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"], optional = true }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"], optional = true }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [dev-dependencies]
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 
 [features]
 async = ["futures", "tokio"]

--- a/eden/scm/lib/streams/Cargo.toml
+++ b/eden/scm/lib/streams/Cargo.toml
@@ -19,4 +19,4 @@ pin-project = "1.1.11"
 
 [dev-dependencies]
 anyhow = "1.0.102"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/eden/scm/lib/vfs/Cargo.toml
+++ b/eden/scm/lib/vfs/Cargo.toml
@@ -26,7 +26,7 @@ sapling-minibytes = { version = "0.1.0", path = "../minibytes" }
 sapling-types = { version = "0.1.0", path = "../types" }
 sapling-util = { version = "0.1.0", path = "../util" }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [dev-dependencies]

--- a/eden/scm/lib/workingcopy/Cargo.toml
+++ b/eden/scm/lib/workingcopy/Cargo.toml
@@ -49,7 +49,7 @@ sapling-vfs = { version = "0.1.0", path = "../vfs" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 watchman_client = { version = "0.9.0", git = "https://github.com/facebook/watchman.git", branch = "main" }
 whoami = "1.5"


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/below/pull/8278

X-link: https://github.com/facebookexperimental/dapper/pull/1

X-link: https://github.com/meta-pytorch/monarch/pull/3495

Upgrading `tokio` from `1.50.0` to `1.52.1`.
- All downstream consumers checked with arc rust-check — 0 errors.

Reviewed By: dtolnay

Differential Revision: D101580193
