### PR TITLE
Fix versionagedays() misparsing build time as a date

### DIFF
--- a/eden/scm/sapling/util.py
+++ b/eden/scm/sapling/util.py
@@ -492,7 +492,16 @@ def versionagedays() -> int:
     try:
         v = version()
         parts = remod.split("_", v)
-        approxbuilddate = datetime.datetime.strptime(parts[1], "%Y%m%d")
+        # The build-date segment's index varies by build path: Meta's internal
+        # Buck build prepends a "MAIN_VERSION" part (making it "x.y.z_YYYYMMDD_
+        # HHMMSS_hash", date at index 1), while the open-source build.py path
+        # omits that prefix ("YYYYMMDD_HHMMSS_hash", date at index 0). Scan for
+        # the first all-digit, 8-character part instead of assuming a fixed
+        # index, so this doesn't silently misparse a HHMMSS part as a date.
+        datepart = next((p for p in parts if len(p) == 8 and p.isdigit()), None)
+        if datepart is None:
+            return 0
+        approxbuilddate = datetime.datetime.strptime(datepart, "%Y%m%d")
         now = datetime.datetime.now()
         return (now - approxbuilddate).days
     except Exception:


### PR DESCRIPTION
versionagedays() split the version string on "_" and always took index 1 as the YYYYMMDD build date. That index is only correct for the Buck build path (gen_version.py), which prepends a MAIN_VERSION component so the string is "x.y.z_YYYYMMDD_HHMMSS_hash" (date at index 1). The open-source build.py path's auto_version() omits that prefix, producing "YYYYMMDD_HHMMSS_hash" instead - so index 1 is actually the HHMMSS time portion, not the date.

Because strptime's "%Y" greedily consumes exactly 4 digits, a 6-digit time string like "044315" doesn't fail to parse - it silently succeeds as year 0443, and the resulting multi-century "old version" hint gets shown even right after a fresh build.

Scan for the first 8-digit, all-numeric "_"-delimited part instead of assuming a fixed index, so this works for both version string shapes.