### PR TITLE
Stacked GitHub PRs: Auto-switch between "single" and "overlap" workflows

### DIFF
--- a/eden/scm/sapling/ext/github/submit.py
+++ b/eden/scm/sapling/ext/github/submit.py
@@ -75,17 +75,17 @@ class SubmitWorkflow(Enum):
         workflow = ui.config(
             "github", "pr-workflow", ui.config("github", "pr_workflow")
         )
-        if not workflow or workflow == "overlap":
-            # For now, default to OVERLAP.
-            return SubmitWorkflow.OVERLAP
-        elif workflow == "single":
+        if not workflow or workflow == "single":
+            # Default to SINGLE.
             return SubmitWorkflow.SINGLE
+        elif workflow == "overlap":
+            return SubmitWorkflow.OVERLAP
         else:
             # Note that "classic" is not recognized yet.
             ui.warn(
                 _("unrecognized config for github.pr_workflow: defaulting to 'overlap'")
             )
-            return SubmitWorkflow.OVERLAP
+            return SubmitWorkflow.SINGLE
 
 
 @dataclass
@@ -160,8 +160,6 @@ async def update_commits_in_stack(
 
     store = PullRequestStore(repo)
 
-    workflow = SubmitWorkflow.from_config(ui)
-
     partitions = await get_partitions(ui, repo, store, "sort(. %% public(), -rev)")
     if not partitions:
         ui.status_err(_("no commits to submit\n"))
@@ -211,6 +209,14 @@ async def update_commits_in_stack(
         return 0
 
     repository = params.repository
+    if not repository:
+        repository = await get_repository_for_origin(origin, github_repo.hostname)
+
+    if repository.upstream is not None:
+        # Always use OVERLAP workflow for forked repositories
+        workflow = SubmitWorkflow.OVERLAP
+    else:
+        workflow = SubmitWorkflow.from_config(ui)
 
     # For the SINGLE workflow, we must update the base branch on existing PRs
     # BEFORE pushing the new branch contents. Otherwise, when commits are
@@ -223,10 +229,6 @@ async def update_commits_in_stack(
             p for p in partitions if p[0].pr and p[0].pr.state == PullRequestState.OPEN
         ]
         if existing_prs:
-            if not repository:
-                repository = await get_repository_for_origin(
-                    origin, github_repo.hostname
-                )
             # Update base branches on existing PRs before pushing.
             # Process from bottom of stack to top so bases are set correctly.
             for index in range(len(partitions)):
@@ -254,8 +256,6 @@ async def update_commits_in_stack(
     run_git_command(git_push_args, gitdir)
 
     if params.pull_requests_to_create:
-        if not repository:
-            repository = await get_repository_for_origin(origin, github_repo.hostname)
         if use_placeholder_strategy:
             assert isinstance(params, PlaceholderStrategyParams)
             await create_pull_requests_from_placeholder_issues(
@@ -286,8 +286,6 @@ async def update_commits_in_stack(
     # Add the head of the stack to the sapling-pr-archive branch.
     tip = hex(partitions[0][0].node)
 
-    if not repository:
-        repository = await get_repository_for_origin(origin, github_repo.hostname)
     rewrite_and_archive_requests = [
         rewrite_pull_request_body(
             partitions, index, workflow, pr_numbers_and_num_commits, repository, ui

--- a/eden/scm/tests/github/mock_create_prs.py
+++ b/eden/scm/tests/github/mock_create_prs.py
@@ -26,7 +26,7 @@ def setup_mock_github_server(ui) -> MockGitHubServer:
         (43, "two\n"),
     ]
 
-    single = ui.config("github", "pr-workflow") == "single"
+    single = ui.config("github", "pr-workflow") != "overlap"
 
     for idx, (num, msg) in enumerate(prs):
         title, body = title_and_body(msg)

--- a/eden/scm/tests/test-ext-github-pr-submit-closed.t
+++ b/eden/scm/tests/test-ext-github-pr-submit-closed.t
@@ -4,7 +4,7 @@
   $ enable github
   $ export SL_TEST_GH_URL=https://github.com/facebook/test_github_repo.git
   $ . $TESTDIR/git.sh
-  $ configure github.pr-workflow=single
+  $ setconfig github.pr-workflow=single
 
 build up a github repo
 

--- a/eden/scm/tests/test-ext-github-pr-submit-open.t
+++ b/eden/scm/tests/test-ext-github-pr-submit-open.t
@@ -6,7 +6,7 @@ Test that `sl pr submit --open` opens created PRs in the browser.
   $ enable github
   $ export SL_TEST_GH_URL=https://github.com/facebook/test_github_repo.git
   $ . $TESTDIR/git.sh
-  $ configure github.pr-workflow=overlap
+  $ setconfig github.pr-workflow=overlap
 
 build up a github repo
 

--- a/eden/scm/tests/test-ext-github-pr-submit-overlap.t
+++ b/eden/scm/tests/test-ext-github-pr-submit-overlap.t
@@ -4,7 +4,7 @@
   $ enable github
   $ export SL_TEST_GH_URL=https://github.com/facebook/test_github_repo.git
   $ . $TESTDIR/git.sh
-  $ configure github.pr-workflow=overlap
+  $ setconfig github.pr-workflow=overlap
 
 build up a github repo
 

--- a/eden/scm/tests/test-ext-github-pr-submit-single.t
+++ b/eden/scm/tests/test-ext-github-pr-submit-single.t
@@ -4,7 +4,7 @@
   $ enable github
   $ export SL_TEST_GH_URL=https://github.com/facebook/test_github_repo.git
   $ . $TESTDIR/git.sh
-  $ configure github.pr-workflow=single
+  $ setconfig github.pr-workflow=single
 
 build up a github repo
 


### PR DESCRIPTION
When submitting stacked GitHub PRs, automatically switch between "single" and "overlap" workflows based on whether the repo is a fork or not.

Because the SINGLE workflow matches the pattern needed for [GitHub's native PR stacks](https://docs.github.com/en/pull-requests/get-started/about-stacked-prs), it makes for a good default.

However, the SINGLE workflow generally doesn't work across repo forks – the OVERLAP workflow is needed here, which is why it is the current default.

This PR automatically switches between the SINGLE workflow (by default) for non-forked repos, and the OVERLAP workflow for forked repos. (The original config stays in place, so OVERLAP workflow can still be chosed for all repos, but the default is SINGLE.)

("SINGLE" workflow means each PR in the stack targets the head of the PR below it in the stack; "OVERLAP" workflow means every PR targets the `main` branch.)
