### PR TITLE
Fix vscode blame username

### DIFF
--- a/addons/vscode/CHANGELOG.md
+++ b/addons/vscode/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.71
+
+- Fix inline blame `(you)` annotations using Sapling `ui.username` instead of the OS username
+
 ## 0.1.70
 
 - Reduced fetching frequency for better performance

--- a/addons/vscode/extension/blame/__tests__/blame.test.ts
+++ b/addons/vscode/extension/blame/__tests__/blame.test.ts
@@ -8,14 +8,21 @@
 import type {Repository} from 'isl-server/src/Repository';
 import type {RepositoryContext} from 'isl-server/src/serverTypes';
 import type {CommitInfo} from 'isl/src/types';
+import type {TextEditor} from 'vscode';
+import type {VSCodeReposList} from '../../VSCodeRepo';
 
 import {GitHubCodeReviewProvider} from 'isl-server/src/github/githubCodeReviewProvider';
 import {mockLogger} from 'shared/testUtils';
-import {contextForRepo} from '../blame';
+import {contextForRepo, InlineBlameProvider} from '../blame';
 import {getDiffBlameHoverMarkup} from '../blameHover';
 import {getRealignedBlameInfo, shortenAuthorName} from '../blameUtils';
 
 jest.mock('vscode', () => jest.requireActual('../../../__mocks__/vscode'));
+
+// OS username that appears inside other authors' emails, e.g. bob@coder.com.
+jest.mock('isl-server/src/analytics/environment', () => ({
+  getUsername: () => 'coder',
+}));
 
 describe('blame', () => {
   describe('contextForRepo', () => {
@@ -159,3 +166,175 @@ describe('blame utils', () => {
     });
   });
 });
+
+describe('InlineBlameProvider (you)', () => {
+  const repoRoot = '/workspace/repo';
+  const filePath = '/workspace/repo/file.ts';
+  const alice = 'Alice <alice@company.com>';
+  const bob = 'Bob <bob@coder.com>';
+
+  type TestableBlameProvider = {
+    authorHint(author: string): string;
+    getBlameText(line: number): {inline: string; hover: string} | undefined;
+    fetchBlameIfMissing(textEditor: TextEditor): Promise<boolean>;
+    currentRepo: Repository | undefined;
+    currentEditor: TextEditor | undefined;
+    observedRepos: Map<
+      string,
+      {
+        username: string | undefined;
+        usernameLoaded: Promise<void>;
+        blameCache: {
+          set: (
+            key: string,
+            value: {
+              baseBlameLines: Array<[string, CommitInfo | undefined]>;
+              currentBlameLines: Array<[string, CommitInfo | undefined]> | undefined;
+            },
+          ) => void;
+        };
+      }
+    >;
+    dispose(): void;
+  };
+
+  let provider: TestableBlameProvider;
+  let getConfig: jest.Mock;
+  let blame: jest.Mock;
+
+  beforeEach(() => {
+    getConfig = jest.fn().mockResolvedValue(alice);
+    blame = jest.fn().mockResolvedValue([['line\n', {author: alice} as CommitInfo]]);
+    const repo = {
+      info: {repoRoot},
+      getConfig,
+      subscribeToHeadCommit: jest.fn().mockReturnValue({dispose: jest.fn()}),
+      blame,
+    } as unknown as Repository;
+    const reposList = {
+      repoForPath: jest.fn().mockReturnValue({repo}),
+    } as unknown as VSCodeReposList;
+    const ctx = {
+      cmd: 'sl',
+      cwd: repoRoot,
+      logger: mockLogger,
+      tracker: {error: jest.fn(), track: jest.fn()},
+    } as unknown as RepositoryContext;
+
+    provider = new InlineBlameProvider(reposList, ctx) as unknown as TestableBlameProvider;
+    provider.currentRepo = repo;
+  });
+
+  afterEach(() => {
+    provider.dispose();
+  });
+
+  function loadBlame(textEditor: TextEditor = editorFor(filePath)): Promise<boolean> {
+    return provider.fetchBlameIfMissing(textEditor);
+  }
+
+  it('does not mark another author as (you) when the OS username appears in their email', async () => {
+    await loadBlame();
+
+    expect(provider.authorHint(bob)).toEqual('Bob, ');
+  });
+
+  it('marks the configured Sapling username as (you)', async () => {
+    await loadBlame();
+
+    expect(provider.authorHint(alice)).toEqual('(you) ');
+  });
+
+  it('does not mark anyone as (you) when ui.username is missing', async () => {
+    getConfig.mockResolvedValue(undefined);
+    await loadBlame();
+
+    expect(provider.authorHint(alice)).toEqual('Alice, ');
+    expect(provider.authorHint(bob)).toEqual('Bob, ');
+  });
+
+  it('does not mark anyone as (you) when ui.username is empty', async () => {
+    getConfig.mockResolvedValue('');
+    await loadBlame();
+
+    expect(provider.authorHint(alice)).toEqual('Alice, ');
+    expect(provider.authorHint(bob)).toEqual('Bob, ');
+  });
+
+  it('fetches ui.username once per repository', async () => {
+    await loadBlame();
+    provider.authorHint(alice);
+    provider.authorHint(bob);
+    await loadBlame(editorFor('/workspace/repo/other.ts'));
+    provider.authorHint(alice);
+
+    expect(getConfig).toHaveBeenCalledTimes(1);
+    expect(getConfig).toHaveBeenCalledWith(expect.objectContaining({cwd: repoRoot}), 'ui.username');
+  });
+
+  it('waits for ui.username before finishing the first blame fetch', async () => {
+    let resolveConfig: (value: string | undefined) => void = () => undefined;
+    getConfig.mockImplementation(
+      () =>
+        new Promise<string | undefined>(resolve => {
+          resolveConfig = resolve;
+        }),
+    );
+
+    let finished = false;
+    const fetchPromise = loadBlame().then(result => {
+      finished = true;
+      return result;
+    });
+    await Promise.resolve();
+    expect(finished).toBe(false);
+    expect(provider.authorHint(alice)).toEqual('Alice, ');
+
+    resolveConfig(alice);
+    await fetchPromise;
+    expect(finished).toBe(true);
+    expect(provider.authorHint(alice)).toEqual('(you) ');
+  });
+
+  it('shares one ui.username fetch across concurrent blame loads', async () => {
+    let resolveConfig: (value: string | undefined) => void = () => undefined;
+    getConfig.mockImplementation(
+      () =>
+        new Promise<string | undefined>(resolve => {
+          resolveConfig = resolve;
+        }),
+    );
+
+    const first = loadBlame(editorFor('/workspace/repo/a.ts'));
+    const second = loadBlame(editorFor('/workspace/repo/b.ts'));
+    expect(getConfig).toHaveBeenCalledTimes(1);
+
+    resolveConfig(alice);
+    await Promise.all([first, second]);
+    expect(getConfig).toHaveBeenCalledTimes(1);
+    expect(provider.authorHint(alice)).toEqual('(you) ');
+  });
+
+  it('still shows (you) for local uncommitted changes', async () => {
+    await loadBlame();
+    const textEditor = editorFor(filePath);
+    provider.currentEditor = textEditor;
+    provider.observedRepos.get(repoRoot)?.blameCache.set(filePath, {
+      baseBlameLines: [['line\n', undefined]],
+      currentBlameLines: [['line\n', undefined]],
+    });
+
+    expect(provider.getBlameText(0)).toEqual({
+      inline: `(you) \u2022 Local Changes`,
+      hover: '',
+    });
+  });
+});
+
+function editorFor(fsPath: string): TextEditor {
+  return {
+    document: {
+      uri: {fsPath, scheme: 'file'},
+    },
+  } as unknown as TextEditor;
+}

--- a/addons/vscode/extension/blame/blame.ts
+++ b/addons/vscode/extension/blame/blame.ts
@@ -18,7 +18,6 @@ import type {
 } from 'vscode';
 import type {VSCodeReposList} from '../VSCodeRepo';
 
-import {getUsername} from 'isl-server/src/analytics/environment';
 import {relativeDate} from 'isl/src/relativeDate';
 import {LRU} from 'shared/LRU';
 import {debounce} from 'shared/debounce';
@@ -28,11 +27,6 @@ import {Internal} from '../Internal';
 import {getDiffBlameHoverMarkup} from './blameHover';
 import {getRealignedBlameInfo, shortenAuthorName} from './blameUtils';
 
-function areYouTheAuthor(author: string) {
-  const you = getUsername();
-  return author.includes(you);
-}
-
 type BlameText = {
   inline: string;
   hover: string;
@@ -40,6 +34,8 @@ type BlameText = {
 type RepoCaches = {
   headHash: string;
   blameCache: LRU<string, CachedBlame>; // Caches file path -> file blame.
+  username: string | undefined;
+  usernameLoaded: Promise<void>;
 };
 type CachedBlame = {
   baseBlameLines: Array<[line: string, info: CommitInfo | undefined]>;
@@ -263,7 +259,10 @@ export class InlineBlameProvider implements Disposable {
       return false;
     }
 
-    const blame = await this.getBlame(textEditor, repoCaches?.headHash);
+    const [blame] = await Promise.all([
+      this.getBlame(textEditor, repoCaches.headHash),
+      repoCaches.usernameLoaded,
+    ]);
 
     if (blame.error) {
       this.ctx.tracker.error('BlameLoaded', 'BlameError', blame.error.message, {
@@ -399,7 +398,7 @@ export class InlineBlameProvider implements Disposable {
   }
 
   private authorHint(author: string): string {
-    if (areYouTheAuthor(author)) {
+    if (this.areYouTheAuthor(author)) {
       return '(you) ';
     }
     if (Internal?.showAuthorNameInInlineBlame?.() === false) {
@@ -409,17 +408,35 @@ export class InlineBlameProvider implements Disposable {
     return shortenAuthorName(author) + ', ';
   }
 
-  private initRepoCaches(repoUri: string): void {
+  private areYouTheAuthor(author: string): boolean {
+    const you = this.currentRepo
+      ? this.observedRepos.get(this.currentRepo.info.repoRoot)?.username
+      : undefined;
+    return you != null && you !== '' && author.includes(you);
+  }
+
+  private initRepoCaches(repo: Repository): void {
+    const repoUri = repo.info.repoRoot;
     const caches: RepoCaches = {
       headHash: '',
       blameCache: new LRU(MAX_NUM_FILES_CACHED),
+      username: undefined,
+      usernameLoaded: repo.getConfig(contextForRepo(this.ctx, repo), 'ui.username').then(
+        username => {
+          const repoCaches = this.observedRepos.get(repoUri);
+          if (repoCaches) {
+            repoCaches.username = username;
+          }
+        },
+        () => undefined,
+      ),
     };
     this.observedRepos.set(repoUri, caches);
   }
 
   private subscribeToRepo(repo: Repository): void {
     const repoUri = repo.info.repoRoot;
-    this.initRepoCaches(repoUri);
+    this.initRepoCaches(repo);
 
     this.disposables.push(
       repo.subscribeToHeadCommit(head => {


### PR DESCRIPTION

Fixes #719.

VS Code inline blame currently uses the OS username to determine whether a commit should be annotated with `(you)`. This can produce false matches when the OS username appears in another author's name or email.

This change uses Sapling's configured `ui.username` instead.

The username is loaded once per repository and cached with the existing blame state. Blame loading waits for the username lookup to finish so the first annotation is rendered with the correct identity.

If `ui.username` is missing or cannot be read, commits are not marked as `(you)`. Local uncommitted changes continue to display `(you) • Local Changes`.

## Test Plan

Added regression coverage for:

* another author's email containing the OS username
* matching the configured `ui.username`
* missing and empty `ui.username`
* fetching `ui.username` only once per repository
* concurrent blame loads sharing the same username lookup
* waiting for `ui.username` before the first blame render
* preserving `(you)` for local uncommitted changes

Ran:

```bash
npx --yes yarn@1.22.22 workspace sapling-scm test extension/blame/__tests__/blame.test.ts --runInBand
```

Result: **15 tests passed**

Also ran:

```bash
npx --yes yarn@1.22.22 workspace sapling-scm lint
git diff --check
```

Lint completed with no errors in the changed files.
