### PR TITLE
contrib: fix scm-prompt triggering chpwd hooks during directory traversal

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 	"name": "Sapling",
 	"build": {
 		"context": "..",
-		"dockerfile": "../.github/workflows/sapling-cli-ubuntu-22.04.Dockerfile"
+		"dockerfile": "../.github/workflows/manylinux_2_34.Dockerfile"
 	},
 	"updateContentCommand": "ln -sf /workspaces/sapling/eden/scm/sl /usr/local/bin/sl",
 	"customizations": {

--- a/eden/scm/contrib/scm-prompt.sh
+++ b/eden/scm/contrib/scm-prompt.sh
@@ -257,7 +257,7 @@ _scm_prompt() {
     fi
     [[ "$dir" = "/" ]] && break
     # portable "realpath" equivalent
-    dir="$(builtin cd -P "$dir/.." >/dev/null && builtin echo "$PWD")"
+    dir="$(chpwd_functions=(); builtin cd -P "$dir/.." >/dev/null && builtin echo "$PWD")"
   done
 
   if [[ -n "$br" ]]; then


### PR DESCRIPTION

When scm-prompt.sh walks up the directory tree to find the root of the
repository (.sl, .git, or .hg), it uses builtin cd -P. In Zsh,
executing cd (even inside a subshell) triggers all functions registered
in chpwd_functions.

This causes unexpected side effects if a chpwd hook performs operations
that bypass standard output capture. For example, Ghostty's shell integration
registers a chpwd hook that writes an OSC 7 escape sequence directly to a
persistent TTY file descriptor (/dev/tty) to report the current working
directory. Because this writes to the TTY directly, the traversal performed by
scm-prompt.sh leaks temporary working directories to the terminal emulator,
causing Ghostty to open new tabs in the repository root rather than the actual
current working directory.

By localizing and clearing chpwd_functions within the subshell before executing
cd, we prevent these hooks from firing during the directory traversal, resolving
the side effects while keeping the traversal logic intact.
