### PR TITLE
fix duplicated-word typos in docstrings and comments

### DIFF
--- a/eden/scm/sapling/crecord.py
+++ b/eden/scm/sapling/crecord.py
@@ -1289,7 +1289,7 @@ class curseschunkselector:
         self, item=None, ignorefolding=False, recursechildren=True, towin=True
     ):
         """
-        use __printitem() to print the the specified item.applied.
+        use __printitem() to print the specified item.applied.
         if item is not specified, then print the entire patch.
         (hiding folded elements, etc. -- see __printitem() docstring)
         """

--- a/eden/scm/sapling/ext/rebase.py
+++ b/eden/scm/sapling/ext/rebase.py
@@ -1263,7 +1263,7 @@ def rebase(ui, repo, templ=None, **opts):
         singletransaction = True
 
       By default, rebase writes to the working copy, but you can configure it
-      to run in-memory for for better performance, and to allow it to run if the
+      to run in-memory for better performance, and to allow it to run if the
       current checkout is dirty::
 
         [rebase]

--- a/eden/scm/sapling/patch.py
+++ b/eden/scm/sapling/patch.py
@@ -2948,7 +2948,7 @@ def diffui(*args, **kw):
 
 def _filepairs(ctx1, ctx2, modified, added, removed, copy, opts):
     """generates tuples (f1, f2, copyop), where f1 is the name of the file
-    before and f2 is the the name after. For added files, f1 will be None,
+    before and f2 is the name after. For added files, f1 will be None,
     and for removed files, f2 will be None. copyop may be set to None, 'copy'
     or 'rename' (the latter two only if opts.git is set)."""
     gone = set()

--- a/eden/scm/sapling/peer.py
+++ b/eden/scm/sapling/peer.py
@@ -31,7 +31,7 @@ class batcher:
     """base class for batches of commands submittable in a single request
 
     All methods invoked on instances of this class are simply queued and
-    return a a future for the result. Once you call submit(), all the queued
+    return a future for the result. Once you call submit(), all the queued
     calls are performed and the results set in their respective futures.
     """
 

--- a/eden/scm/sapling/transaction.py
+++ b/eden/scm/sapling/transaction.py
@@ -410,7 +410,7 @@ class transaction(util.transactional):
         generator will be executed.
 
         The `location` arguments may be used to indicate the files are located
-        outside of the the standard directory for transaction. It should match
+        outside of the standard directory for transaction. It should match
         one of the key of the `transaction.vfsmap` dictionary.
 
         In a lockfree transaction, filenames must be tracked by metalog.


### PR DESCRIPTION
Removes duplicated words in docstrings/comments across a few modules:

- `eden/scm/sapling/ext/rebase.py`: `for for` → `for`
- `eden/scm/sapling/crecord.py`: `the the` → `the`
- `eden/scm/sapling/patch.py`: `the the` → `the`
- `eden/scm/sapling/peer.py`: `a a` → `a`
- `eden/scm/sapling/transaction.py`: `the the` → `the`

Comment/docstring-only, no behavioral change.