### PR TITLE
nanodag: drop Option in return types (#1313)

### DIFF
--- a/eden/scm/lib/linelog/src/debug.rs
+++ b/eden/scm/lib/linelog/src/debug.rs
@@ -216,9 +216,11 @@ impl fmt::Display for NanoDag {
                 let mut children_vec = Vec::with_capacity(end + 1);
                 children_vec.push(dag.roots(&dag.all()).shift1());
                 for rev in 0..dag.parents.len() {
-                    let revs = match dag.children(rev) {
-                        Some(revs) => revs.shift1(),
-                        None => end_revs.clone(),
+                    let children = dag.children(rev);
+                    let revs = if children.is_empty() {
+                        end_revs.clone()
+                    } else {
+                        children.shift1()
                     };
                     children_vec.push(revs);
                 }

--- a/eden/scm/lib/linelog/src/linelog.rs
+++ b/eden/scm/lib/linelog/src/linelog.rs
@@ -405,12 +405,7 @@ impl<T: Default + PartialEq> AbstractLineLog<T> {
         // (a_rev is the last rev, no higher revs ever exist, and b_rev's only direct
         // parent is a_rev, so nothing can get in-between).
         let can_update_cache = a_rev == b_rev
-            || (self
-                .dag
-                .parents(b_rev)
-                .map(|p| p == &[a_rev])
-                .unwrap_or(false)
-                && a_rev == self.max_rev);
+            || (self.dag.parents(b_rev) == [a_rev].as_slice() && a_rev == self.max_rev);
         let maybe_a_lines: MaybeMut<_> = match can_update_cache {
             true => MaybeMut::Mut(&mut a_lines),
             false => MaybeMut::Ref(&a_lines),
@@ -615,15 +610,11 @@ impl<T: Default + PartialEq> AbstractLineLog<T> {
         let mut insert_revs = SmallRevs::empty();
         let mut delete_revs: Option<SmallRevs> = None;
         for target_rev in target_revs.iter() {
-            match self.dag.ancestors(target_rev) {
-                Some(ancestors) => {
-                    insert_revs.union_with(ancestors);
-                    match delete_revs.as_mut() {
-                        Some(delete_revs) => delete_revs.intersect_with(ancestors),
-                        None => delete_revs = Some(ancestors.clone()),
-                    }
-                }
-                None => delete_revs = Some(SmallRevs::empty()),
+            let ancestors = self.dag.ancestors(target_rev);
+            insert_revs.union_with(ancestors);
+            match delete_revs.as_mut() {
+                Some(delete_revs) => delete_revs.intersect_with(ancestors),
+                None => delete_revs = Some(ancestors.clone()),
             }
         }
         let delete_revs = delete_revs.unwrap_or_else(SmallRevs::empty);

--- a/eden/scm/lib/linelog/src/linelog.rs
+++ b/eden/scm/lib/linelog/src/linelog.rs
@@ -176,7 +176,7 @@ impl<T: Default + PartialEq> AbstractLineLog<T> {
     ///
     /// Panics if `a_rev` > `max_rev`.
     pub fn edit_chunk(
-        self,
+        mut self,
         a_rev: Rev,
         mut a1: LineIdx,
         mut a2: LineIdx,
@@ -189,16 +189,13 @@ impl<T: Default + PartialEq> AbstractLineLog<T> {
             "a_rev {a_rev} must not be greater than max_rev {}",
             self.max_rev
         );
-        let this = if flags.contains(EditFlags::ADD_EDGE) && a_rev <= b_rev {
-            Self {
-                dag: self.dag.with_edge(a_rev, b_rev),
-                ..self
-            }
-        } else {
-            self
+        // Resize dag to make b_rev valid rev, regardless of ADD_EDGE.
+        self.dag = self.dag.with_edge(b_rev, b_rev);
+        if flags.contains(EditFlags::ADD_EDGE) && a_rev <= b_rev {
+            self.dag = self.dag.with_edge(a_rev, b_rev);
         };
         let mut b_lines = b_lines.into_iter().map(Arc::new).collect::<VecDeque<_>>();
-        this.with_a_lines_cache(a_rev, b_rev, |this: Self, maybe_mut| {
+        self.with_a_lines_cache(a_rev, b_rev, |this: Self, maybe_mut| {
             if flags.contains(EditFlags::BLOCK_SHIFT) {
                 const DEFAULT_SHIFT_THRESHOLD: usize = 5;
                 this.try_block_shift(
@@ -209,6 +206,7 @@ impl<T: Default + PartialEq> AbstractLineLog<T> {
                     DEFAULT_SHIFT_THRESHOLD,
                 );
             };
+            debug_assert!(this.dag.all().contains(b_rev));
             this.edit_chunk_internal(a1, a2, b_rev, b_lines, maybe_mut)
         })
     }

--- a/eden/scm/lib/linelog/src/linelog.rs
+++ b/eden/scm/lib/linelog/src/linelog.rs
@@ -360,21 +360,13 @@ impl<T: Default + PartialEq + fmt::Debug> AbstractLineLog<T> {
         self.execute(&SmallRevs::from(rev), None)
     }
 
-    /// Checkout the lines of the given revision range `start` to `end`, both
-    /// inclusive.
-    ///
-    /// For example, if `start` is 0, and `rev` is `max_rev()`, the result will
-    /// include all lines ever existed in all revisions.
-    pub fn checkout_range_lines(&self, start: Rev, end: Rev) -> ImVec<LineInfo<T>> {
-        let lines = self.checkout_lines(end);
+    /// Checkout the lines that are visible in any of the given target revisions.
+    pub fn checkout_revs_lines(&self, target_revs: &SmallRevs) -> ImVec<LineInfo<T>> {
+        let head_revs = self.dag.heads(target_revs);
+        let lines = self.execute(&head_revs, None);
         let present_pc_set = lines.into_iter().map(|l| l.pc).collect::<HashSet<Pc>>();
         let is_present = move |pc| present_pc_set.contains(&pc);
-        let target_revs = if start <= end {
-            SmallRevs::from_range(start..end + 1)
-        } else {
-            SmallRevs::empty()
-        };
-        self.execute(&target_revs, Some(Box::new(is_present)))
+        self.execute(target_revs, Some(Box::new(is_present)))
     }
 
     /// Prepare and update a_lines_cache for edit_chunk_internal

--- a/eden/scm/lib/linelog/src/linelog.rs
+++ b/eden/scm/lib/linelog/src/linelog.rs
@@ -700,6 +700,16 @@ impl<T> AbstractLineLog<T> {
         }
     }
 
+    /// Insert a rev after `rev`.
+    ///
+    /// Original `r` (`r > rev`) will shift to `r + 1` in both the linelog
+    /// instructions and the dag.
+    pub fn insert_shift(self, rev: Rev) -> Self {
+        let result = self.remap_revs(&|r| if r > rev { r + 1 } else { r });
+        let dag = result.dag.insert_shift(rev);
+        Self { dag, ..result }
+    }
+
     /// Truncate linelog. Drop revs >= the given `rev`.
     pub fn truncate(self, rev: Rev) -> Self {
         let mut max_rev = 0;

--- a/eden/scm/lib/linelog/src/linelog.rs
+++ b/eden/scm/lib/linelog/src/linelog.rs
@@ -155,7 +155,7 @@ impl Default for EditFlags {
     }
 }
 
-impl<T: Default + PartialEq + fmt::Debug> AbstractLineLog<T> {
+impl<T: Default + PartialEq> AbstractLineLog<T> {
     /// Edit chunk. Replace lines from `a1` (inclusive) to `a2` (exclusive) in rev
     /// `a_rev` with `b_lines`. `b_lines` are considered introduced by `b_rev`.
     /// If `b_lines` is empty, the edit is a deletion. If `a1` equals to `a2`,
@@ -428,7 +428,7 @@ impl<T: Default + PartialEq + fmt::Debug> AbstractLineLog<T> {
                     .clone()
                     .with_perf_stats(None)
                     .execute(&SmallRevs::from(b_rev), None);
-                assert_eq!(fresh_lines, a_lines);
+                assert!(fresh_lines == a_lines);
             }
             result.a_lines_cache = Some((b_rev, a_lines));
         } else {

--- a/eden/scm/lib/linelog/src/linelog.rs
+++ b/eden/scm/lib/linelog/src/linelog.rs
@@ -405,8 +405,16 @@ impl<T: Default + PartialEq + fmt::Debug> AbstractLineLog<T> {
         .unwrap_or_else(|| self.execute(a_rev, a_rev, None));
 
         // Can only update cache if there are no possible edits between a_rev and b_rev.
-        // It could be a_rev == b_rev, or b_rev >= a_rev >= max_rev.
-        let can_update_cache = a_rev == b_rev || (b_rev >= a_rev && a_rev >= self.max_rev);
+        // It could be a_rev == b_rev, or parents(b_rev) == [a_rev] && a_rev >= max_rev
+        // (a_rev is the last rev, no higher revs ever exist, and b_rev's only direct
+        // parent is a_rev, so nothing can get in-between).
+        let can_update_cache = a_rev == b_rev
+            || (self
+                .dag
+                .parents(b_rev)
+                .map(|p| p == &[a_rev])
+                .unwrap_or(false)
+                && a_rev == self.max_rev);
         let maybe_a_lines: MaybeMut<_> = match can_update_cache {
             true => MaybeMut::Mut(&mut a_lines),
             false => MaybeMut::Ref(&a_lines),

--- a/eden/scm/lib/linelog/src/linelog.rs
+++ b/eden/scm/lib/linelog/src/linelog.rs
@@ -18,6 +18,7 @@ use im::Vector as ImVec;
 
 use crate::maybe_mut::MaybeMut;
 use crate::nanodag::NanoDag;
+use crate::small_revs::SmallRevs;
 
 /// See https://sapling-scm.com/docs/internals/linelog for details.
 pub struct AbstractLineLog<T> {
@@ -356,7 +357,7 @@ impl<T: Default + PartialEq + fmt::Debug> AbstractLineLog<T> {
             }
         }
 
-        self.execute(rev, rev, None)
+        self.execute(&SmallRevs::from(rev), None)
     }
 
     /// Checkout the lines of the given revision range `start` to `end`, both
@@ -368,7 +369,12 @@ impl<T: Default + PartialEq + fmt::Debug> AbstractLineLog<T> {
         let lines = self.checkout_lines(end);
         let present_pc_set = lines.into_iter().map(|l| l.pc).collect::<HashSet<Pc>>();
         let is_present = move |pc| present_pc_set.contains(&pc);
-        self.execute(start, end, Some(Box::new(is_present)))
+        let target_revs = if start <= end {
+            SmallRevs::from_range(start..end + 1)
+        } else {
+            SmallRevs::empty()
+        };
+        self.execute(&target_revs, Some(Box::new(is_present)))
     }
 
     /// Prepare and update a_lines_cache for edit_chunk_internal
@@ -402,7 +408,7 @@ impl<T: Default + PartialEq + fmt::Debug> AbstractLineLog<T> {
             }
             _ => None,
         })
-        .unwrap_or_else(|| self.execute(a_rev, a_rev, None));
+        .unwrap_or_else(|| self.execute(&SmallRevs::from(a_rev), None));
 
         // Can only update cache if there are no possible edits between a_rev and b_rev.
         // It could be a_rev == b_rev, or parents(b_rev) == [a_rev] && a_rev >= max_rev
@@ -429,7 +435,7 @@ impl<T: Default + PartialEq + fmt::Debug> AbstractLineLog<T> {
                 let fresh_lines = result
                     .clone()
                     .with_perf_stats(None)
-                    .execute(b_rev, b_rev, None);
+                    .execute(&SmallRevs::from(b_rev), None);
                 assert_eq!(fresh_lines, a_lines);
             }
             result.a_lines_cache = Some((b_rev, a_lines));
@@ -607,13 +613,31 @@ impl<T: Default + PartialEq + fmt::Debug> AbstractLineLog<T> {
     // private because of `present`. no caching.
     fn execute(
         &self,
-        start_rev: Rev,
-        end_rev: Rev,
+        target_revs: &SmallRevs,
         present: Option<Box<dyn Fn(Pc) -> bool>>,
     ) -> ImVec<LineInfo<T>> {
         if let Some(stats) = self.perf_stats.as_ref() {
             stats.execute.fetch_add(1, Ordering::Release);
         }
+
+        // A line inserted in any target rev should be included, but a deletion
+        // only hides the line if it is effective in every target rev.
+        let mut insert_revs = SmallRevs::empty();
+        let mut delete_revs: Option<SmallRevs> = None;
+        for target_rev in target_revs.iter() {
+            match self.dag.ancestors(target_rev) {
+                Some(ancestors) => {
+                    insert_revs.union_with(ancestors);
+                    match delete_revs.as_mut() {
+                        Some(delete_revs) => delete_revs.intersect_with(ancestors),
+                        None => delete_revs = Some(ancestors.clone()),
+                    }
+                }
+                None => delete_revs = Some(SmallRevs::empty()),
+            }
+        }
+        let delete_revs = delete_revs.unwrap_or_else(SmallRevs::empty);
+
         let mut lines = ImVec::<LineInfo<T>>::new();
         let mut pc = 0;
         // Each instructions should be executed at most once. There is no loop.
@@ -638,14 +662,14 @@ impl<T: Default + PartialEq + fmt::Debug> AbstractLineLog<T> {
                     break;
                 }
                 Inst::JGE(rev, j_pc) => {
-                    if self.dag.is_ancestor(*rev, start_rev) {
+                    if delete_revs.contains(*rev) {
                         pc = *j_pc;
                     } else {
                         pc += 1;
                     }
                 }
                 Inst::JL(rev, j_pc) => {
-                    if !self.dag.is_ancestor(*rev, end_rev) {
+                    if !insert_revs.contains(*rev) {
                         pc = *j_pc;
                     } else {
                         pc += 1;

--- a/eden/scm/lib/linelog/src/nanodag.rs
+++ b/eden/scm/lib/linelog/src/nanodag.rs
@@ -326,6 +326,188 @@ impl NanoDag {
         }
     }
 
+    /// Build a topo-numbered DAG from a proposed DAG shape.
+    ///
+    /// `new_parents` must have the same length as this DAG. Each
+    /// `new_parents[old_child]` item lists the proposed parents of
+    /// `old_child`, using old revision ids. The proposed parents do not need
+    /// to be topologically numbered. For example, this is a valid input shape:
+    ///
+    /// ```text
+    /// old ids:     0   1
+    /// proposed:    1 -> 0
+    /// new_parents[0] = [1]
+    /// new_parents[1] = []
+    /// ```
+    ///
+    /// If there are no other constraints, this returns a mapping where old rev
+    /// 1 receives a smaller new rev than old rev 0, and a returned DAG shaped
+    /// as `0 -> 1`.
+    ///
+    /// `constraints` is another DAG over the same old revision ids. Its edges
+    /// are hard dependencies, typically from linelog textual dependencies
+    /// (`dep_map`). Every constraint edge must remain reachable in the returned
+    /// DAG. The proposed DAG may preserve a constraint as an indirect path. For
+    /// example, a constraint edge `1 -> 3` is satisfied by proposed edges
+    /// `1 -> 2 -> 3`.
+    ///
+    /// Returns the new topo-numbered DAG and an old-to-new rev mapping. Callers
+    /// that only want a dry run can use this method and ignore the successful
+    /// value. Callers that want to reoder revs that should match the nanodag
+    /// revs, for example, `LineLog`, should apply the old-to-new rev mapping
+    /// to their own internal states.
+    ///
+    /// Returns an error if a parent or constraint rev is out of bounds, if a
+    /// self-edge is proposed, if a constraint path is missing from the returned
+    /// DAG, or if the proposed edges contain a cycle.
+    pub fn topo_remap(
+        &self,
+        new_parents: Vec<SmallVec<[Rev; 1]>>,
+        constraints: &NanoDag,
+    ) -> Result<(Self, Vec<Rev>), String> {
+        let len = new_parents.len();
+        if self.len() != len {
+            return Err(format!(
+                "proposed dag has {} revs but current dag has {} revs",
+                len,
+                self.len()
+            ));
+        }
+        if constraints.len() > len {
+            return Err(format!(
+                "constraint dag has rev {} but proposed dag only has {} revs",
+                constraints.len() - 1,
+                len
+            ));
+        }
+
+        let mut children = vec![Vec::<Rev>::new(); len];
+
+        for (child, parents) in new_parents.iter().enumerate() {
+            for (index, parent) in parents.iter().enumerate() {
+                if *parent >= len {
+                    return Err(format!(
+                        "parent rev {parent} for child rev {child} is out of bounds"
+                    ));
+                }
+                if *parent == child {
+                    return Err(format!(
+                        "self edge {parent} -> {child} in proposed dag is not allowed"
+                    ));
+                }
+                if parents[..index].contains(parent) {
+                    return Err(format!("duplicate parent {parent} for child rev {child}"));
+                }
+                children[*parent].push(child);
+            }
+        }
+
+        fn find_cycle_edge(children: &[Vec<Rev>]) -> Option<(Rev, Rev)> {
+            fn visit(rev: Rev, children: &[Vec<Rev>], states: &mut [u8]) -> Option<(Rev, Rev)> {
+                states[rev] = 1;
+                for child in &children[rev] {
+                    match states[*child] {
+                        0 => {
+                            if let Some(edge) = visit(*child, children, states) {
+                                return Some(edge);
+                            }
+                        }
+                        1 => return Some((rev, *child)),
+                        _ => {}
+                    }
+                }
+                states[rev] = 2;
+                None
+            }
+
+            let mut states = vec![0; children.len()];
+            for rev in 0..children.len() {
+                if states[rev] == 0 {
+                    if let Some(edge) = visit(rev, children, &mut states) {
+                        return Some(edge);
+                    }
+                }
+            }
+            None
+        }
+        if let Some((parent, child)) = find_cycle_edge(&children) {
+            return Err(format!(
+                "proposed dag contains a cycle involving edge {parent} -> {child}"
+            ));
+        }
+
+        let mut ready: SmallRevs = new_parents
+            .iter()
+            .enumerate()
+            .filter_map(|(rev, parents)| parents.is_empty().then_some(rev))
+            .collect();
+        let mut visited = SmallRevs::empty();
+        let mut old_to_new = vec![0; len];
+        for new_rev in 0..len {
+            let Some(old_rev) = ready.iter().next() else {
+                return Err("proposed dag contains a cycle; no ready root rev remains".to_string());
+            };
+            ready.remove(old_rev);
+            visited.insert(old_rev);
+            old_to_new[old_rev] = new_rev;
+            for child in &children[old_rev] {
+                if new_parents[*child]
+                    .iter()
+                    .all(|parent| visited.contains(*parent))
+                {
+                    ready.insert(*child);
+                }
+            }
+        }
+
+        let mut parents: ImVec<SmallVec<[Rev; 1]>> =
+            (0..old_to_new.len()).map(|_| SmallVec::new()).collect();
+        for (old_child, old_parents) in new_parents.iter().enumerate() {
+            let new_child = old_to_new[old_child];
+            let remapped_parents = old_parents
+                .iter()
+                .map(|old_parent| old_to_new[*old_parent])
+                .collect();
+            parents.set(new_child, remapped_parents);
+        }
+
+        let dag = Self {
+            children: Self::children_from_parents(&parents),
+            parents,
+            cache: Default::default(),
+            perf_stats: self.perf_stats.clone(),
+        };
+
+        for (old_child, old_parents) in constraints.iter() {
+            for old_parent in old_parents {
+                if *old_parent >= len {
+                    return Err(format!(
+                        "constraint parent rev {old_parent} for child rev {old_child} is out of bounds"
+                    ));
+                }
+                if old_child >= len {
+                    return Err(format!(
+                        "constraint child rev {old_child} with parent rev {old_parent} is out of bounds"
+                    ));
+                }
+                if *old_parent == old_child {
+                    return Err(format!(
+                        "constraint self edge {old_parent} -> {old_child} is not allowed"
+                    ));
+                }
+                let new_parent = old_to_new[*old_parent];
+                let new_child = old_to_new[old_child];
+                if !dag.is_ancestor(new_parent, new_child) {
+                    return Err(format!(
+                        "constraint path {old_parent} -> {old_child} is missing from proposed dag after remap ({new_parent} -> {new_child})"
+                    ));
+                }
+            }
+        }
+
+        Ok((dag, old_to_new))
+    }
+
     /// Fold revs into the smallest rev in `revs`.
     ///
     /// Folded revs other than the smallest rev become isolated. Edges crossing
@@ -638,6 +820,82 @@ mod tests {
         let empty = truncated.truncate(0);
         assert_eq!(empty.parents(0), None);
         assert_eq!(revs_vec(&empty.heads(&empty.all())), vec![]);
+    }
+
+    #[test]
+    fn test_topo_remap_reorders_non_topological_parents() {
+        // Proposed old-id graph: 1 -> 0. The returned mapping makes old rev 1
+        // come before old rev 0.
+        let new_parents = vec![SmallVec::from_buf([1]), SmallVec::new()];
+        let dag = NanoDag::from_edges(2, &[]);
+        let (dag, old_to_new) = dag
+            .topo_remap(new_parents, &NanoDag::default())
+            .expect("proposal is acyclic");
+
+        assert_eq!(old_to_new, vec![1, 0]);
+        assert_eq!(dag.to_string(), "0-1");
+    }
+
+    #[test]
+    fn test_topo_remap_respects_constraints() {
+        // The constraint 1 -> 3 can be preserved as the indirect path 1 -> 2 -> 3.
+        let new_parents = vec![
+            SmallVec::new(),
+            SmallVec::new(),
+            SmallVec::from_buf([1]),
+            SmallVec::from_buf([2]),
+        ];
+        let constraints = NanoDag::from_edges(4, &[(1, 3)]);
+        let dag = NanoDag::from_edges(4, &[]);
+        let (dag, old_to_new) = dag
+            .topo_remap(new_parents, &constraints)
+            .expect("proposal preserves the constraint");
+
+        assert!(old_to_new[1] < old_to_new[3]);
+        assert_eq!(dag.to_string(), "{0,1-2-3}");
+
+        let missing_constraint = NanoDag::from_edges(3, &[]).topo_remap(
+            vec![SmallVec::new(), SmallVec::new(), SmallVec::new()],
+            &NanoDag::from_edges(3, &[(1, 2)]),
+        );
+        assert!(missing_constraint.is_err());
+    }
+
+    #[test]
+    fn test_topo_remap_rejects_invalid_proposal() {
+        let dag = NanoDag::from_edges(2, &[]);
+
+        assert!(
+            dag.topo_remap(vec![SmallVec::new()], &NanoDag::default())
+                .is_err()
+        );
+        let cycle = dag.topo_remap(
+            vec![SmallVec::from_buf([1]), SmallVec::from_buf([0])],
+            &NanoDag::default(),
+        );
+        assert_eq!(
+            cycle.err().unwrap(),
+            "proposed dag contains a cycle involving edge 1 -> 0"
+        );
+        assert!(
+            dag.topo_remap(
+                vec![SmallVec::from_buf([2]), SmallVec::new()],
+                &NanoDag::default(),
+            )
+            .is_err()
+        );
+        assert!(
+            dag.topo_remap(
+                vec![SmallVec::from_vec(vec![1, 1]), SmallVec::new()],
+                &NanoDag::default(),
+            )
+            .is_err()
+        );
+        assert!(
+            NanoDag::from_edges(1, &[])
+                .topo_remap(vec![SmallVec::new()], &NanoDag::from_edges(2, &[]))
+                .is_err()
+        );
     }
 
     #[test]

--- a/eden/scm/lib/linelog/src/nanodag.rs
+++ b/eden/scm/lib/linelog/src/nanodag.rs
@@ -71,16 +71,19 @@ impl NanoDag {
         self.parents.len()
     }
 
-    /// Get the parent revs of `rev`. Returns `None` if out of bound.
+    /// Get the parent revs of `rev`. Returns an empty slice if out of bound.
     /// Parent revs preserve insertion order.
-    pub fn parents(&self, rev: Rev) -> Option<&[Rev]> {
-        self.parents.get(rev).map(|v| v.as_ref())
+    pub fn parents(&self, rev: Rev) -> &[Rev] {
+        self.parents
+            .get(rev)
+            .map(|v| v.as_ref())
+            .unwrap_or_default()
     }
 
     /// Get the immediate children of rev.
-    /// Returns None if `rev` is unknown or has no children.
-    pub fn children(&self, rev: Rev) -> Option<&SmallRevs> {
-        self.children.get(&rev)
+    /// Returns an empty set if `rev` is unknown or has no children.
+    pub fn children(&self, rev: Rev) -> &SmallRevs {
+        self.children.get(&rev).unwrap_or_default()
     }
 
     /// Get all revs present in the dag.
@@ -91,12 +94,10 @@ impl NanoDag {
     /// Revs that has no children. O(revs) to O(revs * revs).
     pub fn heads(&self, revs: &SmallRevs) -> SmallRevs {
         revs.iter()
-            .filter(|rev| match self.children(*rev).cloned() {
-                Some(mut children_revs) => {
-                    children_revs.intersect_with(revs);
-                    children_revs.is_empty()
-                }
-                None => true,
+            .filter(|rev| {
+                let mut children_revs = self.children(*rev).clone();
+                children_revs.intersect_with(revs);
+                children_revs.is_empty()
             })
             .collect()
     }
@@ -104,47 +105,52 @@ impl NanoDag {
     /// Revs that has no parents. O(revs) to O(revs * revs).
     pub fn roots(&self, revs: &SmallRevs) -> SmallRevs {
         revs.iter()
-            .filter(|rev| match self.parents(*rev) {
-                Some(mut parents) => {
-                    let mut parent_revs = SmallRevs::from_iter(parents.iter().copied());
-                    parent_revs.intersect_with(revs);
-                    parent_revs.is_empty()
-                }
-                None => true,
+            .filter(|rev| {
+                let mut parent_revs = SmallRevs::from_iter(self.parents(*rev).iter().copied());
+                parent_revs.intersect_with(revs);
+                parent_revs.is_empty()
             })
             .collect()
     }
 
     /// Get the ancestor revs of `rev`, including `rev`.
-    pub fn ancestors(&self, rev: Rev) -> Option<&SmallRevs> {
+    /// Returns an empty set if `rev` is out of bound.
+    pub fn ancestors(&self, rev: Rev) -> &SmallRevs {
         self.walk_revs(rev, WalkKind::Ancestors)
     }
 
     /// Get the descendant revs of `rev`, including `rev`.
-    pub fn descendants(&self, rev: Rev) -> Option<&SmallRevs> {
+    /// Returns an empty set if `rev` is out of bound.
+    pub fn descendants(&self, rev: Rev) -> &SmallRevs {
         self.walk_revs(rev, WalkKind::Descendants)
     }
 
-    fn walk_revs(&self, rev: Rev, kind: WalkKind) -> Option<&SmallRevs> {
+    fn walk_revs(&self, rev: Rev, kind: WalkKind) -> &SmallRevs {
         if rev >= self.parents.len() {
-            return None;
+            return Default::default();
         }
         let cache = self.cache();
-        if let Some(revs) = cache.get(rev)?.revs_for_kind(kind).get() {
-            return Some(revs);
+        if let Some(revs) = cache[rev].revs_for_kind(kind).get() {
+            return revs;
         }
 
         let mut to_visit = vec![rev];
         while let Some(visit_rev) = to_visit.pop() {
-            if cache.get(visit_rev)?.revs_for_kind(kind).get().is_some() {
+            let Some(visit_cache) = cache.get(visit_rev) else {
+                return Default::default();
+            };
+            if visit_cache.revs_for_kind(kind).get().is_some() {
                 continue;
             }
 
             let mut visit_revs = SmallRevs::from(visit_rev);
             let mut revisit = false;
             {
-                let mut visit_related_rev = |related_rev: Rev| -> Option<()> {
-                    match cache.get(related_rev)?.revs_for_kind(kind).get() {
+                let mut visit_related_rev = |related_rev: Rev| -> bool {
+                    let Some(related_cache) = cache.get(related_rev) else {
+                        return false;
+                    };
+                    match related_cache.revs_for_kind(kind).get() {
                         None => {
                             if !revisit {
                                 to_visit.push(visit_rev);
@@ -156,19 +162,24 @@ impl NanoDag {
                             visit_revs.union_with(related_revs);
                         }
                     }
-                    Some(())
+                    true
                 };
 
                 match kind {
                     WalkKind::Ancestors => {
-                        for parent_rev in self.parents.get(visit_rev)? {
-                            visit_related_rev(*parent_rev)?;
+                        let Some(parents) = self.parents.get(visit_rev) else {
+                            return Default::default();
+                        };
+                        for parent_rev in parents {
+                            if !visit_related_rev(*parent_rev) {
+                                return Default::default();
+                            }
                         }
                     }
                     WalkKind::Descendants => {
-                        if let Some(children) = self.children(visit_rev) {
-                            for child_rev in children.iter() {
-                                visit_related_rev(child_rev)?;
+                        for child_rev in self.children(visit_rev).iter() {
+                            if !visit_related_rev(child_rev) {
+                                return Default::default();
                             }
                         }
                     }
@@ -176,14 +187,11 @@ impl NanoDag {
             }
 
             if !revisit {
-                cache
-                    .get(visit_rev)?
-                    .revs_for_kind(kind)
-                    .get_or_init(|| visit_revs);
+                visit_cache.revs_for_kind(kind).get_or_init(|| visit_revs);
             }
         }
 
-        cache.get(rev)?.revs_for_kind(kind).get()
+        cache[rev].revs_for_kind(kind).get().unwrap_or_default()
     }
 
     /// Test if `ancestor` is an ancestor of `descendant`.
@@ -201,10 +209,7 @@ impl NanoDag {
                 return false;
             }
         }
-        let Some(ancestors) = self.ancestors(descendant) else {
-            return false;
-        };
-        ancestors.contains(ancestor)
+        self.ancestors(descendant).contains(ancestor)
     }
 
     /// Insert a child-parent edge to the dag.
@@ -610,8 +615,8 @@ mod tests {
                 if parent >= child {
                     continue;
                 }
-                assert!(dag.parents(*child).unwrap().contains(parent));
-                assert!(dag.children(*parent).unwrap().contains(*child));
+                assert!(dag.parents(*child).contains(parent));
+                assert!(dag.children(*parent).contains(*child));
             }
             dag
         }
@@ -633,13 +638,13 @@ mod tests {
     }
 
     #[test]
-    fn test_empty_dag_queries_are_out_of_bound() {
+    fn test_empty_dag_queries_return_empty_defaults() {
         let dag = NanoDag::default();
 
-        assert_eq!(dag.parents(0), None);
-        assert_eq!(dag.children(0), None);
-        assert_eq!(dag.ancestors(0), None);
-        assert_eq!(dag.descendants(0), None);
+        assert_eq!(dag.parents(0), [].as_slice());
+        assert!(dag.children(0).is_empty());
+        assert!(dag.ancestors(0).is_empty());
+        assert!(dag.descendants(0).is_empty());
         assert_eq!(revs_vec(&dag.heads(&dag.all())), vec![]);
         assert_eq!(revs_vec(&dag.roots(&dag.all())), vec![]);
         assert!(!dag.is_ancestor(0, 0));
@@ -650,19 +655,16 @@ mod tests {
         // 0-{1-3,2-4}-5
         let dag = NanoDag::from_edges(6, &[(0, 1), (0, 2), (1, 3), (2, 4), (3, 5), (4, 5)]);
 
-        assert_eq!(dag.ancestors(5).map(revs_vec), Some(vec![0, 1, 2, 3, 4, 5]));
-        assert_eq!(
-            dag.descendants(0).map(revs_vec),
-            Some(vec![0, 1, 2, 3, 4, 5])
-        );
-        assert_eq!(dag.descendants(1).map(revs_vec), Some(vec![1, 3, 5]));
-        assert_eq!(dag.descendants(2).map(revs_vec), Some(vec![2, 4, 5]));
-        assert_eq!(dag.children(0).map(revs_vec), Some(vec![1, 2]));
-        assert_eq!(dag.children(1).map(revs_vec), Some(vec![3]));
-        assert_eq!(dag.children(2).map(revs_vec), Some(vec![4]));
-        assert_eq!(dag.children(3).map(revs_vec), Some(vec![5]));
-        assert_eq!(dag.children(4).map(revs_vec), Some(vec![5]));
-        assert_eq!(dag.children(5), None);
+        assert_eq!(revs_vec(dag.ancestors(5)), vec![0, 1, 2, 3, 4, 5]);
+        assert_eq!(revs_vec(dag.descendants(0)), vec![0, 1, 2, 3, 4, 5]);
+        assert_eq!(revs_vec(dag.descendants(1)), vec![1, 3, 5]);
+        assert_eq!(revs_vec(dag.descendants(2)), vec![2, 4, 5]);
+        assert_eq!(revs_vec(dag.children(0)), vec![1, 2]);
+        assert_eq!(revs_vec(dag.children(1)), vec![3]);
+        assert_eq!(revs_vec(dag.children(2)), vec![4]);
+        assert_eq!(revs_vec(dag.children(3)), vec![5]);
+        assert_eq!(revs_vec(dag.children(4)), vec![5]);
+        assert!(dag.children(5).is_empty());
         assert_eq!(revs_vec(&dag.heads(&dag.all())), vec![5]);
         assert_eq!(revs_vec(&dag.roots(&dag.all())), vec![0]);
 
@@ -699,16 +701,16 @@ mod tests {
     fn test_self_edge_resizes_dag_without_adding_parent() {
         let dag = NanoDag::default().with_edge(3, 3);
 
-        assert_eq!(dag.parents(0), Some([].as_slice()));
-        assert_eq!(dag.parents(1), Some([].as_slice()));
-        assert_eq!(dag.parents(2), Some([].as_slice()));
-        assert_eq!(dag.parents(3), Some([].as_slice()));
-        assert_eq!(dag.children(0), None);
-        assert_eq!(dag.children(3), None);
+        assert_eq!(dag.parents(0), [].as_slice());
+        assert_eq!(dag.parents(1), [].as_slice());
+        assert_eq!(dag.parents(2), [].as_slice());
+        assert_eq!(dag.parents(3), [].as_slice());
+        assert!(dag.children(0).is_empty());
+        assert!(dag.children(3).is_empty());
         assert_eq!(revs_vec(&dag.heads(&dag.all())), vec![0, 1, 2, 3]);
         assert_eq!(revs_vec(&dag.roots(&dag.all())), vec![0, 1, 2, 3]);
-        assert_eq!(dag.ancestors(3).map(revs_vec), Some(vec![3]));
-        assert_eq!(dag.descendants(3).map(revs_vec), Some(vec![3]));
+        assert_eq!(revs_vec(dag.ancestors(3)), vec![3]);
+        assert_eq!(revs_vec(dag.descendants(3)), vec![3]);
         assert!(dag.is_ancestor(3, 3));
     }
 
@@ -716,28 +718,28 @@ mod tests {
     fn test_sparse_child_slot_and_multiple_parents() {
         let dag = NanoDag::from_edges(4, &[(1, 3), (2, 3)]);
 
-        assert_eq!(dag.parents(0), Some([].as_slice()));
-        assert_eq!(dag.parents(1), Some([].as_slice()));
-        assert_eq!(dag.parents(2), Some([].as_slice()));
-        assert_eq!(dag.parents(3), Some([1, 2].as_slice()));
-        assert_eq!(dag.children(0), None);
-        assert_eq!(dag.children(1).map(revs_vec), Some(vec![3]));
-        assert_eq!(dag.children(2).map(revs_vec), Some(vec![3]));
-        assert_eq!(dag.children(3), None);
+        assert_eq!(dag.parents(0), [].as_slice());
+        assert_eq!(dag.parents(1), [].as_slice());
+        assert_eq!(dag.parents(2), [].as_slice());
+        assert_eq!(dag.parents(3), [1, 2].as_slice());
+        assert!(dag.children(0).is_empty());
+        assert_eq!(revs_vec(dag.children(1)), vec![3]);
+        assert_eq!(revs_vec(dag.children(2)), vec![3]);
+        assert!(dag.children(3).is_empty());
         assert_eq!(revs_vec(&dag.heads(&dag.all())), vec![0, 3]);
         assert_eq!(revs_vec(&dag.roots(&dag.all())), vec![0, 1, 2]);
-        assert_eq!(dag.ancestors(3).map(revs_vec), Some(vec![1, 2, 3]));
+        assert_eq!(revs_vec(dag.ancestors(3)), vec![1, 2, 3]);
     }
 
     #[test]
     fn test_duplicate_edge_preserves_existing_cache() {
         let dag = NanoDag::from_edges(3, &[(0, 1), (1, 2)]);
-        assert_eq!(dag.descendants(0).map(revs_vec), Some(vec![0, 1, 2]));
+        assert_eq!(revs_vec(dag.descendants(0)), vec![0, 1, 2]);
 
         let duplicated = dag.clone().with_edge(0, 1);
-        assert_eq!(duplicated.parents(1), Some([0].as_slice()));
-        assert_eq!(duplicated.children(0).map(revs_vec), Some(vec![1]));
-        assert_eq!(duplicated.descendants(0).map(revs_vec), Some(vec![0, 1, 2]));
+        assert_eq!(duplicated.parents(1), [0].as_slice());
+        assert_eq!(revs_vec(duplicated.children(0)), vec![1]);
+        assert_eq!(revs_vec(duplicated.descendants(0)), vec![0, 1, 2]);
         assert!(Arc::ptr_eq(
             dag.cache.get().expect("cache should be populated"),
             duplicated
@@ -750,17 +752,14 @@ mod tests {
     #[test]
     fn test_with_edge_invalidates_derived_cache_without_mutating_original() {
         let dag = NanoDag::from_edges(3, &[(0, 1), (1, 2)]);
-        assert_eq!(dag.descendants(0).map(revs_vec), Some(vec![0, 1, 2]));
+        assert_eq!(revs_vec(dag.descendants(0)), vec![0, 1, 2]);
 
         let extended = dag.clone().with_edge(2, 3);
-        assert_eq!(dag.descendants(0).map(revs_vec), Some(vec![0, 1, 2]));
-        assert_eq!(dag.children(2), None);
-        assert_eq!(
-            extended.descendants(0).map(revs_vec),
-            Some(vec![0, 1, 2, 3])
-        );
-        assert_eq!(extended.ancestors(3).map(revs_vec), Some(vec![0, 1, 2, 3]));
-        assert_eq!(extended.children(2).map(revs_vec), Some(vec![3]));
+        assert_eq!(revs_vec(dag.descendants(0)), vec![0, 1, 2]);
+        assert!(dag.children(2).is_empty());
+        assert_eq!(revs_vec(extended.descendants(0)), vec![0, 1, 2, 3]);
+        assert_eq!(revs_vec(extended.ancestors(3)), vec![0, 1, 2, 3]);
+        assert_eq!(revs_vec(extended.children(2)), vec![3]);
     }
 
     #[test]
@@ -791,7 +790,7 @@ mod tests {
     #[test]
     fn test_insert_invalidates_derived_cache_without_mutating_original() {
         let dag = NanoDag::from_edges(3, &[(0, 1), (1, 2)]);
-        assert_eq!(dag.descendants(0).map(revs_vec), Some(vec![0, 1, 2]));
+        assert_eq!(revs_vec(dag.descendants(0)), vec![0, 1, 2]);
 
         let inserted = dag.clone().insert_shift(1);
 
@@ -805,20 +804,20 @@ mod tests {
     fn test_truncate_removes_revs_and_rebuilds_children() {
         let dag = NanoDag::from_edges(5, &[(0, 1), (0, 2), (1, 3), (2, 3), (3, 4)]);
         assert_eq!(dag.to_string(), "0-{1,2}-3-4");
-        assert_eq!(dag.descendants(0).map(revs_vec), Some(vec![0, 1, 2, 3, 4]));
+        assert_eq!(revs_vec(dag.descendants(0)), vec![0, 1, 2, 3, 4]);
 
         let truncated = dag.clone().truncate(3);
 
         assert_eq!(dag.to_string(), "0-{1,2}-3-4");
         assert!(dag.cache.get().is_some());
         assert_eq!(truncated.to_string(), "0-{1,2}");
-        assert_eq!(truncated.parents(3), None);
-        assert_eq!(truncated.children(1), None);
-        assert_eq!(truncated.children(2), None);
+        assert_eq!(truncated.parents(3), [].as_slice());
+        assert!(truncated.children(1).is_empty());
+        assert!(truncated.children(2).is_empty());
         assert!(truncated.cache.get().is_none());
 
         let empty = truncated.truncate(0);
-        assert_eq!(empty.parents(0), None);
+        assert_eq!(empty.parents(0), [].as_slice());
         assert_eq!(revs_vec(&empty.heads(&empty.all())), vec![]);
     }
 
@@ -907,12 +906,12 @@ mod tests {
             .fold(&[1, 2].into_iter().collect())
             .expect("folding sibling revs should be valid");
 
-        assert_eq!(folded.parents(1), Some([0].as_slice()));
-        assert_eq!(folded.parents(2), Some([].as_slice()));
-        assert_eq!(folded.parents(3), Some([1].as_slice()));
-        assert_eq!(folded.children(0).map(revs_vec), Some(vec![1]));
-        assert_eq!(folded.children(1).map(revs_vec), Some(vec![3]));
-        assert_eq!(folded.children(2), None);
+        assert_eq!(folded.parents(1), [0].as_slice());
+        assert_eq!(folded.parents(2), [].as_slice());
+        assert_eq!(folded.parents(3), [1].as_slice());
+        assert_eq!(revs_vec(folded.children(0)), vec![1]);
+        assert_eq!(revs_vec(folded.children(1)), vec![3]);
+        assert!(folded.children(2).is_empty());
     }
 
     #[test]
@@ -956,12 +955,8 @@ mod tests {
                 (0..REV_COUNT).all(|descendant| {
                     let expected = reachable[ancestor].contains(descendant);
                     dag.is_ancestor(ancestor, descendant) == expected
-                        && dag
-                            .ancestors(descendant)
-                            .is_some_and(|revs| revs.contains(ancestor) == expected)
-                        && dag
-                            .descendants(ancestor)
-                            .is_some_and(|revs| revs.contains(descendant) == expected)
+                        && dag.ancestors(descendant).contains(ancestor) == expected
+                        && dag.descendants(ancestor).contains(descendant) == expected
                 })
             })
         }

--- a/eden/scm/lib/linelog/src/nanodag.rs
+++ b/eden/scm/lib/linelog/src/nanodag.rs
@@ -271,6 +271,53 @@ impl NanoDag {
         }
     }
 
+    /// Insert a `rev`. Turn:
+    ///
+    /// ```text
+    /// parents -- rev -- children
+    /// ```
+    ///
+    /// into:
+    ///
+    /// ```text
+    /// parents -- rev -- rev+1 -- children
+    /// ```
+    ///
+    /// Original `r` (`r > rev`) will shift to `r + 1` to make room for
+    /// `rev + 1`. The new `rev` keeps the original parents. The new `rev+1`
+    /// keeps the original (but shifted) children.
+    ///
+    /// Panics if `rev` is out of bound.
+    pub fn insert_shift(mut self, rev: Rev) -> Self {
+        assert!(rev < self.len(), "rev {rev} out of bound");
+
+        // note: ImVec::slice is destructive - removes the slice from self.parents
+        let mut parents = self.parents.slice(..=rev);
+        parents.push_back(SmallVec::from_buf([rev])); // rev + 1
+        for mut item in self.parents {
+            for p in item.iter_mut() {
+                if *p >= rev {
+                    *p += 1;
+                }
+            }
+            parents.push_back(item);
+        }
+
+        let mut children: ImMap<Rev, SmallRevs> = ImMap::new();
+        for (child, child_parents) in parents.iter().enumerate() {
+            for parent in child_parents {
+                children.entry(*parent).or_default().insert(child)
+            }
+        }
+
+        Self {
+            parents,
+            children,
+            cache: Default::default(),
+            ..self
+        }
+    }
+
     /// Prepare the self.cache field on demand.
     fn cache(&self) -> &[CacheRevs] {
         let len = self.parents.len();
@@ -472,9 +519,53 @@ mod tests {
     }
 
     #[test]
+    fn test_insert_splits_rev_and_shifts_later_revs() {
+        //     3   4
+        //      \ /
+        //       2
+        //      / \
+        //     0   1
+        let dag = NanoDag::from_edges(5, &[(0, 2), (1, 2), (2, 3), (2, 4)]);
+        assert_eq!(dag.to_string(), "{0,1}-2-{3,4}");
+
+        let inserted = dag.clone().insert_shift(2);
+
+        assert_eq!(dag.to_string(), "{0,1}-2-{3,4}");
+        assert_eq!(inserted.to_string(), "{0,1}-2-3-{4,5}");
+    }
+
+    #[test]
+    fn test_insert_root_rev() {
+        let dag = NanoDag::from_edges(2, &[(0, 1)]);
+
+        let inserted = dag.insert_shift(0);
+
+        assert_eq!(inserted.to_string(), "0-1-2");
+    }
+
+    #[test]
+    fn test_insert_invalidates_derived_cache_without_mutating_original() {
+        let dag = NanoDag::from_edges(3, &[(0, 1), (1, 2)]);
+        assert_eq!(dag.descendants(0).map(revs_vec), Some(vec![0, 1, 2]));
+
+        let inserted = dag.clone().insert_shift(1);
+
+        assert_eq!(dag.to_string(), "0-1-2");
+        assert!(dag.cache.get().is_some());
+        assert!(inserted.cache.get().is_none());
+        assert_eq!(inserted.to_string(), "0-1-2-3");
+    }
+
+    #[test]
     #[should_panic]
     fn test_with_edge_panics_if_parent_is_after_child() {
         let _ = NanoDag::default().with_edge(2, 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_insert_panics_if_rev_is_out_of_bound() {
+        let _ = NanoDag::default().insert_shift(0);
     }
 
     quickcheck! {

--- a/eden/scm/lib/linelog/src/nanodag.rs
+++ b/eden/scm/lib/linelog/src/nanodag.rs
@@ -303,19 +303,37 @@ impl NanoDag {
             parents.push_back(item);
         }
 
+        Self {
+            children: Self::children_from_parents(&parents),
+            parents,
+            cache: Default::default(),
+            ..self
+        }
+    }
+
+    /// Keep only revs below `len`.
+    pub fn truncate(mut self, len: usize) -> Self {
+        if len >= self.len() {
+            return self;
+        }
+
+        let parents = self.parents.slice(..len);
+        Self {
+            children: Self::children_from_parents(&parents),
+            parents,
+            cache: Default::default(),
+            ..self
+        }
+    }
+
+    fn children_from_parents(parents: &ImVec<SmallVec<[Rev; 1]>>) -> ImMap<Rev, SmallRevs> {
         let mut children: ImMap<Rev, SmallRevs> = ImMap::new();
         for (child, child_parents) in parents.iter().enumerate() {
             for parent in child_parents {
                 children.entry(*parent).or_default().insert(child)
             }
         }
-
-        Self {
-            parents,
-            children,
-            cache: Default::default(),
-            ..self
-        }
+        children
     }
 
     /// Prepare the self.cache field on demand.
@@ -554,6 +572,27 @@ mod tests {
         assert!(dag.cache.get().is_some());
         assert!(inserted.cache.get().is_none());
         assert_eq!(inserted.to_string(), "0-1-2-3");
+    }
+
+    #[test]
+    fn test_truncate_removes_revs_and_rebuilds_children() {
+        let dag = NanoDag::from_edges(5, &[(0, 1), (0, 2), (1, 3), (2, 3), (3, 4)]);
+        assert_eq!(dag.to_string(), "0-{1,2}-3-4");
+        assert_eq!(dag.descendants(0).map(revs_vec), Some(vec![0, 1, 2, 3, 4]));
+
+        let truncated = dag.clone().truncate(3);
+
+        assert_eq!(dag.to_string(), "0-{1,2}-3-4");
+        assert!(dag.cache.get().is_some());
+        assert_eq!(truncated.to_string(), "0-{1,2}");
+        assert_eq!(truncated.parents(3), None);
+        assert_eq!(truncated.children(1), None);
+        assert_eq!(truncated.children(2), None);
+        assert!(truncated.cache.get().is_none());
+
+        let empty = truncated.truncate(0);
+        assert_eq!(empty.parents(0), None);
+        assert_eq!(revs_vec(&empty.heads(&empty.all())), vec![]);
     }
 
     #[test]

--- a/eden/scm/lib/linelog/src/nanodag.rs
+++ b/eden/scm/lib/linelog/src/nanodag.rs
@@ -326,6 +326,51 @@ impl NanoDag {
         }
     }
 
+    /// Fold revs into the smallest rev in `revs`.
+    ///
+    /// Folded revs other than the smallest rev become isolated. Edges crossing
+    /// the folded set are rewired to the smallest rev.
+    pub fn fold(self, revs: &SmallRevs) -> Result<Self, &'static str> {
+        let Some(start) = revs.iter().next() else {
+            return Ok(self);
+        };
+        if revs.iter().any(|rev| rev >= self.len()) {
+            return Err("fold rev is out of bounds");
+        }
+
+        let mut parents: ImVec<SmallVec<[Rev; 1]>> =
+            (0..self.len()).map(|_| SmallVec::new()).collect();
+        for (child, child_parents) in self.parents.iter().enumerate() {
+            let mapped_child = if revs.contains(child) { start } else { child };
+            for parent in child_parents {
+                let mapped_parent = if revs.contains(*parent) {
+                    start
+                } else {
+                    *parent
+                };
+                if mapped_parent == mapped_child {
+                    continue;
+                }
+                if mapped_parent >= mapped_child {
+                    return Err("fold breaks topological order");
+                }
+                let Some(child_parents) = parents.get_mut(mapped_child) else {
+                    return Err("fold child is out of bounds");
+                };
+                if !child_parents.contains(&mapped_parent) {
+                    child_parents.push(mapped_parent);
+                }
+            }
+        }
+
+        Ok(Self {
+            children: Self::children_from_parents(&parents),
+            parents,
+            cache: Default::default(),
+            ..self
+        })
+    }
+
     fn children_from_parents(parents: &ImVec<SmallVec<[Rev; 1]>>) -> ImMap<Rev, SmallRevs> {
         let mut children: ImMap<Rev, SmallRevs> = ImMap::new();
         for (child, child_parents) in parents.iter().enumerate() {
@@ -593,6 +638,31 @@ mod tests {
         let empty = truncated.truncate(0);
         assert_eq!(empty.parents(0), None);
         assert_eq!(revs_vec(&empty.heads(&empty.all())), vec![]);
+    }
+
+    #[test]
+    fn test_fold_rewires_edges_to_first_rev() {
+        let dag = NanoDag::from_edges(4, &[(0, 1), (0, 2), (1, 3), (2, 3)]);
+        assert_eq!(dag.to_string(), "0-{1,2}-3");
+
+        let folded = dag
+            .fold(&[1, 2].into_iter().collect())
+            .expect("folding sibling revs should be valid");
+
+        assert_eq!(folded.parents(1), Some([0].as_slice()));
+        assert_eq!(folded.parents(2), Some([].as_slice()));
+        assert_eq!(folded.parents(3), Some([1].as_slice()));
+        assert_eq!(folded.children(0).map(revs_vec), Some(vec![1]));
+        assert_eq!(folded.children(1).map(revs_vec), Some(vec![3]));
+        assert_eq!(folded.children(2), None);
+    }
+
+    #[test]
+    fn test_fold_rejects_invalid_set() {
+        let dag = NanoDag::from_edges(4, &[(0, 2), (1, 2), (2, 3)]);
+
+        assert!(dag.clone().fold(&[4].into_iter().collect()).is_err());
+        assert!(dag.fold(&[0, 2].into_iter().collect()).is_err());
     }
 
     #[test]

--- a/eden/scm/lib/linelog/src/tests.rs
+++ b/eden/scm/lib/linelog/src/tests.rs
@@ -185,6 +185,26 @@ fn test_a_lines_cache_effectiveness() {
 }
 
 #[test]
+fn test_a_lines_cache_does_not_cache_invisible_edit_without_edge() {
+    let stats = Arc::new(PerfStats::default());
+    let log = LineLog::default().with_perf_stats(Some(stats.clone()));
+    // Disabling ADD_EDGE is a power-user use case.
+    let flags = EditFlags::default() - EditFlags::ADD_EDGE;
+
+    let log = log.edit_chunk(0, 0, 0, 1, lines("a\n"), flags);
+
+    // "a" is invisible since rev 1 does not depend on rev 0 in the dag.
+    // If edit_chunk incorrectly updated a_lines_cache, checkout would return "a\n".
+    let cache_hit_before = stats.cache_hit.load(Ordering::Acquire);
+    assert_eq!(log.checkout_text(1), "");
+    let cache_hit_after = stats.cache_hit.load(Ordering::Acquire);
+
+    // No cache hit during checkout: edit_chunk cannot prepare the cache without
+    // the parent edge.
+    assert_eq!(cache_hit_before, cache_hit_after);
+}
+
+#[test]
 fn test_describe_instructions() {
     let log = log_from_texts(&["a\n".into(), "b\n".into()]);
     // The instructions are internal details. For example, an

--- a/eden/scm/lib/linelog/src/tests.rs
+++ b/eden/scm/lib/linelog/src/tests.rs
@@ -529,6 +529,46 @@ fn test_truncate() {
 }
 
 #[test]
+fn test_non_linear_skipped_rev() {
+    let flags = EditFlags::default();
+    // rev 0 has content, rev 1 is skipped (not depend on rev 0), rev 2 depends on rev 1.
+    let log = AbstractLineLog::default()
+        .edit_chunk(0, 0, 0, 0, vec!["a", "c"], flags)
+        .edit_chunk(0, 1, 1, 2, vec!["b"], flags);
+    assert_eq!(log.nanodag().to_string(), "{0-2,1}");
+    assert_eq!(log.dep_map().to_string(), "{0-2,1}");
+    assert_eq!(log.checkout_text(0), "ac");
+    assert_eq!(log.checkout_text(1), "");
+    assert_eq!(log.checkout_text(2), "abc");
+}
+
+#[test]
+fn test_non_linear_merged_rev() {
+    let flags = EditFlags::default();
+    // rev 0: a -> rev 1: b b    ------------> b
+    // rev 0: c                  --> rev 3 --> x
+    // rev 0: d ----> rev 2: e e ------------> e
+    // rev 0: f
+    let log = AbstractLineLog::default()
+        .with_dag_edge(3, 3)
+        .edit_chunk(0, 0, 0, 0, vec!["a", "c", "d", "f"], flags)
+        .edit_chunk(0, 0, 1, 1, vec!["b", "b"], flags)
+        .edit_chunk(0, 2, 3, 2, vec!["e", "e"], flags)
+        .with_dag_edge(2, 3)
+        .with_dag_edge(1, 3);
+    assert_eq!(log.nanodag().to_string(), "0-{1,2}-3");
+    assert_eq!(log.dep_map().to_string(), "0-{1,2}");
+    assert_eq!(log.checkout_text(0), "acdf"); // rev 0, orig content
+    assert_eq!(log.checkout_text(1), "bbcdf"); // rev 1 replaced "a" with "bb"
+    assert_eq!(log.checkout_text(2), "aceef"); // rev 2 replaced "d" with "ee", without rev 1 "bb"
+    assert_eq!(log.checkout_text(3), "bbceef"); // rev 3 is a (unchanged) merge, with both "bb" and "ee"
+
+    // changes on the default merge result
+    let log = log.edit_chunk(3, 1, 4, 3, vec!["x"], flags);
+    assert_eq!(log.checkout_text(3), "bxef"); // rev 3 replaced the middle "bce" with "x"
+}
+
+#[test]
 fn test_flatten() {
     // 3 revisions: rev1 "a b c", rev2 "b c d e", rev3 "a c d f".
     // Edits applied in reverse chunk order within each rev.

--- a/eden/scm/lib/linelog/src/tests.rs
+++ b/eden/scm/lib/linelog/src/tests.rs
@@ -343,12 +343,10 @@ fn test_remap_revs() {
     assert_eq!(merged.checkout_text(1), "b\nc\n");
     assert_eq!(merged.checkout_text(3), "a\nb\nc\n");
 
-    // Can insert changes by remapping to make room, then recording at the gap.
-    let inserted = log_from_texts(&["b\n".into(), "b\nc\n".into()])
-        .remap_revs(&|r| if r == 2 { 3 } else { r });
+    // Can insert changes by shifting revs to make room, then recording at the gap.
+    let inserted = log_from_texts(&["b\n".into(), "b\nc\n".into()]).insert_shift(1);
+    assert_eq!(inserted.max_rev(), 3);
     let inserted = record_text(inserted, "a\nb\n", 1, 2);
-    // Add missing edge 2 -> 3
-    let inserted = inserted.with_dag_edge(2, 3);
     assert_eq!(inserted.checkout_text(3), "a\nb\nc\n");
 
     // Does not check dependencies or conflicts.

--- a/eden/scm/lib/linelog/src/tests.rs
+++ b/eden/scm/lib/linelog/src/tests.rs
@@ -395,7 +395,7 @@ fn test_remap_revs_reorder_insertions() {
 
     let dep_map = log.dep_map();
     for rev in 1..=3 {
-        assert_eq!(dep_map.parents(rev), Some(&[0][..]), "rev={rev}");
+        assert_eq!(dep_map.parents(rev), &[0][..], "rev={rev}");
     }
 
     let swapped = log.remap_revs(&|r| match r {

--- a/eden/scm/lib/linelog/src/tests.rs
+++ b/eden/scm/lib/linelog/src/tests.rs
@@ -128,9 +128,8 @@ fn test_random_cases() {
             assert_eq!(log.checkout_lines(*b_rev).len(), line_count);
         }
 
-        // edit_chunk and checkout_lines sequentially do not trigger (slow)
-        // dag cache initialization.
-        assert_eq!(stats.dag_cache.load(Ordering::Acquire), 0);
+        // execute prepares ancestor revsets once, then reuses the dag cache.
+        assert_eq!(stats.dag_cache.load(Ordering::Acquire), 1);
         // All in "happy" cache_hit paths. "execute" called O(1) times.
         assert_eq!(stats.execute.load(Ordering::Acquire), 1);
 
@@ -181,7 +180,7 @@ fn test_a_lines_cache_effectiveness() {
     check("after checkout", 4, 1);
 
     // Verify the dag cache (for ancestors and descendants) only gets built O(1) times.
-    assert_eq!(stats.dag_cache.load(Ordering::Acquire), 0);
+    assert_eq!(stats.dag_cache.load(Ordering::Acquire), 1);
 }
 
 #[test]

--- a/eden/scm/lib/linelog/src/tests.rs
+++ b/eden/scm/lib/linelog/src/tests.rs
@@ -191,10 +191,14 @@ fn test_a_lines_cache_does_not_cache_invisible_edit_without_edge() {
     // Disabling ADD_EDGE is a power-user use case.
     let flags = EditFlags::default() - EditFlags::ADD_EDGE;
 
-    let log = log.edit_chunk(0, 0, 0, 1, lines("a\n"), flags);
+    let log = log
+        .edit_chunk(0, 0, 0, 0, lines("a\nb\n"), flags)
+        .edit_chunk(0, 1, 1, 1, lines("c\n"), flags);
 
-    // "a" is invisible since rev 1 does not depend on rev 0 in the dag.
-    // If edit_chunk incorrectly updated a_lines_cache, checkout would return "a\n".
+    // rev 1's "c\n" is invisible:
+    // During checkout(rev 1) (in LineLog::execute), the outer rev 0 block is
+    // skipped (checked dag), so the rev 1 insertion inside rev 0 chunk is
+    // skipped too, becomes invisible.
     let cache_hit_before = stats.cache_hit.load(Ordering::Acquire);
     assert_eq!(log.checkout_text(1), "");
     let cache_hit_after = stats.cache_hit.load(Ordering::Acquire);
@@ -202,6 +206,11 @@ fn test_a_lines_cache_does_not_cache_invisible_edit_without_edge() {
     // No cache hit during checkout: edit_chunk cannot prepare the cache without
     // the parent edge.
     assert_eq!(cache_hit_before, cache_hit_after);
+
+    // linelog dep map, rev 1 depends on rev 0 (insert into rev 0 block)
+    assert_eq!(log.dep_map().to_string(), "0-1");
+    // dag edges, rev 1 does not depend on rev 0
+    assert_eq!(log.nanodag().to_string(), "{0,1}");
 }
 
 #[test]

--- a/eden/scm/lib/linelog/src/tests.rs
+++ b/eden/scm/lib/linelog/src/tests.rs
@@ -17,6 +17,7 @@ use rand_core::SeedableRng as _;
 use crate::AbstractLineLog;
 use crate::EditFlags;
 use crate::LineLog;
+use crate::SmallRevs;
 use crate::linelog::PerfStats;
 use crate::linelog::Rev;
 use crate::nanodag::NanoDag;
@@ -944,7 +945,8 @@ impl LineLog {
     }
 
     fn show_range(&self, start: usize, end: usize) -> Vec<String> {
-        self.checkout_range_lines(start, end)
+        let target_revs = SmallRevs::from_range(start..=end);
+        self.checkout_revs_lines(&target_revs)
             .into_iter()
             .map(|l| {
                 format!(

--- a/eden/scm/sapling/ext/absorb/__init__.py
+++ b/eden/scm/sapling/ext/absorb/__init__.py
@@ -422,7 +422,9 @@ class filefixupstate:
         """() -> [str]. prompt all lines for edit"""
         max_rev = self.linelog.max_rev()
         # discard the "end" line
-        alllines = self.linelog.checkout_lines(max_rev, 0)[:-1]
+        alllines = self.linelog.checkout_revs_lines(
+            self.linelog.nanodag().ancestors(max_rev)
+        )[:-1]
         # header
         editortext = _(
             '{0}: editing {1}\n{0}: "y" means the line to the right '
@@ -1091,7 +1093,7 @@ def _amendcmd(flag, orig, ui, repo, *pats, **opts):
 def _calculate_gap_lines(linelog, rev=None):
     if rev is None:
         rev = linelog.max_rev()
-    all_lines = linelog.checkout_lines(rev, 0)
+    all_lines = linelog.checkout_revs_lines(linelog.nanodag().ancestors(rev))
     gap_lines = []
     lineno = -1
     last_gap_line = -1

--- a/eden/scm/saplingnative/bindings/modules/pylinelog/src/lib.rs
+++ b/eden/scm/saplingnative/bindings/modules/pylinelog/src/lib.rs
@@ -39,6 +39,10 @@ py_class!(class SmallRevs |py| {
         Ok(self.inner(py).contains(rev))
     }
 
+    def __bool__(&self) -> PyResult<bool> {
+        Ok(!self.inner(py).is_empty())
+    }
+
     def __repr__(&self) -> PyResult<String> {
         Ok(format!("{:?}", self.inner(py)))
     }
@@ -80,8 +84,8 @@ py_class!(class SmallRevs |py| {
 // Small immutable DAG for linelog revision ordering.
 //
 // Edges are parent -> child, and parent must be <= child. Query methods return
-// None for out-of-bound revisions. Ancestor and descendant sets include the
-// queried revision itself.
+// empty collections for out-of-bound revisions. Ancestor and descendant sets
+// include the queried revision itself.
 py_class!(class NanoDag |py| {
     data inner: NativeNanoDag;
 
@@ -89,33 +93,27 @@ py_class!(class NanoDag |py| {
         Self::create_instance(py, Default::default())
     }
 
-    /// Return parent revisions for rev, or None if rev is out of bound.
-    def parents(&self, rev: usize) -> PyResult<Option<Vec<usize>>> {
-        Ok(self.inner(py).parents(rev).map(|parents| parents.to_vec()))
+    /// Return parent revisions for rev, or an empty list if rev is out of bound.
+    def parents(&self, rev: usize) -> PyResult<Vec<usize>> {
+        Ok(self.inner(py).parents(rev).to_vec())
     }
 
     def __contains__(&self, rev: usize) -> PyResult<bool> {
-        Ok(self.inner(py).parents(rev).is_some())
+        Ok(rev < self.inner(py).len())
     }
 
     def __repr__(&self) -> PyResult<String> {
         Ok(format!("<{:?}>", self.inner(py)))
     }
 
-    /// Return ancestors of rev, including rev itself, or None if out of bound.
-    def ancestors(&self, rev: usize) -> PyResult<Option<SmallRevs>> {
-        self.inner(py)
-            .ancestors(rev)
-            .map(|revs| SmallRevs::create_instance(py, revs.clone()))
-            .transpose()
+    /// Return ancestors of rev, including rev itself, or an empty set if out of bound.
+    def ancestors(&self, rev: usize) -> PyResult<SmallRevs> {
+        SmallRevs::create_instance(py, self.inner(py).ancestors(rev).clone())
     }
 
-    /// Return descendants of rev, including rev itself, or None if out of bound.
-    def descendants(&self, rev: usize) -> PyResult<Option<SmallRevs>> {
-        self.inner(py)
-            .descendants(rev)
-            .map(|revs| SmallRevs::create_instance(py, revs.clone()))
-            .transpose()
+    /// Return descendants of rev, including rev itself, or an empty set if out of bound.
+    def descendants(&self, rev: usize) -> PyResult<SmallRevs> {
+        SmallRevs::create_instance(py, self.inner(py).descendants(rev).clone())
     }
 
     /// Return True if ancestor is an ancestor of descendant.

--- a/eden/scm/saplingnative/bindings/modules/pylinelog/src/lib.rs
+++ b/eden/scm/saplingnative/bindings/modules/pylinelog/src/lib.rs
@@ -177,14 +177,20 @@ py_class!(class IntLineLog |py| {
         NanoDag::create_instance(py, self.inner(py).nanodag().clone())
     }
 
-    /// Get the lines. (rev, start_rev=rev) -> [(rev, line_no, pc, deleted)].
+    /// Get the lines. rev -> [(rev, line_no, pc, deleted)].
     /// Includes a dummy "end" line at the end.
-    def checkout_lines(&self, rev: usize, start_rev: Option<usize> = None) -> PyResult<Vec<(usize, usize, usize, bool)>> {
+    def checkout_lines(&self, rev: usize) -> PyResult<Vec<(usize, usize, usize, bool)>> {
         let inner = self.inner(py);
-        let lines = match start_rev {
-            None => inner.checkout_lines(rev),
-            Some(start) => inner.checkout_range_lines(start, rev),
-        };
+        let lines = inner.checkout_lines(rev);
+        let lines: Vec<_> = lines.into_iter().map(|l| (l.rev, *l.data.as_ref(), l.pc, l.deleted)).collect();
+        Ok(lines)
+    }
+
+    /// Get the lines visible in the revs set. revs -> [(rev, line_no, pc, deleted)].
+    /// Includes a dummy "end" line at the end.
+    def checkout_revs_lines(&self, revs: SmallRevs) -> PyResult<Vec<(usize, usize, usize, bool)>> {
+        let inner = self.inner(py);
+        let lines = inner.checkout_revs_lines(revs.inner(py));
         let lines: Vec<_> = lines.into_iter().map(|l| (l.rev, *l.data.as_ref(), l.pc, l.deleted)).collect();
         Ok(lines)
     }


### PR DESCRIPTION
Summary:

Previously, nanodag APIs can return `Option::None` if the input `rev` is out of
range, which seems more annoying than useful. This diff drops `Option` to
simplify the mental burdern.

Differential Revision: D105784454


