### PR TITLE
github: make the review link in the PR-body stack footer configurable

### DIFF
--- a/eden/scm/sapling/ext/github/mock_utils.py
+++ b/eden/scm/sapling/ext/github/mock_utils.py
@@ -283,6 +283,9 @@ class MockGitHubServer:
         owner: str = OWNER,
         name: str = REPO_NAME,
         stack_pr_ids: Optional[List[int]] = None,
+        *,
+        review_url: str,
+        review_tool: str,
     ) -> "UpdatePrRequest":
         if not stack_pr_ids:
             stack_pr_ids = [pr_number]
@@ -296,7 +299,7 @@ class MockGitHubServer:
                 ("" if commit_msg.endswith("\n") else "\n") + "---\n"
                 "[//]: # (BEGIN SAPLING FOOTER)\n"
                 "Stack created with [Sapling](https://sapling-scm.com). Best reviewed"
-                f" with [ReviewStack](https://reviewstack.dev/{owner}/{name}/pull/{pr_number}).\n"
+                f" with [{review_tool}]({review_url}).\n"
                 + "\n".join(pr_list)
             )
 

--- a/eden/scm/sapling/ext/github/pull_request_body.py
+++ b/eden/scm/sapling/ext/github/pull_request_body.py
@@ -6,10 +6,15 @@
 import re
 from typing import List, Tuple, Union
 
+from sapling import error
+from sapling.i18n import _
+
 from .gh_submit import Repository
 
 _HORIZONTAL_RULE = "---"
 _SAPLING_FOOTER_MARKER = "[//]: # (BEGIN SAPLING FOOTER)"
+DEFAULT_REVIEW_URL_TEMPLATE = "https://reviewstack.dev/{owner}/{repo}/pull/{number}"
+DEFAULT_REVIEW_TOOL_NAME = "ReviewStack"
 
 
 def create_pull_request_title_and_body(
@@ -18,6 +23,8 @@ def create_pull_request_title_and_body(
     pr_numbers_index: int,
     repository: Repository,
     reviewstack: bool = True,
+    review_url_template: str = DEFAULT_REVIEW_URL_TEMPLATE,
+    review_tool_name: str = DEFAULT_REVIEW_TOOL_NAME,
 ) -> Tuple[str, str]:
     r"""Returns (title, body) for the pull request.
 
@@ -84,6 +91,70 @@ def create_pull_request_title_and_body(
     * __->__ #42
     * #4
 
+    Customize the review link, e.g. for a self-hosted review tool:
+    >>> title, body = create_pull_request_title_and_body(
+    ...     commit_msg,
+    ...     pr_numbers_and_num_commits,
+    ...     pr_numbers_index,
+    ...     contributor_repo,
+    ...     review_url_template="https://review.example.com/{owner}/{repo}/{number}",
+    ...     review_tool_name="MyReview",
+    ... )
+    >>> print(body)
+    Second line of message.
+    <BLANKLINE>
+    <BLANKLINE>
+    ---
+    [//]: # (BEGIN SAPLING FOOTER)
+    Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [MyReview](https://review.example.com/facebook/sapling/42).
+    * #1
+    * #2 (2 commits)
+    * __->__ #42
+    * #4
+
+    A customized footer still parses as stack information:
+    >>> parse_stack_information(body)
+    [(False, 1), (False, 2), (True, 42), (False, 4)]
+
+    Customizing only the tool name keeps the default URL:
+    >>> title, body = create_pull_request_title_and_body(commit_msg, pr_numbers_and_num_commits,
+    ...     pr_numbers_index, contributor_repo, review_tool_name="MyReview")
+    >>> print(body.replace(reviewstack_url, "{reviewstack_url}"))
+    Second line of message.
+    <BLANKLINE>
+    <BLANKLINE>
+    ---
+    [//]: # (BEGIN SAPLING FOOTER)
+    Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [MyReview]({reviewstack_url}).
+    * #1
+    * #2 (2 commits)
+    * __->__ #42
+    * #4
+
+    The templates are ignored when the review link is disabled entirely:
+    >>> title, body = create_pull_request_title_and_body(commit_msg, pr_numbers_and_num_commits,
+    ...     pr_numbers_index, contributor_repo, reviewstack=False,
+    ...     review_url_template="https://review.example.com/{owner}/{repo}/{number}",
+    ...     review_tool_name="MyReview")
+    >>> print(body)
+    Second line of message.
+    <BLANKLINE>
+    <BLANKLINE>
+    ---
+    [//]: # (BEGIN SAPLING FOOTER)
+    * #1
+    * #2 (2 commits)
+    * __->__ #42
+    * #4
+
+    An invalid URL template aborts with a message naming the config:
+    >>> create_pull_request_title_and_body(commit_msg, pr_numbers_and_num_commits,
+    ...     pr_numbers_index, contributor_repo,
+    ...     review_url_template="https://review.example.com/{bogus}")
+    Traceback (most recent call last):
+     ...
+    sapling.error.Abort: invalid github.pull-request-review-url-template 'https://review.example.com/{bogus}': 'bogus'
+
     Single commit stack:
     >>> title, body = create_pull_request_title_and_body("Foo", [(1, 1)], 0, contributor_repo)
     >>> print(title)
@@ -108,8 +179,24 @@ def create_pull_request_title_and_body(
     extra = []
     if len(pr_numbers_and_num_commits) > 1:
         if reviewstack:
-            reviewstack_url = f"https://reviewstack.dev/{owner}/{name}/pull/{pr}"
-            review_stack_message = f"Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack]({reviewstack_url})."
+            # Pull requests live in the upstream repository, so - like `owner`
+            # and `name` above (see get_upstream_owner_and_name()) - the
+            # {hostname} placeholder expands from the upstream when submitting
+            # from a fork. For non-fork clones, repository.hostname is the
+            # same host.
+            hostname = (
+                repository.upstream.hostname
+                if repository.upstream
+                else repository.hostname
+            )
+            review_url = _format_review_url(
+                review_url_template,
+                owner=owner,
+                repo=name,
+                number=pr,
+                hostname=hostname,
+            )
+            review_stack_message = f"Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [{review_tool_name}]({review_url})."
             extra.append(review_stack_message)
         bulleted_list = "\n".join(
             _format_stack_entry(pr_number, index, pr_numbers_index, num_commits)
@@ -123,6 +210,26 @@ def create_pull_request_title_and_body(
             body += "\n"
         body += "\n".join([_HORIZONTAL_RULE, _SAPLING_FOOTER_MARKER] + extra)
     return title, body
+
+
+def _format_review_url(
+    template: str, *, owner: str, repo: str, number: int, hostname: str
+) -> str:
+    r"""Expands the github.pull-request-review-url-template config value.
+
+    >>> _format_review_url(DEFAULT_REVIEW_URL_TEMPLATE,
+    ...     owner="facebook", repo="sapling", number=42, hostname="github.com")
+    'https://reviewstack.dev/facebook/sapling/pull/42'
+    >>> _format_review_url("https://{hostname}/{owner}/{repo}/reviews/{number}",
+    ...     owner="facebook", repo="sapling", number=42, hostname="github.example.com")
+    'https://github.example.com/facebook/sapling/reviews/42'
+    """
+    try:
+        return template.format(owner=owner, repo=repo, number=number, hostname=hostname)
+    except (IndexError, KeyError, ValueError) as e:
+        raise error.Abort(
+            _("invalid github.pull-request-review-url-template %r: %s") % (template, e)
+        )
 
 
 _STACK_ENTRY = re.compile(r"^\* (__->__ )?#([1-9]\d*).*$")

--- a/eden/scm/sapling/ext/github/submit.py
+++ b/eden/scm/sapling/ext/github/submit.py
@@ -22,7 +22,12 @@ from .gh_submit import PullRequestDetails, PullRequestState, Repository
 from .github_repo_util import check_github_repo, GitHubRepo
 from .none_throws import none_throws
 from .pr_parser import get_pull_request_for_context
-from .pull_request_body import create_pull_request_title_and_body, title_and_body
+from .pull_request_body import (
+    create_pull_request_title_and_body,
+    DEFAULT_REVIEW_TOOL_NAME,
+    DEFAULT_REVIEW_URL_TEMPLATE,
+    title_and_body,
+)
 from .pullrequest import PullRequestId
 from .pullrequeststore import PullRequestStore
 from .run_git_command import run_git_command
@@ -341,12 +346,22 @@ async def rewrite_pull_request_body(
     else:
         commit_msg_or_title_body = head_commit_data.get_msg()
 
+    review_url_template = (
+        ui.config("github", "pull-request-review-url-template")
+        or DEFAULT_REVIEW_URL_TEMPLATE
+    )
+    review_tool_name = (
+        ui.config("github", "pull-request-review-tool-name")
+        or DEFAULT_REVIEW_TOOL_NAME
+    )
     title, body = create_pull_request_title_and_body(
         commit_msg_or_title_body,
         pr_numbers_and_num_commits,
         index,
         repository,
         reviewstack=ui.configbool("github", "pull-request-include-reviewstack"),
+        review_url_template=review_url_template,
+        review_tool_name=review_tool_name,
     )
 
     if pr.state != PullRequestState.OPEN:

--- a/eden/scm/tests/github/mock_create_one_pr_placeholder_issue.py
+++ b/eden/scm/tests/github/mock_create_one_pr_placeholder_issue.py
@@ -5,7 +5,18 @@
 
 from sapling import extensions
 from sapling.ext.github import github_gh_cli, submit
-from sapling.ext.github.mock_utils import mock_run_git_command, MockGitHubServer
+from sapling.ext.github.consts import GITHUB_HOSTNAME
+from sapling.ext.github.mock_utils import (
+    mock_run_git_command,
+    MockGitHubServer,
+    OWNER,
+    REPO_NAME,
+)
+from sapling.ext.github.pull_request_body import (
+    _format_review_url,
+    DEFAULT_REVIEW_TOOL_NAME,
+    DEFAULT_REVIEW_URL_TEMPLATE,
+)
 
 # An extension to mock network requests by replacing the `github_gh_cli.make_request`
 # and `submit.run_git_command` with the corresponding wrapper functions. Check `uisetup`
@@ -31,7 +42,21 @@ def setup_mock_github_server() -> MockGitHubServer:
     pr_id = f"PR_id_{pr_number}"
     github_server.expect_get_pr_details_request(pr_number).and_respond(pr_id)
 
-    github_server.expect_update_pr_request(pr_id, pr_number, body).and_respond()
+    # Single-PR update: no stack footer is rendered, but the review link
+    # arguments are required by expect_update_pr_request.
+    github_server.expect_update_pr_request(
+        pr_id,
+        pr_number,
+        body,
+        review_url=_format_review_url(
+            DEFAULT_REVIEW_URL_TEMPLATE,
+            owner=OWNER,
+            repo=REPO_NAME,
+            number=pr_number,
+            hostname=GITHUB_HOSTNAME,
+        ),
+        review_tool=DEFAULT_REVIEW_TOOL_NAME,
+    ).and_respond()
     github_server.expect_get_username_request().and_respond()
 
     head = "3a120a3a153f7d2960967ce6f1d52698a4d3a436"

--- a/eden/scm/tests/github/mock_create_prs_footer.py
+++ b/eden/scm/tests/github/mock_create_prs_footer.py
@@ -19,33 +19,38 @@ from sapling.ext.github.pull_request_body import (
     title_and_body,
 )
 
-# An extension to mock network requests by replacing the `github_gh_cli.make_request`
-# and `submit.run_git_command` with the corresponding wrapper functions. Check `uisetup`
-# function for how wrapper functions are registered.
+# An extension to mock network requests for `sl pr submit` with customized
+# github.pull-request-review-url-template / github.pull-request-review-tool-name
+# configs. The expected review link is computed from the same configs the test
+# sets, so the mock server only matches if the customized footer was produced.
 
 
 def setup_mock_github_server(ui) -> MockGitHubServer:
-    """Setup mock GitHub Server for testing happy case of `sl pr submit` command."""
+    """Setup mock GitHub Server for testing `sl pr submit` with a custom review link."""
     github_server = MockGitHubServer()
 
     github_server.expect_get_repository_request().and_respond()
 
     github_server.expect_guess_next_pull_request_number().and_respond()
 
+    url_template = (
+        ui.config("github", "pull-request-review-url-template")
+        or DEFAULT_REVIEW_URL_TEMPLATE
+    )
+    review_tool = (
+        ui.config("github", "pull-request-review-tool-name")
+        or DEFAULT_REVIEW_TOOL_NAME
+    )
+
     prs = [
         (42, "one\n"),
         (43, "two\n"),
     ]
 
-    single = ui.config("github", "pr-workflow") == "single"
-
-    for idx, (num, msg) in enumerate(prs):
+    for num, msg in prs:
         title, body = title_and_body(msg)
         head = f"pr{num}"
-
         base = "main"
-        if single and idx > 0:
-            base = "pr%d" % prs[idx - 1][0]
 
         github_server.expect_create_pr_request(
             body=body,
@@ -57,20 +62,18 @@ def setup_mock_github_server(ui) -> MockGitHubServer:
         pr_id = f"PR_id_{num}"
         github_server.expect_get_pr_details_request(num).and_respond(pr_id)
 
+        review_url = _format_review_url(
+            url_template, owner=OWNER, repo=REPO_NAME, number=num, hostname=GITHUB_HOSTNAME
+        )
+
         github_server.expect_update_pr_request(
             pr_id,
             num,
             msg,
             base=base,
             stack_pr_ids=[pr[0] for pr in prs],
-            review_url=_format_review_url(
-                DEFAULT_REVIEW_URL_TEMPLATE,
-                owner=OWNER,
-                repo=REPO_NAME,
-                number=num,
-                hostname=GITHUB_HOSTNAME,
-            ),
-            review_tool=DEFAULT_REVIEW_TOOL_NAME,
+            review_url=review_url,
+            review_tool=review_tool,
         ).and_respond()
 
     github_server.expect_get_username_request().and_respond()

--- a/eden/scm/tests/github/mock_create_prs_with_open.py
+++ b/eden/scm/tests/github/mock_create_prs_with_open.py
@@ -11,8 +11,19 @@ and print them to stderr so they can be verified in tests.
 
 from sapling import extensions
 from sapling.ext.github import github_gh_cli, submit
-from sapling.ext.github.mock_utils import mock_run_git_command, MockGitHubServer
-from sapling.ext.github.pull_request_body import title_and_body
+from sapling.ext.github.consts import GITHUB_HOSTNAME
+from sapling.ext.github.mock_utils import (
+    mock_run_git_command,
+    MockGitHubServer,
+    OWNER,
+    REPO_NAME,
+)
+from sapling.ext.github.pull_request_body import (
+    _format_review_url,
+    DEFAULT_REVIEW_TOOL_NAME,
+    DEFAULT_REVIEW_URL_TEMPLATE,
+    title_and_body,
+)
 
 
 def setup_mock_github_server(ui) -> MockGitHubServer:
@@ -49,7 +60,19 @@ def setup_mock_github_server(ui) -> MockGitHubServer:
         github_server.expect_get_pr_details_request(num).and_respond(pr_id)
 
         github_server.expect_update_pr_request(
-            pr_id, num, msg, base=base, stack_pr_ids=[pr[0] for pr in prs]
+            pr_id,
+            num,
+            msg,
+            base=base,
+            stack_pr_ids=[pr[0] for pr in prs],
+            review_url=_format_review_url(
+                DEFAULT_REVIEW_URL_TEMPLATE,
+                owner=OWNER,
+                repo=REPO_NAME,
+                number=num,
+                hostname=GITHUB_HOSTNAME,
+            ),
+            review_tool=DEFAULT_REVIEW_TOOL_NAME,
         ).and_respond()
 
     github_server.expect_get_username_request().and_respond()

--- a/eden/scm/tests/test-ext-github-pr-submit-footer.t
+++ b/eden/scm/tests/test-ext-github-pr-submit-footer.t
@@ -1,0 +1,33 @@
+#require git no-eden no-windows
+
+  $ eagerepo
+  $ enable github
+  $ export SL_TEST_GH_URL=https://github.com/facebook/test_github_repo.git
+  $ . $TESTDIR/git.sh
+  $ configure github.pr-workflow=overlap
+  $ setconfig github.pull-request-review-url-template='https://review.example.com/{owner}/{repo}/{number}'
+  $ setconfig github.pull-request-review-tool-name=MyReview
+
+build up a github repo
+
+  $ sl init --git repo1
+  $ cd repo1
+  $ echo a > a1
+  $ sl ci -Aqm one
+  $ echo a >> a1
+  $ sl ci -Aqm two
+
+confirm it is a 'github_repo'
+  $ sl log -r. -T '{github_repo}\n'
+  True
+
+test sending pr with a customized review link: the mock server expects the
+footer to link to the configured review tool, so this only passes if the
+templates were applied
+
+  $ sl pr submit --config extensions.pr_submit=$TESTDIR/github/mock_create_prs_footer.py
+  pushing 2 to https://github.com/facebook/test_github_repo.git
+  created new pull request: https://github.com/facebook/test_github_repo/pull/42
+  created new pull request: https://github.com/facebook/test_github_repo/pull/43
+  updated body for https://github.com/facebook/test_github_repo/pull/43
+  updated body for https://github.com/facebook/test_github_repo/pull/42

--- a/website/docs/addons/reviewstack.md
+++ b/website/docs/addons/reviewstack.md
@@ -34,3 +34,22 @@ ReviewStack supports the following keyboard shortcuts:
 | `alt+A`                     | select Approve Changes action |
 | `alt+R`                     | select Request Changes action |
 | `alt+C`                     | select Comment action         |
+
+## Linking to a different review tool
+
+When <Command name="pr" linkText="sl pr submit" /> creates a stack, it appends a footer to each pull request body with a link to the stack on **reviewstack.dev**. If you run your own instance of ReviewStack (or another review tool that understands stacks), you can point that link elsewhere:
+
+```ini
+[github]
+pull-request-review-url-template=https://review.example.com/{owner}/{repo}/pull/{number}
+pull-request-review-tool-name=MyReview
+```
+
+The URL template supports the `{owner}`, `{repo}`, `{number}`, and `{hostname}` placeholders. `{hostname}` expands to the GitHub host the repository lives on — `github.com` for repositories on github.com, or your GitHub Enterprise hostname; when submitting from a fork it is the upstream's host. Note that the host in the template itself is your review tool, not GitHub: `{hostname}` is handy when a single review-tool instance serves repositories on more than one GitHub host and needs the GitHub host in the URL to tell them apart:
+
+```ini
+[github]
+pull-request-review-url-template=https://reviewstack.example.com/{hostname}/{owner}/{repo}/pull/{number}
+```
+
+When these configs are unset, the footer links to reviewstack.dev as before. Setting `github.pull-request-include-reviewstack=false` removes the review link line entirely.


### PR DESCRIPTION
Closes #1409.

`sl pr submit` hard-codes `https://reviewstack.dev/...` as the "Best reviewed with" link in the stack footer. Teams on GitHub Enterprise (#512), running a self-hosted ReviewStack fork (#304), or using another stack-aware review tool get a wrong or dead link in every PR. The ReviewStack source itself anticipates alternate hosts (`saplingStack.ts`: the URL "can change over time (particularly if someone wants to run their own fork of ReviewStack)").

This PR adds two configs:

```ini
[github]
pull-request-review-url-template=https://review.example.com/{owner}/{repo}/pull/{number}
pull-request-review-tool-name=MyReview
```

producing:

> Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [MyReview](https://review.example.com/facebook/sapling/42).

## Design notes

- **Unset ⇒ byte-for-byte today's output.** The three existing `test-ext-github-pr-submit-*.t` tests pass unchanged, which doubles as the regression proof.
- The URL template uses `str.format` placeholders (`{owner}`, `{repo}`, `{number}`, `{hostname}`) rather than the full Sapling templater: it keeps `create_pull_request_title_and_body()` a pure, doctest-able function and matches how the URL is already written. Happy to switch to the templater (as `github.pr.branch-name-template` does) if you'd prefer.
- The sentence shape is deliberately **not** configurable. `parse_stack_information()` only tolerates the intro line because it starts with the literal `Stack created with [Sapling]`; free-form text would also risk corrupting ReviewStack's bullet parsing (`* `-prefixed lines, bare `---`, `__->__`). Keeping the fixed sentence means even old `sl` binaries parse customized bodies correctly.
- An invalid URL template aborts at submit time with a message naming the config.
- `github.pull-request-include-reviewstack=false` still suppresses the whole line; the new configs are no-ops in that case.
- Config resolution happens at the call boundary (`submit.py`: `ui.config(...) or DEFAULT_...`), so the library function and the test mocks take non-Optional values; the defaults are exported as `DEFAULT_REVIEW_URL_TEMPLATE` / `DEFAULT_REVIEW_TOOL_NAME`.

## Follow-up

The footer-parser hardening that was originally a second commit here (tolerating free-text introduction lines after the modern footer marker) is now its own PR per review feedback: #1419. The two are independent.

## Test plan

- New doctests in `pull_request_body.py` (custom URL, custom name, both, invalid-template abort, round-trip parse of a customized footer) — module doctests all pass.
- New `eden/scm/tests/test-ext-github-pr-submit-footer.t` + `tests/github/mock_create_prs_footer.py`: the mock server computes the expected footer from the same configs the test sets, so it only matches if the templates were applied. `mock_utils.expect_update_pr_request()` now takes required keyword-only `review_url`/`review_tool` args; all mock callers construct them from the exported defaults via `_format_review_url()`.
- Existing `test-ext-github-pr-submit-{single,overlap,open}.t` pass unchanged.
- All four `.t` tests ran green against an OSS `make oss`-equivalent build (`build.py --oss sl`) in a manylinux_2_34 container on the initial submission; module doctests re-verified after each review revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaQdFpGUAEQSBSqHwtQCZ1
