### PR TITLE
repository: Resolve PRs against the upstream repo when available

### DIFF
--- a/addons/isl-server/src/Repository.ts
+++ b/addons/isl-server/src/Repository.ts
@@ -70,6 +70,7 @@ import {parseAlerts} from './alerts';
 import {
   MAX_SIMULTANEOUS_CAT_CALLS,
   READ_COMMAND_TIMEOUT_MS,
+  codeReviewRepoUrls,
   computeNewConflicts,
   extractRepoInfoFromUrl,
   findDotDir,
@@ -533,8 +534,10 @@ export class Repository {
       // However, `sl debugexpandpaths` is currently too slow and impacts startup time.
       getConfigs(ctx, [
         'paths.default',
+        'paths.upstream',
         'github.pull_request_domain',
         'github.preferred_submit_command',
+        'github.pull_request_repo',
         'phrevset.callsign',
       ]),
     ]);
@@ -573,11 +576,27 @@ export class Repository {
     } else if (pathsDefault === '') {
       codeReviewSystem = {type: 'none'};
     } else {
-      const repoInfo = extractRepoInfoFromUrl(pathsDefault);
-      if (
-        repoInfo != null &&
-        (repoInfo.hostname === 'github.com' || (await isGithubEnterprise(repoInfo.hostname)))
-      ) {
+      const candidates = codeReviewRepoUrls({
+        pathsDefault,
+        pathsUpstream: configs.get('paths.upstream') ?? '',
+        pullRequestRepo: configs.get('github.pull_request_repo'),
+      })
+        .map(url => extractRepoInfoFromUrl(url))
+        .filter(info => info != null);
+      // A fork and its upstream share a host, so resolve each host once rather than per candidate:
+      // `isGithubEnterprise` shells out to `gh`.
+      const hostnames = [...new Set(candidates.map(info => info.hostname))];
+      const githubHostnames = new Set(
+        (
+          await Promise.all(
+            hostnames.map(async hostname =>
+              hostname === 'github.com' || (await isGithubEnterprise(hostname)) ? hostname : null,
+            ),
+          )
+        ).filter(hostname => hostname != null),
+      );
+      const repoInfo = candidates.find(info => githubHostnames.has(info.hostname));
+      if (repoInfo != null) {
         const {owner, repo, hostname} = repoInfo;
         codeReviewSystem = {
           type: 'github',

--- a/addons/isl-server/src/__tests__/Repository.test.ts
+++ b/addons/isl-server/src/__tests__/Repository.test.ts
@@ -173,6 +173,75 @@ describe('Repository', () => {
       });
     });
 
+    it('prefers the upstream repo over the fork it was cloned from', async () => {
+      setConfigOverrideForTests(
+        [
+          ['paths.default', 'https://github.com/myUsername/myRepo.git'],
+          ['paths.upstream', 'https://github.com/upstreamOrg/myRepo.git'],
+        ],
+        false,
+      );
+      const info = (await Repository.getRepoInfo(ctx)) as ValidatedRepoInfo;
+      expect(info.codeReviewSystem).toEqual({
+        type: 'github',
+        owner: 'upstreamOrg',
+        repo: 'myRepo',
+        hostname: 'github.com',
+      });
+    });
+
+    it('falls back to the default path when upstream is not a github repo', async () => {
+      setConfigOverrideForTests(
+        [
+          ['paths.default', 'https://github.com/myUsername/myRepo.git'],
+          ['paths.upstream', 'https://gitlab.myCompany.com/myUsername/myRepo.git'],
+        ],
+        false,
+      );
+      const info = (await Repository.getRepoInfo(ctx)) as ValidatedRepoInfo;
+      expect(info.codeReviewSystem).toEqual({
+        type: 'github',
+        owner: 'myUsername',
+        repo: 'myRepo',
+        hostname: 'github.com',
+      });
+    });
+
+    it('lets github.pull_request_repo override both paths', async () => {
+      setConfigOverrideForTests(
+        [
+          ['paths.default', 'https://github.com/myUsername/myRepo.git'],
+          ['paths.upstream', 'https://github.com/upstreamOrg/myRepo.git'],
+          ['github.pull_request_repo', 'chosenOrg/chosenRepo'],
+        ],
+        false,
+      );
+      const info = (await Repository.getRepoInfo(ctx)) as ValidatedRepoInfo;
+      expect(info.codeReviewSystem).toEqual({
+        type: 'github',
+        owner: 'chosenOrg',
+        repo: 'chosenRepo',
+        hostname: 'github.com',
+      });
+    });
+
+    it('resolves a bare github.pull_request_repo against the enterprise host in use', async () => {
+      setConfigOverrideForTests(
+        [
+          ['paths.default', 'https://ghe.myCompany.com/myUsername/myRepo.git'],
+          ['github.pull_request_repo', 'chosenOrg/chosenRepo'],
+        ],
+        false,
+      );
+      const info = (await Repository.getRepoInfo(ctx)) as ValidatedRepoInfo;
+      expect(info.codeReviewSystem).toEqual({
+        type: 'github',
+        owner: 'chosenOrg',
+        repo: 'chosenRepo',
+        hostname: 'ghe.myCompany.com',
+      });
+    });
+
     it('handles non-github-enterprise unknown code review providers', async () => {
       setPathsDefault('https://gitlab.myCompany.com/myUsername/myRepo.git');
       const info = (await Repository.getRepoInfo(ctx)) as ValidatedRepoInfo;

--- a/addons/isl-server/src/commands.ts
+++ b/addons/isl-server/src/commands.ts
@@ -320,6 +320,35 @@ export function extractRepoInfoFromUrl(
   return {owner, repo, hostname: hostname1 ?? hostname2};
 }
 
+/**
+ * The repo URLs that may hold this checkout's pull requests, best candidate first.
+ *
+ * A fork pushes to itself but its pull requests belong upstream, which is already how the CLI
+ * behaves: `try_find_upstream` in the github extension resolves a bare pull request number against
+ * `paths.upstream` before `paths.default`. Follow the same order so ISL reports on the same pull
+ * requests `sl pr` does, and let `github.pull_request_repo` override it for checkouts whose
+ * remotes do not follow that convention.
+ *
+ * `github.pull_request_repo` accepts either a full URL or a bare `owner/name`, which is resolved
+ * against the host the checkout already uses.
+ */
+export function codeReviewRepoUrls(configs: {
+  pathsDefault: string;
+  pathsUpstream: string;
+  pullRequestRepo: string | undefined;
+}): Array<string> {
+  const {pathsDefault, pathsUpstream, pullRequestRepo} = configs;
+  const fallbacks = [pathsUpstream, pathsDefault].filter(url => url !== '');
+  if (pullRequestRepo == null || pullRequestRepo === '') {
+    return fallbacks;
+  }
+  if (!/^[^/\s]+\/[^/\s]+$/.test(pullRequestRepo)) {
+    return [pullRequestRepo];
+  }
+  const hostname = fallbacks.map(url => extractRepoInfoFromUrl(url)?.hostname).find(h => h != null);
+  return [`https://${hostname ?? 'github.com'}/${pullRequestRepo}`];
+}
+
 export function computeNewConflicts(
   previousConflicts: MergeConflicts,
   commandOutput: ResolveCommandConflictOutput,


### PR DESCRIPTION
## Summary

Fixes resolution of Pull Requests in ISL, in the case when a Git repo is cloned with both `origin` and `upstream` remotes (as is the default for `gh repo clone` with a user fork of an open source repo).

**Example**

For a `react-native` checkout whose `origin` is `huntie/react-native`, ISL queries that repo for pull requests that instead live on the upstream `react/react-native`. It finds nothing, and therefore every pull request stays stuck loading against the wrong repo:

<img width="1514" height="530" alt="Screenshot 2026-08-28 at 16 55 57" src="https://github.com/user-attachments/assets/c854273f-d300-401a-b72b-74b2543ec6f3" />

**Root cause**

`getRepoInfo` builds `codeReviewSystem` from `paths.default` alone, so it always lands on the push remote. The CLI does not: `try_find_upstream` in the github extension resolves a bare pull request number against `paths.upstream` before `paths.default`, and `sl pr submit` targets `get_upstream_owner_and_name()`. So the CLI files and reads pull requests upstream while ISL looks for them in the fork — they never agree.

**Fix**

Resolve `codeReviewSystem` from an ordered list of candidate repos rather than from `paths.default` alone: prefer `paths.upstream` when it names a GitHub repo, and fall back to `paths.default` otherwise. Leave repos with no upstream untouched — the fallback is then the only candidate.

This is the precedence Sapling's CLI already applies, so ISL and `sl pr` now resolve a checkout's pull requests to the same repo.

**Note**: This touches only `codeReviewSystem`, which feeds the code review provider — pull request queries, review links, and remote file links. Push and pull still use `paths.default`.

## Test Plan

<img width="1503" height="526" alt="Screenshot 2026-08-28 at 17 05 39" src="https://github.com/user-attachments/assets/21f1f7e4-6cfa-4e06-9adb-293173306c4b" />

✅ Upstream PRs resolve