### PR TITLE
cpython-ext: raise the concrete OSError subclass for I/O errors (fixes Windows clone/pull/rebase)

### DIFF
--- a/eden/scm/lib/cpython-ext/src/io_error.rs
+++ b/eden/scm/lib/cpython-ext/src/io_error.rs
@@ -5,26 +5,50 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use cpython::ObjectProtocol;
 use cpython::Python;
+use cpython::PythonObject;
+use cpython::ToPyObject;
 use cpython::exc;
 use util::path_error_details;
 
 pub fn translate_io_error(py: Python, e: &std::io::Error) -> cpython::PyErr {
-    if let Some(details) = path_error_details(e) {
-        let e = details.original_io_error;
-        let errno = io_error_errno(e);
-        return cpython::PyErr::new::<exc::OSError, _>(
-            py,
-            (
-                errno,
-                io_error_strerror(e, errno),
-                details.path.display().to_string(),
-            ),
-        );
-    }
+    let (e, filename) = match path_error_details(e) {
+        Some(details) => (
+            details.original_io_error,
+            Some(details.path.display().to_string()),
+        ),
+        None => (e, None),
+    };
 
     let errno = io_error_errno(e);
-    cpython::PyErr::new::<exc::OSError, _>(py, (errno, io_error_strerror(e, errno)))
+    let strerror = io_error_strerror(e, errno);
+
+    // On Windows `raw_os_error` is a Win32 error code, not an errno. Report it
+    // as `OSError.winerror` so CPython replaces the errno above with the
+    // matching one, like it does for its own Windows errors in
+    // `PyErr_SetExcFromWindowsErrWithFilenameObjects`. Without this,
+    // ERROR_PATH_NOT_FOUND (3) would be taken as ESRCH, and ERROR_ACCESS_DENIED
+    // (5) as EIO, picking the wrong exception type below.
+    #[cfg(windows)]
+    let args = (errno, strerror, filename, e.raw_os_error()).to_py_object(py);
+    #[cfg(not(windows))]
+    let args = (errno, strerror, filename).to_py_object(py);
+
+    // Instantiate the exception instead of using
+    // `PyErr::new::<exc::OSError, _>(py, args)`, which would keep `OSError` as
+    // the exception type and only build the instance when the error gets
+    // normalized. Normalization does not adjust the type, so the type stays
+    // `OSError` even though `OSError.__new__` picks a subclass based on errno.
+    // Interpreters matching `except` clauses against the type instead of the
+    // instance (CPython 3.10 and older) then fail to run `except
+    // FileNotFoundError` for an ENOENT error raised from Rust.
+    let os_error_type = py.get_type::<exc::OSError>().into_object();
+    match os_error_type.call(py, args, None) {
+        Ok(instance) => cpython::PyErr::from_instance(py, instance),
+        // Building the exception failed. Report that failure instead.
+        Err(err) => err,
+    }
 }
 
 fn io_error_strerror(e: &std::io::Error, errno: Option<i32>) -> String {
@@ -51,6 +75,11 @@ fn io_error_strerror(e: &std::io::Error, errno: Option<i32>) -> String {
     message
 }
 
+/// The raw OS error code, or an errno inferred from the error type.
+///
+/// On Windows `raw_os_error` is a Win32 error code rather than an errno. It is
+/// still the code Rust puts in the error message, and it is passed to Python as
+/// `OSError.winerror` so that CPython derives the real errno from it.
 fn io_error_errno(e: &std::io::Error) -> Option<i32> {
     if let Some(errno) = e.raw_os_error() {
         return Some(errno);
@@ -82,5 +111,78 @@ fn io_error_errno(e: &std::io::Error) -> Option<i32> {
         TimedOut => Some(libc::ETIMEDOUT),
         Interrupted => Some(libc::EINTR),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+
+    use cpython::PythonObjectWithTypeObject;
+
+    use super::*;
+
+    #[test]
+    fn test_missing_file_is_a_file_not_found_error() {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+
+        let io_error = std::fs::metadata("this-path-does-not-exist").unwrap_err();
+        let err = translate_io_error(py, &io_error);
+
+        // `PyErr::matches` is what an `except FileNotFoundError` clause does on
+        // CPython 3.10 and older: it compares against the exception type rather
+        // than the exception instance. Newer CPython compares against the
+        // instance and hides the difference when the error is actually raised,
+        // so this checks the exception type directly to stay meaningful on
+        // every Python version.
+        assert!(err.matches(py, py.get_type::<exc::FileNotFoundError>()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_errno_selects_the_exception_type() {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+
+        assert_error::<exc::FileNotFoundError>(py, libc::ENOENT, libc::ENOENT);
+        assert_error::<exc::PermissionError>(py, libc::EACCES, libc::EACCES);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_win32_error_code_selects_the_exception_type() {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+
+        // Win32 error codes are not errno values. Used as errno,
+        // ERROR_PATH_NOT_FOUND would be ESRCH and ERROR_ACCESS_DENIED would be
+        // EIO.
+        const ERROR_FILE_NOT_FOUND: i32 = 2;
+        const ERROR_PATH_NOT_FOUND: i32 = 3;
+        const ERROR_ACCESS_DENIED: i32 = 5;
+        const ERROR_ALREADY_EXISTS: i32 = 183;
+
+        assert_error::<exc::FileNotFoundError>(py, ERROR_FILE_NOT_FOUND, libc::ENOENT);
+        assert_error::<exc::FileNotFoundError>(py, ERROR_PATH_NOT_FOUND, libc::ENOENT);
+        assert_error::<exc::PermissionError>(py, ERROR_ACCESS_DENIED, libc::EACCES);
+        assert_error::<exc::FileExistsError>(py, ERROR_ALREADY_EXISTS, libc::EEXIST);
+    }
+
+    /// Check that an `io::Error` with `raw_os_error` becomes an exception of
+    /// type `T` carrying `errno`.
+    fn assert_error<T: PythonObjectWithTypeObject>(py: Python, raw_os_error: i32, errno: i32) {
+        let mut err = translate_io_error(py, &io::Error::from_raw_os_error(raw_os_error));
+        assert!(
+            err.matches(py, py.get_type::<T>()),
+            "os error {raw_os_error} has an unexpected exception type"
+        );
+        let actual = err
+            .instance(py)
+            .getattr(py, "errno")
+            .unwrap()
+            .extract::<i32>(py)
+            .unwrap();
+        assert_eq!(actual, errno, "os error {raw_os_error} has a wrong errno");
     }
 }

--- a/eden/scm/tests/test-rust-io-errors.py
+++ b/eden/scm/tests/test-rust-io-errors.py
@@ -1,0 +1,64 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This software may be used and distributed according to the terms of the
+# GNU General Public License version 2.
+
+"""I/O errors raised by Rust are catchable as the matching OSError subclass.
+
+Rust reports I/O errors as `OSError` plus its constructor arguments, and
+CPython only builds the concrete exception when the error is normalized.
+Normalization keeps `OSError` as the exception type even though
+`OSError.__new__` picks a subclass from errno, so on CPython 3.10 and older -
+which matches `except` clauses against the type rather than the instance -
+`except FileNotFoundError` did not catch a missing file reported by Rust.
+`localrepo.transaction()` relies on exactly that, which used to make every
+locked transaction (clone, pull, rebase) abort on Windows builds, where the
+embedded interpreter is CPython 3.10.
+
+CPython 3.12 and newer normalize exceptions when they are raised, so these
+tests pass with or without the fix there. The check that is meaningful on
+every Python version lives in the Rust unit tests of
+eden/scm/lib/cpython-ext/src/io_error.rs.
+"""
+
+import os
+import tempfile
+import unittest
+
+import silenttestrunner
+from sapling import vfs as vfsmod
+
+
+class testrustioerrors(unittest.TestCase):
+    def setUp(self):
+        self.vfs = vfsmod.vfs(tempfile.mkdtemp(dir=os.getcwd()), audit=False)
+
+    def teststat(self):
+        with self.assertRaises(FileNotFoundError):
+            self.vfs.stat("missing")
+
+    def testlstat(self):
+        with self.assertRaises(FileNotFoundError):
+            self.vfs.lstat("missing")
+
+    def testread(self):
+        with self.assertRaises(FileNotFoundError):
+            self.vfs.read("missing")
+
+    def testlistdir(self):
+        with self.assertRaises(FileNotFoundError):
+            self.vfs.listdir("missing")
+
+    def testunlink(self):
+        with self.assertRaises(FileNotFoundError):
+            self.vfs.unlink("missing")
+
+    def testlexistsofmissingvfs(self):
+        # lexists() swallows FileNotFoundError to report a vfs whose own base
+        # directory is gone.
+        missing = vfsmod.vfs(os.path.join(self.vfs.base, "missing"), audit=False)
+        self.assertFalse(missing.lexists("anything"))
+
+
+if __name__ == "__main__":
+    silenttestrunner.main(__name__)


### PR DESCRIPTION
## Problem

On Windows, every command that opens a locked transaction fails:

```
$ sl pull
abort: The system cannot find the file specified.: journal
```

`clone`, `pull` and `rebase` all abort this way. `commit` and `goto` use
lock-free transactions and keep working, which is why only some commands are
affected.

With `--traceback` (sl 0.2.20260811-150444+8fb02b32, Windows 11):

```
File "static:sapling.git", line 628, in pull
    with repo.lock(), repo.transaction("pull"):
File "static:sapling.localrepo", line 1781, in transaction
    self.svfs.stat("journal")
File "static:sapling.vfs", line 551, in stat
    return self.lstat(path)
File "static:sapling.vfs", line 501, in lstat
    return self._rustvfs.metadata(self._rustpath(path))
FileNotFoundError: [Errno 2] The system cannot find the file specified.: 'journal'
```

`localrepo.transaction()` treats a missing journal as the normal case:

```python
if not lockfree:
    try:
        self.svfs.stat("journal")
    except FileNotFoundError:
        # No existing transaction - this is the normal case.
        pass
    else:
        self.recover()
```

The `except` clause does not match, so the normal case aborts the command.
`vfs.lexists()` uses the same pattern.

## Root cause

`cpython_ext::error::translate_io_error()` built the error with

```rust
cpython::PyErr::new::<exc::OSError, _>(py, (errno, strerror, path))
```

`PyErr::new::<T>` stores `T` as `ptype` and the argument tuple as `pvalue`.
CPython builds the actual exception instance when the error is normalized, and
`_PyErr_NormalizeException()` does not replace the type when it instantiates
from an argument tuple - so the type stays `OSError` even though
`OSError.__new__` returned a `FileNotFoundError`.

CPython 3.10 and older push the exception *type* for `except` matching
(`JUMP_IF_NOT_EXC_MATCH` compares `PyErr_GivenExceptionMatches(OSError,
FileNotFoundError)`, which is false), while the bound object is the
`FileNotFoundError` instance. That produces the confusing state where

```
except FileNotFoundError:                 # does not catch
except OSError:                           # catches, errno == 2
type(e) is builtins.FileNotFoundError     # True
isinstance(e, FileNotFoundError)          # True
```

CPython 3.11 matches against the instance and 3.12 normalizes at raise time,
so neither is affected.

### Why this is Windows-only

It depends on the version of the embedded interpreter, not on the OS:

* The Windows release binaries embed CPython 3.10.11
  (`sl debugshell -c "import sys; print(sys.version)"`), so the bug reproduces.
* The Homebrew formula depends on `python@3.13`, so macOS and Linux are fine
  and CI stays green.

This is not a recent regression - the released 0.2.20260522 Windows binary
behaves the same way.

Errors raised by Python itself (`open()`, `os.stat()`) are unaffected; only
errors crossing the Rust boundary are.

## Fix

Instantiate `OSError` and build the `PyErr` from the instance, so `ptype` is
the concrete subclass that `OSError.__new__` picked. This is correct on every
supported Python version and fixes every `except FileNotFoundError` /
`PermissionError` / `FileExistsError` / ... over a Rust-raised I/O error at
once, including the two sites above.

### Windows error codes

Included in the same change because it is now load-bearing: `io_error_errno()`
returned `io::Error::raw_os_error()` as the errno, but on Windows that is a
Win32 error code. `ERROR_FILE_NOT_FOUND` (2) happens to equal `ENOENT`, which
is why the journal probe still carried `errno == 2`, but the others do not
line up. Verified against the released Windows build:

```
ERROR_ACCESS_DENIED (5)   -> errno 5 (EIO)   -> plain OSError, not PermissionError
ERROR_PATH_NOT_FOUND (3)  -> errno 3 (ESRCH) -> would map to ProcessLookupError
```

Before this change a wrong errno was only a wrong `e.errno`; once errno selects
the exception type, it becomes a wrong exception type. So the Win32 code is now
passed as `OSError`'s `winerror` argument and CPython derives the errno from it,
exactly as it does for its own Windows I/O errors in
`PyErr_SetExcFromWindowsErrWithFilenameObjects`. `OSError.strerror` and
`OSError.filename` are unchanged, so the `abort:` messages built by
`scmutil.callcatch()` are unchanged.

## Tests

`eden/scm/lib/cpython-ext/src/io_error.rs` asserts on the exception type
directly, so those tests fail without the fix on **any** Python version:

* `test_missing_file_is_a_file_not_found_error`
* `test_errno_selects_the_exception_type` (unix)
* `test_win32_error_code_selects_the_exception_type` (windows)

`eden/scm/tests/test-rust-io-errors.py` covers the Python side through `vfs`
(`stat`, `lstat`, `read`, `listdir`, `unlink`, and the `lexists()` fallback).
It uses `except`, so it only reproduces the original bug on CPython 3.10 and
older - the module docstring says so explicitly, since a 3.12+ test runner
passes it either way.

## Reproducing

On a Windows build with an embedded CPython 3.10:

```
sl clone https://github.com/facebook/sapling
cd sapling && sl pull      # abort: The system cannot find the file specified.: journal
```

Or without a repo:

```
sl debugshell -c "
import tempfile
from sapling import vfs
v = vfs.vfs(tempfile.mkdtemp(), audit=False)
try:
    v.stat('missing')
except FileNotFoundError:
    print('caught')
except OSError as e:
    print('NOT caught by except FileNotFoundError:', type(e).__name__, e.errno)
"
```

## Verification

* `cargo test -p sapling-cpython-ext --lib io_error` passes with the change and
  fails on both tests without it (Windows 11, x86_64-msvc).
* `cargo clippy -p sapling-cpython-ext --all-targets` and `rustfmt --check` are
  clean.
* Each assertion in `test-rust-io-errors.py` was confirmed to reproduce the bug
  against the released Windows binary via `sl debugshell`. The test file itself
  was not run under `run-tests.py` - I could not produce a full local build of
  `sl` on Windows.
* The pre-existing `cpython_ext` serde tests crash in my local environment
  because the only Python I could link against is 3.14; that is unrelated to
  this change and reproduces on a clean tree.
