### PR TITLE
ci: declare workflow-level `contents: read` on 2 workflows

### DIFF
--- a/.github/workflows/edenscm-libs.yml
+++ b/.github/workflows/edenscm-libs.yml
@@ -3,6 +3,9 @@ name: EdenSCM Rust Libraries
 on:
   workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/sapling-addons.yml
+++ b/.github/workflows/sapling-addons.yml
@@ -5,6 +5,9 @@ env:
 on:
   public
 
+permissions:
+  contents: read
+
 jobs:
   verify-addons:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 2 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

The following files were left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Those scopes are best declared by maintainers: `manylinux_2_34.yml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.