### PR TITLE
refresh 10 crates to latest compatible versions

### DIFF
--- a/eden/mononoke/blobstore/ephemeral_blobstore/Cargo.toml
+++ b/eden/mononoke/blobstore/ephemeral_blobstore/Cargo.toml
@@ -14,7 +14,7 @@ async-trait = "0.1.86"
 bincode = { version = "2", features = ["serde"] }
 blobstore = { version = "0.1.0", path = ".." }
 bonsai_globalrev_mapping = { version = "0.1.0", path = "../../repo_attributes/bonsai_globalrev_mapping" }
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 commit_graph = { version = "0.1.0", path = "../../repo_attributes/commit_graph/commit_graph" }
 commit_graph_types = { version = "0.1.0", path = "../../repo_attributes/commit_graph/commit_graph_types" }
 context = { version = "0.1.0", path = "../../servers/slapi/slapi_server/context" }

--- a/eden/mononoke/blobstore/multiplexedblob/Cargo.toml
+++ b/eden/mononoke/blobstore/multiplexedblob/Cargo.toml
@@ -11,7 +11,7 @@ license = "GPLv2+"
 anyhow = "1.0.102"
 blobstore = { version = "0.1.0", path = ".." }
 blobstore_stats = { version = "0.1.0", path = "../blobstore_stats" }
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 clap = { version = "4.6.0", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 context = { version = "0.1.0", path = "../../servers/slapi/slapi_server/context" }
 futures = { version = "0.3.31", features = ["async-await", "compat"] }

--- a/eden/mononoke/blobstore/s3blob/Cargo.toml
+++ b/eden/mononoke/blobstore/s3blob/Cargo.toml
@@ -11,7 +11,7 @@ license = "GPLv2+"
 anyhow = "1.0.102"
 async-trait = "0.1.86"
 blobstore = { version = "0.1.0", path = ".." }
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 context = { version = "0.1.0", path = "../../servers/slapi/slapi_server/context" }
 futures_stats = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 hyper = { version = "0.14.32", features = ["client", "http1", "http2", "stream"] }

--- a/eden/mononoke/common/async_limiter/examples/tokio_v2/Cargo.toml
+++ b/eden/mononoke/common/async_limiter/examples/tokio_v2/Cargo.toml
@@ -14,7 +14,7 @@ path = "main.rs"
 [dependencies]
 anyhow = "1.0.102"
 async_limiter = { version = "0.1.0", path = "../.." }
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
 governor = "0.10.4"
 nonzero_ext = "0.2"

--- a/eden/mononoke/common/cats/Cargo.toml
+++ b/eden/mononoke/common/cats/Cargo.toml
@@ -10,7 +10,7 @@ license = "GPLv2+"
 [dependencies]
 anyhow = "1.0.102"
 fbinit = { version = "0.2.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-http = "1.4.0"
+http = "1.4.1"
 metaconfig_types = { version = "0.1.0", path = "../../metaconfig/types" }
 permission_checker = { version = "0.1.0", path = "../permission_checker" }
 sapling-cats-constants = { version = "0.1.0", path = "../../../scm/lib/cats/constants" }

--- a/eden/mononoke/common/gotham_ext/Cargo.toml
+++ b/eden/mononoke/common/gotham_ext/Cargo.toml
@@ -25,10 +25,10 @@ gotham = "0.8"
 gotham_derive = "0.8"
 hex = { version = "0.4.3", features = ["alloc"] }
 hickory-resolver = { version = "0.26.1", features = ["system-config", "tokio"] }
-http = "1.4.0"
+http = "1.4.1"
 http-body = "1.0.1"
 http-body-util = "0.1.0"
-hyper = { version = "1.9.0", features = ["client", "http1", "http2"] }
+hyper = { version = "1.10.1", features = ["client", "http1", "http2"] }
 hyper-util = { version = "0.1.20", features = ["client-legacy", "http1", "http2", "server-auto", "service", "tokio"] }
 justknobs = { version = "0.1.0", path = "../rust/justknobs_ext" }
 metaconfig_types = { version = "0.1.0", path = "../../metaconfig/types" }

--- a/eden/mononoke/common/lfs_protocol/Cargo.toml
+++ b/eden/mononoke/common/lfs_protocol/Cargo.toml
@@ -10,7 +10,7 @@ license = "GPLv2+"
 [dependencies]
 anyhow = "1.0.102"
 faster-hex = "0.6.1"
-http = "1.4.0"
+http = "1.4.1"
 mime = "0.3.14"
 once_cell = "1.21.4"
 quickcheck = "1.1"

--- a/eden/mononoke/common/memory_profiling/Cargo.toml
+++ b/eden/mononoke/common/memory_profiling/Cargo.toml
@@ -10,6 +10,6 @@ license = "GPLv2+"
 [dependencies]
 anyhow = "1.0.102"
 gotham_ext = { version = "0.1.0", path = "../gotham_ext" }
-http = "1.4.0"
+http = "1.4.1"
 jemalloc_pprof = { version = "0.8.2", features = ["flamegraph"], optional = true }
 permission_checker = { version = "0.1.0", path = "../permission_checker" }

--- a/eden/mononoke/common/ods_counters/Cargo.toml
+++ b/eden/mononoke/common/ods_counters/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPLv2+"
 
 [dependencies]
 async-trait = "0.1.86"
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 fbinit = { version = "0.2.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 maplit = "1.0"
 thiserror = "2.0.18"

--- a/eden/mononoke/derived_data/changeset_info/Cargo.toml
+++ b/eden/mononoke/derived_data/changeset_info/Cargo.toml
@@ -23,7 +23,7 @@ mononoke_types = { version = "0.1.0", path = "../../mononoke_types" }
 mononoke_types_serialization = { version = "0.1.0", path = "../../mononoke_types/serialization" }
 smallvec = { version = "1.15", features = ["impl_bincode", "serde", "specialization", "union", "write"] }
 sorted_vector_map = { version = "0.2.1", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-unicode-segmentation = "1.13.2"
+unicode-segmentation = "1.13.3"
 
 [dev-dependencies]
 bonsai_hg_mapping = { version = "0.1.0", path = "../../repo_attributes/bonsai_hg_mapping" }

--- a/eden/mononoke/features/commit_rate_limit/Cargo.toml
+++ b/eden/mononoke/features/commit_rate_limit/Cargo.toml
@@ -15,7 +15,7 @@ doctest = false
 anyhow = "1.0.102"
 blobstore = { version = "0.1.0", path = "../../blobstore" }
 bookmarks = { version = "0.1.0", path = "../../repo_attributes/bookmarks" }
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 commit_graph = { version = "0.1.0", path = "../../repo_attributes/commit_graph/commit_graph" }
 commit_rate_limit_config = { version = "0.1.0", path = "../../repo_attributes/commit_rate_limit" }
 context = { version = "0.1.0", path = "../../servers/slapi/slapi_server/context" }

--- a/eden/mononoke/features/hooks/Cargo.toml
+++ b/eden/mononoke/features/hooks/Cargo.toml
@@ -32,7 +32,7 @@ fsnodes = { version = "0.1.0", path = "../../derived_data/fsnodes" }
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
 gix-config = { version = "0.56.0", features = ["sha1"] }
 hook_manager = { version = "0.1.0", path = "../../repo_attributes/hook_manager/hook_manager" }
-http = "1.4.0"
+http = "1.4.1"
 http-body-util = "0.1.0"
 hyper-tls = "0.6"
 hyper-util = { version = "0.1.20", features = ["client-legacy", "http1", "http2", "server-auto", "service", "tokio"] }

--- a/eden/mononoke/features/repo_update_logger/Cargo.toml
+++ b/eden/mononoke/features/repo_update_logger/Cargo.toml
@@ -16,7 +16,7 @@ bonsai_globalrev_mapping = { version = "0.1.0", path = "../../repo_attributes/bo
 bookmarks = { version = "0.1.0", path = "../../repo_attributes/bookmarks" }
 bookmarks_types = { version = "0.1.0", path = "../../repo_attributes/bookmarks/bookmarks_types" }
 borrowed = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 commit_graph = { version = "0.1.0", path = "../../repo_attributes/commit_graph/commit_graph" }
 context = { version = "0.1.0", path = "../../servers/slapi/slapi_server/context" }
 ephemeral_blobstore = { version = "0.1.0", path = "../../blobstore/ephemeral_blobstore" }

--- a/eden/mononoke/git/import_tools/Cargo.toml
+++ b/eden/mononoke/git/import_tools/Cargo.toml
@@ -33,7 +33,7 @@ git_types = { version = "0.1.0", path = "../git_types" }
 gix-actor = "0.41.0"
 gix-hash = { version = "0.25.0", features = ["sha1"] }
 gix-object = "0.60.0"
-http = "1.4.0"
+http = "1.4.1"
 http-body-util = "0.1.0"
 hyper-openssl = { version = "0.10", features = ["client-legacy", "tokio"] }
 hyper-proxy2 = { version = "0.1", features = ["rustls"], default-features = false }

--- a/eden/mononoke/jobs/blobstore_healer/Cargo.toml
+++ b/eden/mononoke/jobs/blobstore_healer/Cargo.toml
@@ -15,7 +15,7 @@ blobstore_factory = { version = "0.1.0", path = "../../blobstore/factory" }
 blobstore_sync_queue = { version = "0.1.0", path = "../../blobstore_sync_queue" }
 borrowed = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 cached_config = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 clap = { version = "4.6.0", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 cloned = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 context = { version = "0.1.0", path = "../../servers/slapi/slapi_server/context" }

--- a/eden/mononoke/jobs/walker/Cargo.toml
+++ b/eden/mononoke/jobs/walker/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = "1.0.102"
 array-init = "0.1"
 async-trait = "0.1.86"
 auto_impl = "1.3.0"
-bitflags = { version = "2.11.1", features = ["serde", "std"], default-features = false }
+bitflags = { version = "2.13.0", features = ["serde", "std"], default-features = false }
 blame = { version = "0.1.0", path = "../../derived_data/blame" }
 blobrepo_hg = { version = "0.1.0", path = "../../blobrepo/blobrepo_hg" }
 blobstore = { version = "0.1.0", path = "../../blobstore" }

--- a/eden/mononoke/mercurial/revlog/Cargo.toml
+++ b/eden/mononoke/mercurial/revlog/Cargo.toml
@@ -13,7 +13,7 @@ path = "lib.rs"
 [dependencies]
 anyhow = "1.0.102"
 ascii = "1.1.0"
-bitflags = { version = "2.11.1", features = ["serde", "std"], default-features = false }
+bitflags = { version = "2.13.0", features = ["serde", "std"], default-features = false }
 bytes = { version = "1.11.1", features = ["serde"] }
 flate2 = { version = "1.0.33", features = ["rust_backend"], default-features = false }
 futures_ext = { package = "futures_01_ext", version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }

--- a/eden/mononoke/mercurial/types/Cargo.toml
+++ b/eden/mononoke/mercurial/types/Cargo.toml
@@ -14,7 +14,7 @@ async-stream = "0.3"
 async-trait = "0.1.86"
 base64 = { version = "0.22.1", features = ["alloc"] }
 bincode = { version = "2", features = ["serde"] }
-bitflags = { version = "2.11.1", features = ["serde", "std"], default-features = false }
+bitflags = { version = "2.13.0", features = ["serde", "std"], default-features = false }
 blake3 = { version = "=1.8.2", features = ["mmap", "rayon", "traits-preview"] }
 blobstore = { version = "0.1.0", path = "../../blobstore" }
 bytes = { version = "1.11.1", features = ["serde"] }

--- a/eden/mononoke/mononoke_api/Cargo.toml
+++ b/eden/mononoke/mononoke_api/Cargo.toml
@@ -31,7 +31,7 @@ bundle_uri = { version = "0.1.0", path = "../git/bundle_uri" }
 bytes = { version = "1.11.1", features = ["serde"] }
 changeset_info = { version = "0.1.0", path = "../derived_data/changeset_info" }
 changesets_creation = { version = "0.1.0", path = "../features/changesets_creation" }
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 cloned = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 commit_cloud = { version = "0.1.0", path = "../features/commit_cloud" }
 commit_cloud_types = { version = "0.1.0", path = "../features/commit_cloud/types" }

--- a/eden/mononoke/mononoke_types/Cargo.toml
+++ b/eden/mononoke/mononoke_types/Cargo.toml
@@ -19,7 +19,7 @@ blobstore = { version = "0.1.0", path = "../blobstore" }
 borrowed = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 bounded_traversal = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 bytes = { version = "1.11.1", features = ["serde"] }
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 chrono-english = "0.1.8"
 cloned = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 context = { version = "0.1.0", path = "../servers/slapi/slapi_server/context" }

--- a/eden/mononoke/mononoke_types/mocks/Cargo.toml
+++ b/eden/mononoke/mononoke_types/mocks/Cargo.toml
@@ -11,7 +11,7 @@ license = "GPLv2+"
 path = "lib.rs"
 
 [dependencies]
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 lazy_static = "1.5"
 mononoke_types = { version = "0.1.0", path = ".." }
 

--- a/eden/mononoke/servers/git/git_server/Cargo.toml
+++ b/eden/mononoke/servers/git/git_server/Cargo.toml
@@ -39,7 +39,7 @@ gotham = "0.8"
 gotham_derive = "0.8"
 gotham_ext = { version = "0.1.0", path = "../../../common/gotham_ext" }
 hex = { version = "0.4.3", features = ["alloc"] }
-http = "1.4.0"
+http = "1.4.1"
 http-body-util = "0.1.0"
 import_direct = { version = "0.1.0", path = "../../../git/import_direct" }
 import_tools = { version = "0.1.0", path = "../../../git/import_tools" }

--- a/eden/mononoke/servers/lfs/lfs_server/Cargo.toml
+++ b/eden/mononoke/servers/lfs/lfs_server/Cargo.toml
@@ -27,7 +27,7 @@ gotham = "0.8"
 gotham_derive = "0.8"
 gotham_ext = { version = "0.1.0", path = "../../../common/gotham_ext" }
 hostname = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-http = "1.4.0"
+http = "1.4.1"
 http-body = "1.0.1"
 http-body-util = "0.1.0"
 hyper-openssl = { version = "0.10", features = ["client-legacy", "tokio"] }

--- a/eden/mononoke/servers/scs/scs_methods/Cargo.toml
+++ b/eden/mononoke/servers/scs/scs_methods/Cargo.toml
@@ -17,7 +17,7 @@ bookmarks = { version = "0.1.0", path = "../../../repo_attributes/bookmarks" }
 bookmarks_movement = { version = "0.1.0", path = "../../../repo_attributes/bookmarks/bookmarks_movement" }
 borrowed = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 bytes = { version = "1.11.1", features = ["serde"] }
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 cloned = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 commit_cloud_helpers = { version = "0.1.0", path = "../../../features/commit_cloud/helpers" }
 commit_cloud_types = { version = "0.1.0", path = "../../../features/commit_cloud/types" }

--- a/eden/mononoke/servers/slapi/slapi_server/context/Cargo.toml
+++ b/eden/mononoke/servers/slapi/slapi_server/context/Cargo.toml
@@ -14,7 +14,7 @@ doc = false
 
 [dependencies]
 async_limiter = { version = "0.1.0", path = "../../../../common/async_limiter" }
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 fbinit = { version = "0.2.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 governor = "0.10.4"
 metadata = { version = "0.1.0", path = "../../../../common/metadata" }

--- a/eden/mononoke/servers/slapi/slapi_server/repo_listener/Cargo.toml
+++ b/eden/mononoke/servers/slapi/slapi_server/repo_listener/Cargo.toml
@@ -15,7 +15,7 @@ bookmarks_cache = { version = "0.1.0", path = "../../../../repo_attributes/bookm
 bytes = { version = "1.11.1", features = ["serde"] }
 cached_config = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 cats = { version = "0.1.0", path = "../../../../common/cats" }
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 connection_security_checker = { version = "0.1.0", path = "../../../../common/connection_security_checker" }
 context = { version = "0.1.0", path = "../context" }
 fbinit = { version = "0.2.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
@@ -26,10 +26,10 @@ futures_stats = { version = "0.1.0", git = "https://github.com/facebookexperimen
 gotham_ext = { version = "0.1.0", path = "../../../../common/gotham_ext" }
 hgproto = { version = "0.1.0", path = "../../../../common/hgproto" }
 hostname = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
-http = "1.4.0"
+http = "1.4.1"
 http-body = "1.0.1"
 http-body-util = "0.1.0"
-hyper = { version = "1.9.0", features = ["client", "http1", "http2"] }
+hyper = { version = "1.10.1", features = ["client", "http1", "http2"] }
 hyper-util = { version = "0.1.20", features = ["client-legacy", "http1", "http2", "server-auto", "service", "tokio"] }
 justknobs = { version = "0.1.0", path = "../../../../common/rust/justknobs_ext" }
 lazy_static = "1.5"

--- a/eden/mononoke/servers/slapi/slapi_service/Cargo.toml
+++ b/eden/mononoke/servers/slapi/slapi_service/Cargo.toml
@@ -35,7 +35,7 @@ gotham_derive = "0.8"
 gotham_ext = { version = "0.1.0", path = "../../../common/gotham_ext" }
 hex = { version = "0.4.3", features = ["alloc"] }
 hooks = { version = "0.1.0", path = "../../../features/hooks" }
-http = "1.4.0"
+http = "1.4.1"
 http-body-util = "0.1.0"
 itertools = "0.14.0"
 justknobs = { version = "0.1.0", path = "../../../common/rust/justknobs_ext" }

--- a/eden/mononoke/third_party/git_delta/Cargo.toml
+++ b/eden/mononoke/third_party/git_delta/Cargo.toml
@@ -15,4 +15,4 @@ libz-sys = "1.1.28"
 mononoke_macros = { version = "0.1.0", path = "../../common/mononoke_macros" }
 
 [build-dependencies]
-cc = "1.2.62"
+cc = "1.2.63"

--- a/eden/mononoke/tools/admin/Cargo.toml
+++ b/eden/mononoke/tools/admin/Cargo.toml
@@ -38,7 +38,7 @@ case_conflict_skeleton_manifest = { version = "0.1.0", path = "../../derived_dat
 changeset_info = { version = "0.1.0", path = "../../derived_data/changeset_info" }
 changesets_creation = { version = "0.1.0", path = "../../features/changesets_creation" }
 changesets_uploader = { version = "0.1.0", path = "../../common/cas_client/changesets_uploader" }
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 clap = { version = "4.6.0", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 cloned = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 cmdlib_cross_repo = { version = "0.1.0", path = "../../cmdlib/cross_repo" }

--- a/eden/scm/exec/hgmain/Cargo.toml
+++ b/eden/scm/exec/hgmain/Cargo.toml
@@ -14,7 +14,7 @@ sapling-configloader = { version = "0.1.0", path = "../../lib/config/loader" }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [build-dependencies]
-cc = "1.2.62"
+cc = "1.2.63"
 sapling-python-sysconfig = { version = "0.1.0", path = "../../lib/util/python-sysconfig" }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/eden/scm/lib/auth/Cargo.toml
+++ b/eden/scm/lib/auth/Cargo.toml
@@ -14,7 +14,7 @@ name = "auth"
 
 [dependencies]
 anyhow = "1.0.102"
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 indexmap = { version = "2.14.0", features = ["arbitrary", "rayon", "serde"] }
 pem = "3.0.3"
 sapling-configmodel = { version = "0.1.0", path = "../config/model", features = ["convert-path"] }

--- a/eden/scm/lib/backingstore/Cargo.toml
+++ b/eden/scm/lib/backingstore/Cargo.toml
@@ -46,7 +46,7 @@ tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 tracing-subscriber = { version = "0.3.23", features = ["chrono", "env-filter", "json", "local-time", "parking_lot", "registry"] }
 
 [dev-dependencies]
-http = "1.4.0"
+http = "1.4.1"
 rand_chacha = "0.10"
 url = "2.5.8"
 

--- a/eden/scm/lib/backtrace-python/evalframe-sys/Cargo.toml
+++ b/eden/scm/lib/backtrace-python/evalframe-sys/Cargo.toml
@@ -17,5 +17,5 @@ name = "evalframe_sys"
 libc = "0.2.186"
 
 [build-dependencies]
-cc = "1.2.62"
+cc = "1.2.63"
 sapling-python-sysconfig = { version = "0.1.0", path = "../../util/python-sysconfig" }

--- a/eden/scm/lib/commands/commands/cmdworktree/Cargo.toml
+++ b/eden/scm/lib/commands/commands/cmdworktree/Cargo.toml
@@ -11,7 +11,7 @@ license = "GPL-2.0-only"
 
 [dependencies]
 anyhow = "1.0.102"
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 cmdutil = { version = "0.1.0", path = "../../cmdutil" }
 flume = "0.11.1"
 fs-err = { version = "3.3.0", features = ["tokio"] }

--- a/eden/scm/lib/commands/debugcommands/cmddebugtop/Cargo.toml
+++ b/eden/scm/lib/commands/debugcommands/cmddebugtop/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/facebook/sapling"
 license = "GPL-2.0-only"
 
 [dependencies]
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 cmdutil = { version = "0.1.0", path = "../../cmdutil" }
 sapling-ascii-tree = { version = "0.1.0", path = "../../../util/ascii-tree" }
 sapling-clidispatch = { version = "0.1.0", path = "../../../clidispatch" }

--- a/eden/scm/lib/commitcloudsubscriber/Cargo.toml
+++ b/eden/scm/lib/commitcloudsubscriber/Cargo.toml
@@ -33,7 +33,7 @@ log = { version = "0.4.29", features = ["kv_unstable", "kv_unstable_std"] }
 mime = "0.3.14"
 parking_lot = { version = "0.12.1", features = ["arc_lock", "send_guard"] }
 regex = "1.12.3"
-reqwest = { version = "0.13.2", features = ["blocking", "brotli", "charset", "cookies", "deflate", "gzip", "http2", "json", "multipart", "native-tls", "rustls", "socks", "stream", "system-proxy", "zstd"], default-features = false }
+reqwest = { version = "0.13.4", features = ["blocking", "brotli", "charset", "cookies", "deflate", "gzip", "http2", "json", "multipart", "native-tls", "rustls", "socks", "stream", "system-proxy", "zstd"], default-features = false }
 sapling-configset = { version = "0.1.0", path = "../config/set" }
 sapling-identity = { version = "0.1.0", path = "../identity" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }

--- a/eden/scm/lib/dag/Cargo.toml
+++ b/eden/scm/lib/dag/Cargo.toml
@@ -16,7 +16,7 @@ name = "dag"
 [dependencies]
 anyhow = "1.0.102"
 async-trait = "0.1.86"
-bitflags = { version = "2.11.1", features = ["serde", "std"], default-features = false }
+bitflags = { version = "2.13.0", features = ["serde", "std"], default-features = false }
 byteorder = "1.5"
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = { version = "0.3.31", features = ["async-await", "compat"] }

--- a/eden/scm/lib/debugtop/Cargo.toml
+++ b/eden/scm/lib/debugtop/Cargo.toml
@@ -14,5 +14,5 @@ name = "debugtop"
 
 [dependencies]
 anyhow = "1.0.102"
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 sapling-runlog = { version = "0.1.0", path = "../runlog" }

--- a/eden/scm/lib/doctor/network/Cargo.toml
+++ b/eden/scm/lib/doctor/network/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 name = "network_doctor"
 
 [dependencies]
-http = "1.4.0"
+http = "1.4.1"
 sapling-auth = { version = "0.1.0", path = "../../auth" }
 sapling-configmodel = { version = "0.1.0", path = "../../config/model" }
 sapling-hg-http = { version = "0.1.0", path = "../../hg-http" }

--- a/eden/scm/lib/eagerepo/Cargo.toml
+++ b/eden/scm/lib/eagerepo/Cargo.toml
@@ -18,7 +18,7 @@ async-trait = "0.1.86"
 blob = { version = "0.1.0", path = "../blob" }
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
-http = "1.4.0"
+http = "1.4.1"
 manifest-augmented-tree = { version = "0.1.0", path = "../manifest-augmented-tree" }
 parking_lot = { version = "0.12.1", features = ["arc_lock", "send_guard"] }
 sapling-dag = { version = "0.1.0", path = "../dag" }

--- a/eden/scm/lib/edenapi/Cargo.toml
+++ b/eden/scm/lib/edenapi/Cargo.toml
@@ -15,7 +15,7 @@ name = "edenapi"
 [dependencies]
 anyhow = "1.0.102"
 async-trait = "0.1.86"
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
 itertools = "0.14.0"
 once_cell = "1.21.4"

--- a/eden/scm/lib/edenapi/trait/Cargo.toml
+++ b/eden/scm/lib/edenapi/trait/Cargo.toml
@@ -16,7 +16,7 @@ name = "edenapi_trait"
 anyhow = "1.0.102"
 async-trait = "0.1.86"
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
-http = "1.4.0"
+http = "1.4.1"
 sapling-auth = { version = "0.1.0", path = "../../auth" }
 sapling-configmodel = { version = "0.1.0", path = "../../config/model" }
 sapling-edenapi_types = { version = "0.1.0", path = "../types" }

--- a/eden/scm/lib/hgtime/Cargo.toml
+++ b/eden/scm/lib/hgtime/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT"
 name = "hgtime"
 
 [dependencies]
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 humantime = "2.1"
 serde = { version = "1.0.219", features = ["derive", "rc"], optional = true }
 

--- a/eden/scm/lib/http-client/Cargo.toml
+++ b/eden/scm/lib/http-client/Cargo.toml
@@ -20,7 +20,7 @@ curl = { version = "0.4.49", features = ["http2", "static-ssl"] }
 curl-sys = "0.4.87"
 flume = "0.11.1"
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
-http = "1.4.0"
+http = "1.4.1"
 lru-cache = "0.1.2"
 maplit = "1.0"
 once_cell = "1.21.4"

--- a/eden/scm/lib/linelog/Cargo.toml
+++ b/eden/scm/lib/linelog/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 name = "linelog"
 
 [dependencies]
-bitflags = { version = "2.11.1", features = ["serde", "std"], default-features = false }
+bitflags = { version = "2.13.0", features = ["serde", "std"], default-features = false }
 im = { version = "15.1", default-features = false }
 smallvec = { version = "1.15", default-features = false }
 

--- a/eden/scm/lib/mpatch-sys/Cargo.toml
+++ b/eden/scm/lib/mpatch-sys/Cargo.toml
@@ -13,4 +13,4 @@ license = "MIT"
 name = "mpatch_sys"
 
 [build-dependencies]
-cc = "1.2.62"
+cc = "1.2.63"

--- a/eden/scm/lib/mutationstore/Cargo.toml
+++ b/eden/scm/lib/mutationstore/Cargo.toml
@@ -14,7 +14,7 @@ name = "mutationstore"
 
 [dependencies]
 anyhow = "1.0.102"
-bitflags = { version = "2.11.1", features = ["serde", "std"], default-features = false }
+bitflags = { version = "2.13.0", features = ["serde", "std"], default-features = false }
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
 sapling-dag = { version = "0.1.0", path = "../dag", features = ["render"] }
 sapling-indexedlog = { version = "0.1.0", path = "../indexedlog" }

--- a/eden/scm/lib/pathmatcher/Cargo.toml
+++ b/eden/scm/lib/pathmatcher/Cargo.toml
@@ -14,7 +14,7 @@ name = "pathmatcher"
 
 [dependencies]
 anyhow = "1.0.102"
-bitflags = { version = "2.11.1", features = ["serde", "std"], default-features = false }
+bitflags = { version = "2.13.0", features = ["serde", "std"], default-features = false }
 fancy-regex = "0.16.2"
 fs-err = { version = "3.3.0", features = ["tokio"] }
 glob = "0.3.2"

--- a/eden/scm/lib/procinfo/Cargo.toml
+++ b/eden/scm/lib/procinfo/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0.219", features = ["derive", "rc"] }
 tempfile = "3.27.0"
 
 [target.'cfg(target_os = "macos")'.build-dependencies]
-cc = "1.2.62"
+cc = "1.2.63"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 ntapi = "0.4.3"

--- a/eden/scm/lib/progress/render/Cargo.toml
+++ b/eden/scm/lib/progress/render/Cargo.toml
@@ -18,5 +18,5 @@ sapling-progress-model = { version = "0.1.0", path = "../model" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 termwiz = { git = "https://github.com/wezterm/wezterm.git", rev = "05343b387085842b434d267f91b6b0ec157e4331", features = ["use_serde", "widgets"], default-features = false }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
-unicode-segmentation = "1.13.2"
+unicode-segmentation = "1.13.3"
 unicode-width = "0.1.14"

--- a/eden/scm/lib/renderdag/Cargo.toml
+++ b/eden/scm/lib/renderdag/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT"
 name = "renderdag"
 
 [dependencies]
-bitflags = { version = "2.11.1", features = ["serde", "std"], default-features = false }
+bitflags = { version = "2.13.0", features = ["serde", "std"], default-features = false }
 serde = { version = "1.0.219", features = ["derive", "rc"], optional = true }
 
 [dev-dependencies]

--- a/eden/scm/lib/revisionstore/Cargo.toml
+++ b/eden/scm/lib/revisionstore/Cargo.toml
@@ -21,7 +21,7 @@ flume = "0.11.1"
 fn-error-context = "0.2"
 fs-err = { version = "3.3.0", features = ["tokio"] }
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
-http = "1.4.0"
+http = "1.4.1"
 lfs_protocol = { version = "0.1.0", path = "../../../mononoke/common/lfs_protocol" }
 once_cell = "1.21.4"
 parking_lot = { version = "0.12.1", features = ["arc_lock", "send_guard"] }

--- a/eden/scm/lib/runlog/Cargo.toml
+++ b/eden/scm/lib/runlog/Cargo.toml
@@ -14,7 +14,7 @@ name = "runlog"
 
 [dependencies]
 anyhow = "1.0.102"
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 parking_lot = { version = "0.12.1", features = ["arc_lock", "send_guard"] }
 rand = "0.10.1"
 sapling-configmodel = { version = "0.1.0", path = "../config/model" }

--- a/eden/scm/lib/third-party/streampager/Cargo.toml
+++ b/eden/scm/lib/third-party/streampager/Cargo.toml
@@ -28,7 +28,7 @@ terminfo = "0.9"
 termwiz = { git = "https://github.com/wezterm/wezterm.git", rev = "05343b387085842b434d267f91b6b0ec157e4331", default-features = false }
 thiserror = "2.0.18"
 toml = { version = "0.9.12", features = ["preserve_order"], optional = true }
-unicode-segmentation = "1.13.2"
+unicode-segmentation = "1.13.3"
 unicode-width = "0.1.14"
 vec_map = "0.8"
 

--- a/eden/scm/lib/treestate/Cargo.toml
+++ b/eden/scm/lib/treestate/Cargo.toml
@@ -14,7 +14,7 @@ name = "treestate"
 
 [dependencies]
 anyhow = "1.0.102"
-bitflags = { version = "2.11.1", features = ["serde", "std"], default-features = false }
+bitflags = { version = "2.13.0", features = ["serde", "std"], default-features = false }
 byteorder = "1.5"
 fs-err = { version = "3.3.0", features = ["tokio"] }
 sapling-atomicfile = { version = "0.1.0", path = "../atomicfile" }

--- a/eden/scm/lib/types/Cargo.toml
+++ b/eden/scm/lib/types/Cargo.toml
@@ -14,7 +14,7 @@ name = "types"
 
 [dependencies]
 anyhow = "1.0.102"
-bitflags = { version = "2.11.1", features = ["serde", "std"], default-features = false }
+bitflags = { version = "2.13.0", features = ["serde", "std"], default-features = false }
 bytecount = "0.6.9"
 byteorder = "1.5"
 quickcheck = { version = "1.1", optional = true }

--- a/eden/scm/lib/util/Cargo.toml
+++ b/eden/scm/lib/util/Cargo.toml
@@ -15,7 +15,7 @@ name = "util"
 
 [dependencies]
 anyhow = "1.0.102"
-bitflags = { version = "2.11.1", features = ["serde", "std"], default-features = false }
+bitflags = { version = "2.13.0", features = ["serde", "std"], default-features = false }
 dirs = "6.0"
 fn-error-context = "0.2"
 fs-err = { version = "3.3.0", features = ["tokio"] }

--- a/eden/scm/lib/util/format-util/Cargo.toml
+++ b/eden/scm/lib/util/format-util/Cargo.toml
@@ -14,7 +14,7 @@ name = "format_util"
 
 [dependencies]
 anyhow = "1.0.102"
-memchr = "2.8.0"
+memchr = "2.8.1"
 once_cell = "1.21.4"
 sapling-hgtime = { version = "0.1.0", path = "../../hgtime" }
 sapling-minibytes = { version = "0.1.0", path = "../../minibytes" }

--- a/eden/scm/lib/util/python-sysconfig/Cargo.toml
+++ b/eden/scm/lib/util/python-sysconfig/Cargo.toml
@@ -14,4 +14,4 @@ license = "MIT"
 name = "python_sysconfig"
 
 [dependencies]
-cc = "1.2.62"
+cc = "1.2.63"

--- a/eden/scm/lib/util/rewrite-macros/tree-pattern-match/Cargo.toml
+++ b/eden/scm/lib/util/rewrite-macros/tree-pattern-match/Cargo.toml
@@ -14,4 +14,4 @@ license = "MIT"
 name = "tree_pattern_match"
 
 [dependencies]
-bitflags = { version = "2.11.1", features = ["serde", "std"], default-features = false }
+bitflags = { version = "2.13.0", features = ["serde", "std"], default-features = false }

--- a/eden/scm/lib/vfs/Cargo.toml
+++ b/eden/scm/lib/vfs/Cargo.toml
@@ -14,7 +14,7 @@ name = "vfs"
 
 [dependencies]
 anyhow = "1.0.102"
-bitflags = { version = "2.11.1", features = ["serde", "std"], default-features = false }
+bitflags = { version = "2.13.0", features = ["serde", "std"], default-features = false }
 blob = { version = "0.1.0", path = "../blob" }
 dashmap = { version = "6.1.0", features = ["rayon", "serde"] }
 flume = "0.11.1"

--- a/eden/scm/lib/workingcopy/Cargo.toml
+++ b/eden/scm/lib/workingcopy/Cargo.toml
@@ -14,7 +14,7 @@ name = "workingcopy"
 
 [dependencies]
 anyhow = "1.0.102"
-bitflags = { version = "2.11.1", features = ["serde", "std"], default-features = false }
+bitflags = { version = "2.13.0", features = ["serde", "std"], default-features = false }
 crossbeam = "0.8"
 fs-err = { version = "3.3.0", features = ["tokio"] }
 once_cell = "1.21.4"

--- a/eden/scm/lib/worktree/Cargo.toml
+++ b/eden/scm/lib/worktree/Cargo.toml
@@ -15,7 +15,7 @@ name = "worktree"
 [dependencies]
 anyhow = "1.0.102"
 blake2 = "0.10"
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 fs-err = { version = "3.3.0", features = ["tokio"] }
 sapling-util = { version = "0.1.0", path = "../util" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }

--- a/eden/scm/lib/xdiff-sys/Cargo.toml
+++ b/eden/scm/lib/xdiff-sys/Cargo.toml
@@ -17,4 +17,4 @@ name = "xdiff_sys_bin"
 path = "src/bin/xdiff-sys-bin.rs"
 
 [build-dependencies]
-cc = "1.2.62"
+cc = "1.2.63"

--- a/eden/scm/saplingnative/bindings/modules/pycext/Cargo.toml
+++ b/eden/scm/saplingnative/bindings/modules/pycext/Cargo.toml
@@ -10,5 +10,5 @@ cpython = { version = "0.7.2", features = ["python3-sys"], default-features = fa
 python3-sys = "0.7.2"
 
 [build-dependencies]
-cc = "1.2.62"
+cc = "1.2.63"
 sapling-python-sysconfig = { version = "0.1.0", path = "../../../../lib/util/python-sysconfig" }

--- a/thrift/lib/rust/Cargo.toml
+++ b/thrift/lib/rust/Cargo.toml
@@ -18,7 +18,7 @@ bytes = { version = "1.11.1", features = ["serde"] }
 clap = { version = "4.6.0", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
 ghost = "0.1.21"
-memchr = "2.8.0"
+memchr = "2.8.1"
 num-derive = "0.4.2"
 num-traits = { version = "0.2.19", default-features = false }
 ordered-float = { version = "4.6.0", features = ["serde"] }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/pyrefly/pull/3707

X-link: https://github.com/facebookincubator/below/pull/8282

X-link: https://github.com/facebookincubator/reindeer/pull/106

X-link: https://github.com/facebookexperimental/rust-shed/pull/75

X-link: https://github.com/facebookexperimental/reverie/pull/37

X-link: https://github.com/facebookexperimental/hermit/pull/66

X-link: https://github.com/facebookexperimental/dapper/pull/3

X-link: https://github.com/facebook/hhvm/pull/9791

X-link: https://github.com/facebook/ocamlrep/pull/93

X-link: https://github.com/facebook/buck2-shims-meta/pull/17

X-link: https://github.com/facebook/flow/pull/9420

X-link: https://github.com/WhatsApp/erlang-language-platform/pull/215

X-link: https://github.com/facebook/buck2/pull/1335

X-link: https://github.com/meta-pytorch/monarch/pull/4193

Refreshes 10 third-party Rust crates to their latest semver-compatible versions. These are dependencies used by the hzdb/metavr CLI (`arvr/apps/hzdb`) that were behind in the shared lockfile; the bumps apply repo-wide since `third-party/rust` is shared.

- `bitflags` `2.11.1` -> `2.13.0`
- `bumpalo` `3.20.2` -> `3.20.3`
- `cc` `1.2.62` -> `1.2.63` (additively vendors `shlex` `2.0.1` as a new transitive of `cc`)
- `chrono` `0.4.44` -> `0.4.45`
- `http` `1.4.0` -> `1.4.1`
- `hyper` `1.9.0` -> `1.10.1`
- `memchr` `2.8.0` -> `2.8.1`
- `reqwest` `0.13.2` -> `0.13.4`
- `unicode-segmentation` `1.13.2` -> `1.13.3`
- `zerocopy` `0.8.48` -> `0.8.50`

All are patch/minor (semver-compatible) bumps requiring no first-party code changes. Mirrored the applicable bumps into the github shim manifest (`fbcode/github/standard/shim/third-party/rust/Cargo.toml`) for `bitflags`, `bumpalo`, `chrono`, `http`, `hyper`, `memchr`, and `unicode-segmentation`. Regenerated with `reindeer vendor`, which also refreshed 255 first-party `Cargo.toml` manifests via autocargo. No first-party Rust source changes were needed.

Differential Revision: D107740437
