### PR TITLE
repository: Only report repo roots that form a real submodule chain

### DIFF
--- a/addons/isl-server/src/Repository.ts
+++ b/addons/isl-server/src/Repository.ts
@@ -79,6 +79,7 @@ import {
   getConfigs,
   getExecParams,
   listWorktrees,
+  narrowToSubmoduleChain,
   runCommand,
   setConfig,
 } from './commands';
@@ -525,7 +526,7 @@ export class Repository {
    */
   static async getRepoInfo(ctx: RepositoryContext): Promise<RepoInfo> {
     const {cmd, cwd, logger} = ctx;
-    const [repoRoot, repoRoots, dotdir, configs] = await Promise.all([
+    const [repoRoot, allRepoRoots, dotdir, configs] = await Promise.all([
       findRoot(ctx).catch((err: Error) => err),
       findRoots(ctx),
       findDotDir(ctx),
@@ -561,6 +562,13 @@ export class Repository {
       }
       return {type: 'cwdNotARepository', cwd};
     }
+
+    // `debugroots` reports every repo above the cwd, including unrelated ones that happen to
+    // contain this checkout, so keep only the genuine submodule chain.
+    const repoRoots =
+      allRepoRoots != null && allRepoRoots.length > 1
+        ? await narrowToSubmoduleChain(ctx, allRepoRoots)
+        : allRepoRoots;
 
     const isEdenFs = await isEdenFsRepo(repoRoot as AbsolutePath);
 

--- a/addons/isl-server/src/__tests__/Repository.test.ts
+++ b/addons/isl-server/src/__tests__/Repository.test.ts
@@ -209,6 +209,19 @@ describe('Repository', () => {
       [/^sl root --dotdir/, {stdout: '/path/to/myRepo/.sl'}],
       [/^sl root/, {stdout: '/path/to/myRepo'}],
       [/^sl debugroots/, {stdout: '/path/to/myRepo/submodule\n/path/to/myRepo'}],
+      [
+        /^sl debuggitmodules/,
+        {
+          stdout: JSON.stringify([
+            {
+              name: 'submodule',
+              url: 'https://example.com/submodule',
+              path: 'submodule',
+              active: true,
+            },
+          ]),
+        },
+      ],
     ]);
     const info = (await Repository.getRepoInfo(ctx)) as ValidatedRepoInfo;
     const repo = new Repository(info, ctx);
@@ -223,6 +236,34 @@ describe('Repository', () => {
       preferredSubmitCommand: undefined,
       isEdenFs: false,
     });
+  });
+
+  it('drops ancestor repos that are not really submodules', async () => {
+    setConfigOverrideForTests([]);
+    setPathsDefault('mononoke://0.0.0.0/fbsource');
+    // A checkout cloned inside another repo's working copy. `debugroots` reports both, but the
+    // outer repo does not declare it as a submodule, so only the most local repo survives.
+    mockEjeca([
+      [/^sl root --dotdir/, {stdout: '/workspace/project/.sl'}],
+      [/^sl root/, {stdout: '/workspace/project'}],
+      [/^sl debugroots/, {stdout: '/workspace/project\n/workspace'}],
+      [/^sl debuggitmodules/, {stdout: '[]'}],
+    ]);
+    const info = (await Repository.getRepoInfo(ctx)) as ValidatedRepoInfo;
+    expect(info.repoRoots).toEqual(['/workspace/project']);
+  });
+
+  it('drops ancestor repos when submodules cannot be listed', async () => {
+    setConfigOverrideForTests([]);
+    setPathsDefault('mononoke://0.0.0.0/fbsource');
+    mockEjeca([
+      [/^sl root --dotdir/, {stdout: '/workspace/project/.sl'}],
+      [/^sl root/, {stdout: '/workspace/project'}],
+      [/^sl debugroots/, {stdout: '/workspace/project\n/workspace'}],
+      [/^sl debuggitmodules/, new Error('unknown command debuggitmodules')],
+    ]);
+    const info = (await Repository.getRepoInfo(ctx)) as ValidatedRepoInfo;
+    expect(info.repoRoots).toEqual(['/workspace/project']);
   });
 
   it('handles cwd not exists', async () => {
@@ -1195,7 +1236,7 @@ describe('fetchSubmoduleMap', () => {
         {stdout: JSON.stringify(submodulesOfMyRepo)},
       ],
       [/^sl root/, {stdout: submoduleBRoot}],
-      [/^sl debugroots/, {stdout: myRepoRoot + '\n' + submoduleARoot + '\n' + submoduleBRoot}],
+      [/^sl debugroots/, {stdout: submoduleBRoot + '\n' + submoduleARoot + '\n' + myRepoRoot}],
     ]);
     const updatedCtx = {...ctx, cwd: submoduleBRoot};
     const info = (await Repository.getRepoInfo(updatedCtx)) as ValidatedRepoInfo;

--- a/addons/isl-server/src/commands.ts
+++ b/addons/isl-server/src/commands.ts
@@ -12,9 +12,11 @@ import {
   ConflictType,
   type AbsolutePath,
   type MergeConflicts,
+  type Submodule,
   type WorktreeEntry,
 } from 'isl/src/types';
 import os from 'node:os';
+import path from 'node:path';
 import {ejeca} from 'shared/ejeca';
 import {isEjecaError} from './utils';
 
@@ -129,6 +131,62 @@ export async function findRoots(ctx: RepositoryContext): Promise<AbsolutePath[] 
     ctx.logger.error(`Failed to find repository roots starting from ${ctx.cwd}`, error);
     return undefined;
   }
+}
+
+/**
+ * The submodules `root` declares, or undefined if they could not be read.
+ */
+export async function findSubmodules(
+  ctx: RepositoryContext,
+  root: AbsolutePath,
+): Promise<Array<Submodule> | undefined> {
+  try {
+    const proc = await runCommand(ctx, ['debuggitmodules', '--json', '--repo', root]);
+    return JSON.parse(proc.stdout) as Array<Submodule>;
+  } catch (error) {
+    ctx.logger.error(`Failed to list submodules of ${root}`, error);
+    return undefined;
+  }
+}
+
+/**
+ * Narrow the roots reported by `debugroots` to the submodule chain that contains the cwd.
+ *
+ * `debugroots` walks all the way to the system root, so it also reports repos that merely contain
+ * this checkout somewhere in their directory tree. Cloning a project inside another project's
+ * working copy does not make it a submodule of that project, and treating it as one mislabels the
+ * repo and hides the superproject's real submodules. Keep only the innermost run of roots where
+ * each root is a submodule of the one above it, leaving the most local repo first in line.
+ *
+ * `roots` is ordered furthest-to-closest, so the chain is always a suffix of it.
+ */
+export async function narrowToSubmoduleChain(
+  ctx: RepositoryContext,
+  roots: ReadonlyArray<AbsolutePath>,
+): Promise<Array<AbsolutePath>> {
+  // Every root but the innermost is a candidate parent; chains are short, so ask them all at once.
+  const submodulesByParent = await Promise.all(
+    roots.slice(0, -1).map(parent => findSubmodules(ctx, parent)),
+  );
+  let outermost = roots.length - 1;
+  while (outermost > 0) {
+    const parent = roots[outermost - 1];
+    const child = roots[outermost];
+    const submodules = submodulesByParent[outermost - 1];
+    if (
+      submodules == null ||
+      !submodules.some(m => m.path === relativeSubmodulePath(parent, child))
+    ) {
+      break;
+    }
+    outermost--;
+  }
+  return roots.slice(outermost);
+}
+
+/** Submodule paths are always posix-style, even on Windows. */
+function relativeSubmodulePath(parent: AbsolutePath, child: AbsolutePath): string {
+  return path.relative(parent, child).split(path.sep).join('/');
 }
 
 export async function findDotDir(ctx: RepositoryContext): Promise<AbsolutePath | undefined> {


### PR DESCRIPTION
## Summary

Fixes an edge case when using ISL inside a VS Code workspace with nested (non-submodule) Git repos.

**Example**: `~/devroot` tracked with git, holding `projects/react/` and `projects/react-native/` as independent clones.

The UI suggests this is entirely supported — with one inner Git repo per configured workspace folder — and indeed the switching behaviour works.

<img width="400" src="https://github.com/user-attachments/assets/285772c3-29c7-4ed6-a892-ea1302f7ea80" />

However, ISL:

- **Bug 1**: Misreports the repo name in the cwd dropdown when selected. The button is labelled with the outer repo (`devroot`) instead of the selected repo.
- **Bug 2**: Overflows the UI component in this state (the dropdown arrow disappears).

<img width="1614" height="384" alt="Screenshot 2026-08-28 at 16 38 50" src="https://github.com/user-attachments/assets/99fa729c-95e5-4560-a3dd-f2cc12ab8da1" />

**Root cause**

`debugroots` walks up to the system root, so it reports every repo above the cwd, related or not. `RepoInfo.repoRoots` passes that through, but its consumers read it as a submodule chain: `CwdSelector` labels the button from `repoRoots[0]` and treats `repoRoots.length > 1` as "submodule breadcrumbs follow", which suppresses the `ButtonDropdown`. Nothing renders in their place, because the outer repo has no submodules to offer. `fetchSubmoduleMap` also queried the unrelated ancestors.

**Fix**

Narrow the roots in `getRepoInfo` to the innermost run where each root is a submodule of the one above it, so the most local repo always leads. Ancestors are dropped when they do not declare the root below them, and when their submodules cannot be listed at all — an older `sl` without `debuggitmodules` already renders no breadcrumbs, so truncating costs nothing there.

Command count is unchanged in practice: the ancestors this drops are exactly the ones `fetchSubmoduleMap` no longer has to query.

**Notes**

The `fetchSubmoduleMap` 'nested' test mocked `debugroots` outermost-first, the reverse of what the command emits. Order never mattered before, since `fetchSubmoduleMap` iterates the list; it does now, so the mock is corrected.

## Test Plan

After this fix:

<img width="1557" height="378" alt="Screenshot 2026-08-28 at 16 40 33" src="https://github.com/user-attachments/assets/47df6927-9d5d-4c9a-811f-574078c0e3f8" />
