### PR TITLE
pager: add opt-in mouse wheel scrolling to streampager

### DIFF
--- a/eden/scm/lib/io/src/lib.rs
+++ b/eden/scm/lib/io/src/lib.rs
@@ -31,6 +31,7 @@ use pipe::pipe;
 use spawn_ext::CommandExt;
 use streampager::Pager;
 use streampager::action::Action;
+use streampager::config::Config as PagerConfig;
 use streampager::config::InterfaceMode;
 use streampager::config::WrappingMode;
 use term::DEFAULT_TERM_HEIGHT;
@@ -660,8 +661,11 @@ impl IO {
 
         inner.set_progress(&[])?;
 
-        let mut pager = Pager::new_using_system_terminal()
-            .or_else(|_| Pager::new_using_stdio())
+        let mut pager_config = PagerConfig::from_config_file().with_env();
+        pager_config.mouse = config.must_get("pager", "mouse").unwrap_or(false);
+
+        let mut pager = Pager::new_using_system_terminal_with_config(pager_config.clone())
+            .or_else(|_| Pager::new_using_stdio_with_config(pager_config))
             .map_err(io::Error::other)?;
 
         // Configure the pager.

--- a/eden/scm/lib/third-party/streampager/src/config.rs
+++ b/eden/scm/lib/third-party/streampager/src/config.rs
@@ -176,6 +176,9 @@ pub struct Config {
     /// Specify default wrapping move.
     pub wrapping_mode: WrappingMode,
 
+    /// Specify whether to handle the mouse, so the scroll wheel scrolls.
+    pub mouse: bool,
+
     /// Specify the name of the default key map.
     pub keymap: KeymapConfig,
 }
@@ -191,6 +194,7 @@ impl Default for Config {
             // See issue #52. With cursor hidden, scrolling is flaky in VSCode terminal.
             show_cursor: std::env::var("TERM_PROGRAM").ok().as_deref() == Some("vscode"),
             wrapping_mode: Default::default(),
+            mouse: false,
             keymap: Default::default(),
         }
     }
@@ -230,6 +234,11 @@ impl Config {
         if let Ok(s) = var("SP_READ_AHEAD_LINES") {
             if let Ok(n) = s.parse::<usize>() {
                 self.read_ahead_lines = n;
+            }
+        }
+        if let Ok(s) = var("SP_MOUSE") {
+            if let Some(b) = parse_bool(&s) {
+                self.mouse = b;
             }
         }
         self

--- a/eden/scm/lib/third-party/streampager/src/display.rs
+++ b/eden/scm/lib/third-party/streampager/src/display.rs
@@ -8,12 +8,13 @@ use scopeguard::guard;
 use termwiz::caps::Capabilities as TermCapabilities;
 use termwiz::cell::CellAttributes;
 use termwiz::color::ColorAttribute;
-use termwiz::input::InputEvent;
+use termwiz::input::{InputEvent, MouseButtons};
 use termwiz::surface::change::Change;
 use termwiz::surface::{CursorVisibility, Position};
 use termwiz::terminal::Terminal;
 use vec_map::VecMap;
 
+use crate::action::Action;
 use crate::command;
 use crate::config::Config;
 use crate::direct;
@@ -24,6 +25,9 @@ use crate::help::help_text;
 use crate::progress::Progress;
 use crate::screen::Screen;
 use crate::search::SearchKind;
+
+/// How many lines to scroll for each click of the mouse wheel.
+const WHEEL_SCROLL_LINES: usize = 3;
 
 /// Capabilities of the terminal that we care about.
 #[derive(Default)]
@@ -315,6 +319,21 @@ pub(crate) fn start(
                             command::search(SearchKind::First, event_sender.clone())
                         })
                         .paste(text, width)
+                }
+                // Only the vertical wheel scrolls; other mouse events are
+                // ignored. Check the config here rather than relying on mouse
+                // events not arriving, since Windows always puts the console in
+                // mouse-input mode.
+                Some(Event::Input(InputEvent::Mouse(ref mouse)))
+                    if config.mouse
+                        && mouse.mouse_buttons.contains(MouseButtons::VERT_WHEEL) =>
+                {
+                    let action = if mouse.mouse_buttons.contains(MouseButtons::WHEEL_POSITIVE) {
+                        Action::ScrollUpLines(WHEEL_SCROLL_LINES)
+                    } else {
+                        Action::ScrollDownLines(WHEEL_SCROLL_LINES)
+                    };
+                    screen.dispatch_action(action, &event_sender)
                 }
                 Some(Event::Loaded(index)) if screens.is_current_index(index) => {
                     DisplayAction::Refresh

--- a/eden/scm/lib/third-party/streampager/src/pager.rs
+++ b/eden/scm/lib/third-party/streampager/src/pager.rs
@@ -43,15 +43,18 @@ pub struct Pager {
 }
 
 /// Determine terminal capabilities.
-fn termcaps() -> Result<Capabilities> {
-    // Get terminal capabilities from the environment, but disable mouse
-    // reporting, as we don't want to change the terminal's mouse handling.
-    // Enable TrueColor support, which is backwards compatible with 16
-    // or 256 colors. Applications can still limit themselves to 16 or
-    // 256 colors if they want.
+///
+/// Mouse reporting is only enabled if the user asked for it, as it takes the
+/// mouse away from the terminal and so stops click-and-drag text selection
+/// from working.
+fn termcaps(mouse: bool) -> Result<Capabilities> {
+    // Get terminal capabilities from the environment. Enable TrueColor
+    // support, which is backwards compatible with 16 or 256 colors.
+    // Applications can still limit themselves to 16 or 256 colors if they
+    // want.
     let hints = ProbeHints::new_from_env()
         .color_level(Some(ColorLevel::TrueColor))
-        .mouse_reporting(Some(false));
+        .mouse_reporting(Some(mouse));
     let caps = Capabilities::new_with_hints(hints).map_err(Error::Termwiz)?;
     if cfg!(unix) && caps.terminfo_db().is_none() {
         Err(Error::TerminfoDatabaseMissing)
@@ -140,7 +143,7 @@ impl Pager {
         create_term: impl FnOnce(Capabilities) -> Result<SystemTerminal>,
         config: Config,
     ) -> Result<Self> {
-        let caps = termcaps()?;
+        let caps = termcaps(config.mouse)?;
         let term = create_term(caps.clone())?;
 
         let events = EventStream::new(term.waker());

--- a/eden/scm/sapling/helptext.py
+++ b/eden/scm/sapling/helptext.py
@@ -1730,6 +1730,17 @@ Setting used to control when to paginate and with what external tool. See
 
     Only affects streampager.
 
+``mouse``
+    Whether the pager handles the mouse, so that the scroll wheel scrolls
+    the output. Default: false.
+
+    Turning this on tells the terminal to send mouse events to the pager
+    instead of acting on them itself, which stops click-and-drag text
+    selection from working. Most terminals still let you select text while
+    holding shift.
+
+    Only affects streampager.
+
 ``wrapping-mode``
     Choose the line wrapping boundary: none, word, line.
 


### PR DESCRIPTION
Summary:
This adds a `pager.mouse` config option, off by default, that turns mouse reporting on and scrolls the output three lines per wheel click.

It is off by default because it interferes with normal terminal selection and copying behavior.

The option is named `pager.mouse` even though it only affects streampager, because that is what the existing options do (`pager.wrapping-mode`, `pager.interface`, etc). The new config is documented as "Only affects streampager".

The display event loop turns a wheel event into the same scroll actions the key bindings already use. That loop checks the config option rather than relying on mouse events not arriving at all, because on Windows termwiz always puts the console into mouse-input mode, so wheel events show up even when the user did not ask us to handle the mouse.

Sapling passes the option in when it builds the pager rather than through a setter, because the value decides which terminal capabilities the pager is created with. streampager also reads the option from an SP_MOUSE environment variable for use outside Sapling, matching the existing SP_INTERFACE_MODE and SP_SCROLL_PAST_EOF.

Tested by hand on Windows and macOS with `sl help config --config pager.mouse=true` and `sl help config --config pager.mouse=false`, confirming the wheel scrolls only when it is on.