### PR TITLE
fix(oss-build): allow nightly features on stable via RUSTC_BOOTSTRAP

### DIFF
--- a/eden/scm/build.py
+++ b/eden/scm/build.py
@@ -430,6 +430,9 @@ def cargo_env(args):
         env["OPENSSL_DIR"] = str(openssl)
         env.pop("OPENSSL_STATIC", None)
     env["RUSTFLAGS"] = (env.get("RUSTFLAGS", "") + " -Anon_local_definitions").strip()
+    # Allow nightly features (smallvec specialization, once_cell_try) on stable Rust.
+    # Required for `make oss` / cargo oss builds. Buck builds use nightly toolchain internally.
+    env.setdefault("RUSTC_BOOTSTRAP", "1")
     set_windows_python_path(env, args.python)
     return env
 


### PR DESCRIPTION

make oss failed on stable Rust 1.97.1 with:

  error[E0554]: #![feature] may not be used on stable
    --> smallvec-1.15.2/src/lib.rs:95: specialization
  and 8 crates using #![feature(once_cell_try)]

Buck builds use a nightly toolchain internally and handle this,
but cargo oss builds use stable rustc by default.

Cargo.toml files are @generated by autocargo from BUCK files,
so we should not hand-edit them to remove the features.

Setting RUSTC_BOOTSTRAP=1 in build.py's cargo_env allows stable
cargo/rustc to accept these nightly features without requiring
users to install a nightly toolchain or override.

Fixes: cd eden/scm && make -j oss
