### PR TITLE
Fix ISL "Goto" hanging in OSS by always replying to fetchQeFlag

### DIFF
--- a/addons/isl-server/src/ServerToClientAPI.ts
+++ b/addons/isl-server/src/ServerToClientAPI.ts
@@ -1010,7 +1010,11 @@ export default class ServerToClientAPI {
         break;
       }
       case 'fetchQeFlag': {
-        Internal.fetchQeFlag?.(repo.initialConnectionContext, data.name).then((passes: boolean) => {
+        // In OSS there is no Internal.fetchQeFlag, so default to `false`. We must always
+        // reply: the client awaits `fetchedQeFlag` and hangs forever without a response.
+        (
+          Internal.fetchQeFlag?.(repo.initialConnectionContext, data.name) ?? Promise.resolve(false)
+        ).then((passes: boolean) => {
           this.logger.info(`qe flag ${data.name} ${passes ? 'PASSES' : 'FAILS'}`);
           this.postMessage({type: 'fetchedQeFlag', name: data.name, passes});
         });

--- a/addons/isl-server/src/__tests__/ServerToClientAPI.test.ts
+++ b/addons/isl-server/src/__tests__/ServerToClientAPI.test.ts
@@ -10,8 +10,11 @@ import type {ClientConnection} from '..';
 import type {ServerPlatform} from '../serverPlatform';
 import type {RepositoryContext} from '../serverTypes';
 
-import {serializeToString} from 'isl/src/serialize';
+import {deserializeFromString, serializeToString} from 'isl/src/serialize';
 import {mockLogger, nextTick} from 'shared/testUtils';
+import {Internal} from '../Internal';
+import {Repository} from '../Repository';
+import {repositoryCache} from '../RepositoryCache';
 import ServerToClientAPI from '../ServerToClientAPI';
 import {makeServerSideTracker} from '../analytics/serverSideTracker';
 
@@ -154,5 +157,66 @@ describe('ServerToClientAPI disposable scoping', () => {
     api.dispose();
 
     expect(connectionDispose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ServerToClientAPI QE flags without an Internal implementation (OSS)', () => {
+  let platform: ServerPlatform;
+  let connection: ReturnType<typeof createMockConnection>;
+  let api: ServerToClientAPI;
+
+  beforeEach(async () => {
+    platform = {
+      platformName: 'test',
+      handleMessageFromClient: jest.fn(),
+    };
+
+    // `fetchQeFlag` is only handled once the connection has an active repo, which
+    // requires the resolved value to pass `instanceof Repository`. Give a plain object
+    // Repository's prototype so the connection reaches the "repo" state.
+    const repo = Object.assign(Object.create(Repository.prototype), {
+      info: mockRepoInfo,
+      initialConnectionContext: {logger: mockLogger},
+      codeReviewProvider: null,
+      ref: jest.fn(),
+      unref: jest.fn(),
+      dispose: jest.fn(),
+      fetchAndSetRecommendedBookmarks: jest.fn(),
+      fetchAndSetHiddenMasterConfig: jest.fn(),
+      pullFetchedDiffs: jest.fn().mockResolvedValue(undefined),
+    });
+    (repositoryCache.getOrCreate as jest.Mock).mockReturnValue({
+      promise: Promise.resolve(repo),
+      unref: jest.fn(),
+    });
+
+    connection = createMockConnection();
+    api = new ServerToClientAPI(platform, connection, mockTracker, mockLogger);
+    api.setActiveRepoForCwd('/path/to/repo/cwd');
+    await nextTick();
+  });
+
+  afterEach(() => {
+    api.dispose();
+    jest.clearAllMocks();
+  });
+
+  function responsesOfType(type: string): Array<Record<string, unknown>> {
+    return (connection.postMessage as jest.Mock).mock.calls
+      .map(([str]) => deserializeFromString(str as string) as Record<string, unknown>)
+      .filter(msg => msg.type === type);
+  }
+
+  it('replies to fetchQeFlag with passes=false when Internal.fetchQeFlag is unavailable', async () => {
+    // OSS builds have no Internal.fetchQeFlag; the server must still answer,
+    // otherwise the client (e.g. gotoAction) awaits a reply that never comes.
+    expect(Internal.fetchQeFlag).toBeUndefined();
+
+    connection.triggerMessage({type: 'fetchQeFlag', name: 'isl_rebase_onto_warm_button'});
+    await nextTick();
+
+    expect(responsesOfType('fetchedQeFlag')).toEqual([
+      {type: 'fetchedQeFlag', name: 'isl_rebase_onto_warm_button', passes: false},
+    ]);
   });
 });


### PR DESCRIPTION

The "Goto" button (and the right-click "Goto" context-menu item) in `sl web`
silently did nothing in OSS builds (#1332). Both call gotoAction(), which awaits
runWarningChecks(), whose last check awaits
getQeFlag('isl_rebase_onto_warm_button').

getQeFlag posts a `fetchQeFlag` message and awaits a `fetchedQeFlag` reply. The
server handler was `Internal.fetchQeFlag?.(...).then(...)`; in OSS there is no
Internal.fetchQeFlag, so the optional chain short-circuits and no reply is ever
posted. nextMessageMatching has no timeout, so getQeFlag never resolves,
gotoAction never dispatches the GotoOperation, and Goto appears dead. This
regressed when the "rebase onto warm" work started passing a hardcoded QE flag
name (bypassing the usual OSS null-gating).

Fix: always reply to fetchQeFlag, defaulting to `false` when Internal.fetchQeFlag
is unavailable (the correct OSS semantics), so the client never hangs.

Note: the sibling handlers fetchFeatureFlag and bulkFetchFeatureFlags share the
same `Internal.x?.(...).then(...)` short-circuit shape. They are not currently
reachable with a missing reply in OSS (feature flags are gated client-side via
Internal.featureFlags?.), so this focused change leaves them as-is; they should
get the same "always reply" guard as a follow-up.

Fixes #1332
